### PR TITLE
small fix for completion cache

### DIFF
--- a/clients/vscode/src/CompletionCache.ts
+++ b/clients/vscode/src/CompletionCache.ts
@@ -14,25 +14,23 @@ export type CompletionCacheEntry = {
 };
 
 export class CompletionCache {
-  public static cacheSize = 10;
+  public static capacity = 10;
   private cache = new LinkedList<CompletionCacheEntry>();
 
   constructor() {}
 
-  private evict() {
-    while (this.cache.length > CompletionCache.cacheSize) {
-      this.cache.removeTail();
-    }
-  }
-
-  private pop(entry: CompletionCacheEntry) {
+  private refresh(entry: CompletionCacheEntry) {
     this.cache.remove(entry);
     this.cache.prepend(entry);
   }
 
   public add(entry: CompletionCacheEntry) {
-    this.evict();
     this.cache.prepend(entry);
+
+    while (this.cache.length > CompletionCache.capacity) {
+      this.cache.removeTail();
+    }
+
   }
 
   public findCompatible(documentId: any, text: string, cursor: number): CompletionResponse | null {
@@ -63,7 +61,7 @@ export class CompletionCache {
       }
     }
     if (hit) {
-      this.pop(hit.entry);
+      this.refresh(hit.entry);
       return {
         id: hit.entry.completion.id,
         created: hit.entry.completion.created,


### PR DESCRIPTION
Small fix changing `>`  to `>=` to fix the bug that when making `add()` to an already full cache, the `evict()` and then `prepend()` would make the cache size to be `capacity+1`.

Also some small renaming for better readability.

Technically the evicting while loop should be fenced with `capacity != 0`. Now that it is hardcoded as a static value, it's fine so far. In the future when we decide to make it configurable, we need to add the fence in `add()`.

Also, would prefer classic LRU implementation with a hashmap together with a linked list. The current implementation's matching is a full O(n) complexity, and so is `refresh()`. Would be a nice-to-have to reduce the complexity with a custom hash function for `documentId`, `text` and `cursor`. Could leave it as a TODO.