### PR TITLE
fix link to vim extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Tabby has opened a FastAPI server at [localhost:5000](https://localhost:5000), w
 ### Editor Extensions
 
 * [VSCode Extension](./clients/vscode)
-* [VIM Extension](./clients/vscode)
+* [VIM Extension](./clients/vim)
 
 ## Development
 


### PR DESCRIPTION
original version of link to vim extension in README file pointed to vscode.