### PR TITLE
VSCode extension: add language field in completion request.

### DIFF
--- a/clients/vscode/src/TabbyClient.ts
+++ b/clients/vscode/src/TabbyClient.ts
@@ -16,6 +16,11 @@ if (logAxios) {
   });
 }
 
+export interface TabbyCompletionRequest {
+  prompt: string;
+  language?: string;
+}
+
 export interface TabbyCompletion {
   id?: string;
   created?: number;
@@ -89,14 +94,12 @@ export class TabbyClient extends EventEmitter {
     }
   }
 
-  public async getCompletion(prompt: string): Promise<TabbyCompletion | null> {
+  public async getCompletion(request: TabbyCompletionRequest): Promise<TabbyCompletion | null> {
     if (this.status == "disconnected") {
       this.ping();
     }
     try {
-      const response = await axios.post<TabbyCompletion>(`${this.tabbyServerUrl}/v1/completions`, {
-        prompt,
-      });
+      const response = await axios.post<TabbyCompletion>(`${this.tabbyServerUrl}/v1/completions`, request);
       assert(response.status == 200);
       return response.data;
     } catch (e) {
@@ -113,7 +116,7 @@ export class TabbyClient extends EventEmitter {
       const response = await axios.post(`${this.tabbyServerUrl}/v1/events`, {
         type: event.type,
         completion_id: event.id,
-        choice_index: event.index
+        choice_index: event.index,
       });
       assert(response.status == 200);
     } catch (e) {

--- a/clients/vscode/src/TabbyCompletionProvider.ts
+++ b/clients/vscode/src/TabbyCompletionProvider.ts
@@ -66,7 +66,7 @@ export class TabbyCompletionProvider implements InlineCompletionItemProvider {
     // Prompt is already nil-checked
     const completion = await this.tabbyClient.getCompletion({
       prompt: prompt as string,
-      language: document.languageId,
+      language: document.languageId, // https://code.visualstudio.com/docs/languages/identifiers
     });
 
     const hasSuffixParen = this.hasSuffixParen(document, position);

--- a/clients/vscode/src/TabbyCompletionProvider.ts
+++ b/clients/vscode/src/TabbyCompletionProvider.ts
@@ -59,11 +59,15 @@ export class TabbyCompletionProvider implements InlineCompletionItemProvider {
       {
         uuid: this.uuid,
         timestamp: currentTimestamp,
-        prompt
+        prompt,
+        language: document.languageId
       }
     );
     // Prompt is already nil-checked
-    const completion = await this.tabbyClient.getCompletion(prompt as string);
+    const completion = await this.tabbyClient.getCompletion({
+      prompt: prompt as string,
+      language: document.languageId,
+    });
 
     const hasSuffixParen = this.hasSuffixParen(document, position);
     const replaceRange = hasSuffixParen

--- a/clients/vscode/webpack.config.js
+++ b/clients/vscode/webpack.config.js
@@ -11,7 +11,7 @@ const webpack = require("webpack");
 /** @type WebpackConfig */
 const extensionNodeConfig = {
   target: 'node', // VS Code extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-	mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
+  mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
 
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
@@ -49,7 +49,7 @@ const extensionNodeConfig = {
 
 const extensionWebConfig = {
   target: 'webworker', // VS Code extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-	mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
+  mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
 
   entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
@@ -103,4 +103,4 @@ const extensionWebConfig = {
   },
 };
 
-module.exports = [ extensionNodeConfig, extensionWebConfig ];
+module.exports = [extensionNodeConfig, extensionWebConfig];

--- a/tabby/server/models.py
+++ b/tabby/server/models.py
@@ -8,7 +8,7 @@ class Choice(BaseModel):
     index: int
     text: str
 
-
+# https://code.visualstudio.com/docs/languages/identifiers
 class Language(str, Enum):
     UNKNOWN = "unknown"
     PYTHON = "python"


### PR DESCRIPTION
Use [language identifiers](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers) as language field in completion request.