### PR TITLE
Allow using santa-coder models

### DIFF
--- a/tabby/tools/download_models.py
+++ b/tabby/tools/download_models.py
@@ -25,7 +25,7 @@ def parse_args():
 def preload(local_files_only=False):
     AutoTokenizer.from_pretrained(args.repo_id, local_files_only=local_files_only)
     AutoModelForCausalLM.from_pretrained(
-        args.repo_id, local_files_only=local_files_only
+        args.repo_id, local_files_only=local_files_only, trust_remote_code=True
     )
     snapshot_download(
         repo_id=args.repo_id,


### PR DESCRIPTION
If one try to use a model like [santacoder](https://huggingface.co/bigcode/santacoder), they will get the following error:
```python
Traceback (most recent call last):
  File "/home/app/.pyenv/versions/3.10.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/app/.pyenv/versions/3.10.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/app/tabby/tools/download_models.py", line 44, in <module>
    preload(local_files_only=False)
  File "/home/app/tabby/tools/download_models.py", line 27, in preload
    AutoModelForCausalLM.from_pretrained(
  File "/home/app/.pyenv/versions/3.10.10/lib/python3.10/site-packages/transformers/models/auto/auto_factory.py", line 441, in from_pretrained
    config, kwargs = AutoConfig.from_pretrained(
  File "/home/app/.pyenv/versions/3.10.10/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 899, in from_pretrained
    raise ValueError(
ValueError: Loading bigcode/santacoder requires you to execute the configuration file in that repo on your local machine. Make sure you have read the code there to avoid malicious use, then set the option `trust_remote_code=True` to remove this error.
```

This PR is passing the flag to the model triton server also. I wonder if it should be optional.