### PR TITLE
fix: vim plugin inline completion display error if starts with newline.

### DIFF
--- a/clients/vim/autoload/tabby.vim
+++ b/clients/vim/autoload/tabby.vim
@@ -397,6 +397,13 @@ function! tabby#Show()
     return
   endif
   let lines = split(choice.text, "\n")
+  " split will not give an empty line if text starts with "\n" or ends with "\n"
+  if choice.text[0] == "\n"
+    call insert(lines, '')
+  endif
+  if choice.text[-1] == "\n"
+    call add(lines, '')
+  endif
   call tabby#virtual_text#Show(lines)
   let s:shown_lines = lines
   call s:PostEvent('view')

--- a/clients/vim/autoload/tabby/virtual_text.vim
+++ b/clients/vim/autoload/tabby/virtual_text.vim
@@ -35,14 +35,15 @@ function! tabby#virtual_text#Show(lines)
   endif
   if s:vim
     " virtual text requires 9.0.0534
+    " append line with a space to avoid empty line, which will result in unexpected behavior
     call prop_add(line('.'), col('.'), #{
       \ type: s:prop_type,
-      \ text: a:lines[0],
+      \ text: a:lines[0] . ' ', 
       \ })
     for line in a:lines[1:]
       call prop_add(line('.'), 0, #{
         \ type: s:prop_type,
-        \ text: line,
+        \ text: line . ' ',
         \ text_align: 'below',
         \ })
     endfor


### PR DESCRIPTION
Fix TAB-28
Fix #159