### PR TITLE
fix(vim): text inserted position error when completion ends with empty line.

### DIFF
--- a/clients/vim/autoload/tabby.vim
+++ b/clients/vim/autoload/tabby.vim
@@ -410,13 +410,14 @@ function! tabby#Show()
     return
   endif
   let lines = split(choice.text, "\n")
-  " split will not give an empty line if text starts with "\n" or ends with "\n"
+  " split will not give an empty line if text starts with "\n"
   if choice.text[0] == "\n"
     call insert(lines, '')
   endif
-  if choice.text[-1] == "\n"
-    call add(lines, '')
-  endif
+  " ignore trailing empty lines
+  while len(lines) > 0 && (lines[-1] == '')
+    call remove(lines, -1)
+  endwhile
   call tabby#virtual_text#Show(lines)
   let s:shown_lines = lines
   call s:PostEvent('view')


### PR DESCRIPTION
fix TAB-159