### PR TITLE
VIM plugin: Improve commands, and help document.

### DIFF
--- a/clients/vim/.gitignore
+++ b/clients/vim/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags

--- a/clients/vim/README.md
+++ b/clients/vim/README.md
@@ -12,12 +12,15 @@
 " Make sure that the filetype plugin has been enabled.
 filetype plugin on
 
+" Assume using vim-plug as plugin manager
 Plug 'TabbyML/tabby', {'rtp': 'clients/vim'}
+
+" Set URL of Tabby server
 let g:tabby_server_url = 'http://127.0.0.1:5000'
 ```
 
 ## Usage
 
 1. In insert mode, Tabby will show code suggestion when you stop typing. Press `<Tab>` to accpet the current suggestion, `<M-]>` to see the next suggestion, `<M-[>` to see previous suggestion, or `<C-]>` to dismiss.
-
 2. Use command `:Tabby enable` to enable, `:Tabby disable` to disable Tabby, and `:Tabby status` to check status.
+3. Use command `:help Tabby` for more information.

--- a/clients/vim/autoload/tabby.vim
+++ b/clients/vim/autoload/tabby.vim
@@ -26,7 +26,47 @@ function! s:commands.toggle(...)
 endfunction
 
 function! s:commands.help(...)
-  help 'tabby'
+  let args = get(a:, 1, [])
+  if len(args) < 1
+    execute 'help Tabby'
+    return
+  endif
+  try
+    execute 'help Tabby-' . join(args, '-')
+    return
+  catch
+  endtry
+  try
+    execute 'help tabby_' . join(args, '_')
+    return
+  catch
+  endtry
+  execute 'help Tabby'
+endfunction
+
+function! tabby#CompleteCommands(arglead, cmd, pos)
+  let words = split(a:cmd[0:a:pos].'#', ' ')
+  if len(words) > 3
+    return []
+  endif
+  if len(words) == 3
+    if words[1] == 'help'
+      let candidates = ['compatibility', 'commands', 'options', 'keybindings']
+    else
+      return []
+    endif
+  else
+    let candidates = keys(s:commands)
+  endif
+
+  let end_index = len(a:arglead) - 1
+  if end_index < 0
+    return candidates
+  else
+    return filter(candidates, { idx, val ->
+      \ val[0:end_index] ==# a:arglead
+      \})
+  endif
 endfunction
 
 function! tabby#Command(args)

--- a/clients/vim/doc/tabby.txt
+++ b/clients/vim/doc/tabby.txt
@@ -1,0 +1,102 @@
+tabby.txt  Tabby
+					*Tabby* *Tabby-doc*
+Tabby is a self-hosted AI coding assistant that can suggest multi-line code or
+full functions in real-time. For more information, please check out our
+{Website}{1} and {Github}{2}. If you encounter any problem or have any
+suggestion, please open an {issue}{3}.
+  {1}  https://www.tabbyml.com/
+  {2}  https://github.com/TabbyML/tabby
+  {3}  https://github.com/TabbyML/tabby/issues/new
+
+					*Tabby-compatibility* *Tabby-neovim*
+Compatibility~
+This plugin is compatible with VIM 9.0+ with `+job` and `+textprop` features
+enabled, or NeoVIM 0.6.0+.
+
+					*Tabby-commands*
+Commands~
+                                        *:Tabby*
+:Tabby			Same as |:Tabby-status|.
+					*:Tabby-enable*
+:Tabby	enable 		Start Tabby if not currently running in current VIM
+			process.
+					*:Tabby-disable*
+:Tabby	disable		Stop Tabby in current VIM process. To disable Tabby
+			globally, set |g:tabby_enable| to v:false.
+					*:Tabby-toggle*
+:Tabby  toggle  	Toggle enable or disable Tabby, same as use command
+			|:Tabby-enable| or |:Tabby-disable|.
+					*:Tabby-status*
+:Tabby  status          Check whether Tabby is enabled or not, and the
+			reachabilty to the Tabby server. Also report errors
+			if any compatibility problems exist.
+					*:Tabby-help*
+:Tabby  help [...]      Search for help information in this document.
+			Same as `:help Tabby [...]`.
+
+					*Tabby-options*
+Options~
+					*g:tabby_enable*
+g:tabby_enable 		Controls Tabby whether auto-starts along with VIM or
+			not. Modifying this value do not start or stop Tabby
+			at the same time. You can use |:Tabby-enable| or
+			|:Tabby-disable| to start or stop Tabby manually in
+			current VIM process.
+>
+	let g:tabby_enable = v:true
+<
+					*g:tabby_server_url*
+g:tabby_server_url	Specify the Tabby server URL. You always need this
+			setting in your vimrc file, unless you are using the
+			default value: "http://localhost:5000".
+>
+	let g:tabby_server_url = 'http://localhost:5000'
+<
+					*g:tabby_suggestion_delay*
+g:tabby_suggestion_delay
+			Controls the delay after which the suggestion request
+			is sent to server. If you want suggestion to show up
+			more quickly or slowly, try to tune this value.
+			Default value is 150 milliseconds.
+>
+	let g:tabby_suggestion_delay = 150
+<
+					*g:tabby_filetype_to_languages*
+g:tabby_filetype_to_languages
+			This option is a dictionary that map from the VIM
+			`:filetype` to {VSCode-Language-Identifier}{1}. Not
+			listed filetype will be used as language identifier
+			directly.
+			A correct language identifier is required for the
+			Tabby server to generate suggestion. If your filetype
+			need converting to language identifier but not listed,
+			add it in this dictionary.
+			You can also map a filetype to "unknow" to prevent
+			Tabby giving suggestion for specified filetype.
+  {1}  https://code.visualstudio.com/docs/languages/identifiers
+>
+	let g:tabby_filetype_to_languages = {
+		\ "bash": "shellscript",
+		\ "cs": "csharp",
+		\ "objc": "objective-c",
+		\ "objcpp": "objective-cpp",
+		\ }
+<
+
+					*Tabby-keybindings* *Tabby-maps*
+Keybindings~
+
+<Tab>			Accept the current suggestion, fallback to normal
+			`<TAB>` if no suggestion is shown.
+
+<C-]>			Dismiss the current suggestion. Fallback to normal
+			`<C-]>` if no suggestion is shown.
+
+<M-]>			Show the next suggestion. There is a empty suggestion
+			after the last, before return to first one.
+
+<M-[>			Show the previous suggestion. There is a empty
+			suggestion before the first, before return to last
+			one.
+
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/clients/vim/doc/tabby.txt
+++ b/clients/vim/doc/tabby.txt
@@ -1,5 +1,5 @@
 tabby.txt  Tabby
-					*Tabby* *Tabby-doc*
+					*Tabby* *tabby* *Tabby-doc*
 Tabby is a self-hosted AI coding assistant that can suggest multi-line code or
 full functions in real-time. For more information, please check out our
 {Website}{1} and {Github}{2}. If you encounter any problem or have any
@@ -31,8 +31,8 @@ Commands~
 			reachabilty to the Tabby server. Also report errors
 			if any compatibility problems exist.
 					*:Tabby-help*
-:Tabby  help [...]      Search for help information in this document.
-			Same as `:help Tabby [...]`.
+:Tabby  help [subject]  Search for help information in this document using
+			VIM command `:help`.
 
 					*Tabby-options*
 Options~

--- a/clients/vim/plugin/tabby.vim
+++ b/clients/vim/plugin/tabby.vim
@@ -5,7 +5,7 @@ let g:loaded_tabby = 1
 
 call tabby#Start()
 
-command! -nargs=* Tabby exe tabby#Command(<q-args>)
+command! -nargs=* -complete=customlist,tabby#CompleteCommands Tabby call tabby#Command(<q-args>)
 
 imap  <script><silent><nowait><expr>  <Tab>  tabby#Accept(pumvisible() ? "\<C-N>" : "\t")
 imap  <script><silent><nowait><expr>  <C-]>  tabby#Dismiss("\<C-]>")

--- a/clients/vim/plugin/tabby.vim
+++ b/clients/vim/plugin/tabby.vim
@@ -25,3 +25,5 @@ augroup tabby
   autocmd BufLeave      *  call tabby#Clear()
   autocmd InsertLeave   *  call tabby#Clear()
 augroup END
+
+silent! execute 'helptags' fnameescape(expand('<sfile>:h:h') . '/doc')


### PR DESCRIPTION
* Add help document. Use `:help Tabby` or `:Tabby help [subject]` to search help document. 
* Add command line completion.
* Move `suggestion_delay` to `g:tabby_suggestion_delay`