### PR TITLE
VSCode extensions: add completion cache.

### DIFF
--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -107,6 +107,7 @@
     "axios": "^1.3.4",
     "events": "^3.3.0",
     "form-data": "^4.0.0",
+    "linked-list-typescript": "^1.0.15",
     "process": "^0.11.10"
   }
 }

--- a/clients/vscode/src/CompletionCache.ts
+++ b/clients/vscode/src/CompletionCache.ts
@@ -1,0 +1,75 @@
+import { LinkedList } from "linked-list-typescript";
+import { CompletionResponse, Choice } from "./generated";
+
+type Range = {
+  start: number;
+  end: number;
+};
+
+export type CompletionCacheEntry = {
+  documentId: any;
+  promptRange: Range;
+  prompt: string;
+  completion: CompletionResponse;
+};
+
+export class CompletionCache {
+  public static cacheSize = 10;
+  private cache = new LinkedList<CompletionCacheEntry>();
+
+  constructor() {}
+
+  private evict() {
+    while (this.cache.length > CompletionCache.cacheSize) {
+      this.cache.removeTail();
+    }
+  }
+
+  private pop(entry: CompletionCacheEntry) {
+    this.cache.remove(entry);
+    this.cache.prepend(entry);
+  }
+
+  public add(entry: CompletionCacheEntry) {
+    this.evict();
+    this.cache.prepend(entry);
+  }
+
+  public findCompatible(documentId: any, text: string, cursor: number): CompletionResponse | null {
+    let hit: { entry: CompletionCacheEntry; compatibleChoices: Choice[] } | null = null;
+    for (const entry of this.cache) {
+      if (entry.documentId !== documentId) {
+        continue;
+      }
+      // Check if text in prompt range has not changed
+      if (text.slice(entry.promptRange.start, entry.promptRange.end) !== entry.prompt) {
+        continue;
+      }
+      // Filter choices that start with inputed text after prompt
+      const compatibleChoices = entry.completion.choices
+        .filter((choice) => choice.text.startsWith(text.slice(entry.promptRange.end, cursor)))
+        .map((choice) => {
+          return {
+            index: choice.index,
+            text: choice.text.substring(cursor - entry.promptRange.end),
+          };
+        });
+      if (compatibleChoices.length > 0) {
+        hit = {
+          entry,
+          compatibleChoices,
+        };
+        break;
+      }
+    }
+    if (hit) {
+      this.pop(hit.entry);
+      return {
+        id: hit.entry.completion.id,
+        created: hit.entry.completion.created,
+        choices: hit.compatibleChoices,
+      };
+    }
+    return null;
+  }
+}

--- a/clients/vscode/yarn.lock
+++ b/clients/vscode/yarn.lock
@@ -1740,6 +1740,11 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
+linked-list-typescript@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/linked-list-typescript/-/linked-list-typescript-1.0.15.tgz#faeed93cf9203f102e2158c29edcddda320abe82"
+  integrity sha512-RIyUu9lnJIyIaMe63O7/aFv/T2v3KsMFuXMBbUQCHX+cgtGro86ETDj5ed0a8gQL2+DFjzYYsgVG4I36/cUwgw==
+
 linkify-it@^3.0.1:
   version "3.0.3"
   resolved "https://registry.npmmirror.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"


### PR DESCRIPTION
#127 

Add a LRU cache to save recently completions. 

* When a completion returned from server and will show up, add it to cache.
* If prompt text range remains unchanged, and inputed characters after prompt text range are matched with any choice of a cached completion, use cached completion instead of making new request.