### PR TITLE
feat: add architecture/cpu info to health api response [TAB-162]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,17 +411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cl3"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "215a3aa32ab5d7928c539c4289d1cf144257c3cb05e05a4b7e61d5a6bb6583a5"
-dependencies = [
- "libc",
- "opencl-sys",
- "thiserror",
-]
-
-[[package]]
 name = "clap"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,24 +625,6 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "cuda-config"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
-dependencies = [
- "glob",
-]
-
-[[package]]
-name = "cuda-driver-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
-dependencies = [
- "cuda-config",
 ]
 
 [[package]]
@@ -914,18 +885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "fil-rustacuda"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40666d4072d5353fd2fd3aa26e4ddb225c38c6440e8c467cae9b17688ae6191c"
-dependencies = [
- "bitflags",
- "cuda-driver-sys",
- "rustacuda_core",
- "rustacuda_derive",
 ]
 
 [[package]]
@@ -1200,27 +1159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1893,25 +1837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opencl-sys"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75919008b8ed7ce9620e2b3580c648db40c7f564a368f271b2647145046d8ba"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "opencl3"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247ee0c98af8a67ab9c836ed2ea663ac19a17d8bae71325b509835e536c18ad"
-dependencies = [
- "cl3",
- "libc",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,23 +2433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-gpu-tools"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ce78d5548a74fad25177825d0c20f4cfbc6eaf796bcee53afe792e39ede4e2"
-dependencies = [
- "fil-rustacuda",
- "hex",
- "home",
- "log",
- "once_cell",
- "opencl3",
- "sha2",
- "temp-env",
- "thiserror",
-]
-
-[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,23 +2440,6 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "rustacuda_core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
-
-[[package]]
-name = "rustacuda_derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2922,7 +2813,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "rust-embed",
- "rust-gpu-tools",
  "serde",
  "serde_json",
  "serdeconv",
@@ -3105,15 +2995,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "temp-env"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9547444bfe52cbd79515c6c8087d8ae6ca8d64d2d31a27746320f5cb81d1a15c"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cl3"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "215a3aa32ab5d7928c539c4289d1cf144257c3cb05e05a4b7e61d5a6bb6583a5"
+dependencies = [
+ "libc",
+ "opencl-sys",
+ "thiserror",
+]
+
+[[package]]
 name = "clap"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +636,24 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-driver-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
+dependencies = [
+ "cuda-config",
 ]
 
 [[package]]
@@ -885,6 +914,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fil-rustacuda"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40666d4072d5353fd2fd3aa26e4ddb225c38c6440e8c467cae9b17688ae6191c"
+dependencies = [
+ "bitflags",
+ "cuda-driver-sys",
+ "rustacuda_core",
+ "rustacuda_derive",
 ]
 
 [[package]]
@@ -1159,12 +1200,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1741,6 +1797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +1890,25 @@ checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "opencl-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75919008b8ed7ce9620e2b3580c648db40c7f564a368f271b2647145046d8ba"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "opencl3"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247ee0c98af8a67ab9c836ed2ea663ac19a17d8bae71325b509835e536c18ad"
+dependencies = [
+ "cl3",
+ "libc",
 ]
 
 [[package]]
@@ -2424,6 +2508,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-gpu-tools"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ce78d5548a74fad25177825d0c20f4cfbc6eaf796bcee53afe792e39ede4e2"
+dependencies = [
+ "fil-rustacuda",
+ "hex",
+ "home",
+ "log",
+ "once_cell",
+ "opencl3",
+ "sha2",
+ "temp-env",
+ "thiserror",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,6 +2532,23 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rustacuda_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
+
+[[package]]
+name = "rustacuda_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2775,6 +2893,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sysinfo"
+version = "0.29.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10ed79c22663a35a255d289a7fdcb43559fc77ff15df5ce6c341809e7867528"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "tabby"
 version = "0.1.0"
 dependencies = [
@@ -2789,11 +2922,13 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "rust-embed",
+ "rust-gpu-tools",
  "serde",
  "serde_json",
  "serdeconv",
  "strfmt",
  "strum",
+ "sysinfo",
  "tabby-common",
  "tabby-download",
  "tabby-inference",
@@ -2973,6 +3108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "temp-env"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9547444bfe52cbd79515c6c8087d8ae6ca8d64d2d31a27746320f5cb81d1a15c"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "temp_testdir"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,18 +3146,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "dedd246497092a89beedfe2c9f176d44c1b672ea6090edc20544ade01fbb7ea0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "7d7b1fadccbbc7e19ea64708629f9d8dccd007c260d66485f20a6d41bc1cf4b3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -34,7 +34,6 @@ tracing-opentelemetry = "0.18.0"
 tantivy = { workspace = true }
 anyhow = { workspace = true }
 sysinfo = "0.29.8"
-rust-gpu-tools = "0.7.2"
 
 
 [dependencies.uuid]

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -33,6 +33,8 @@ axum-tracing-opentelemetry = "0.10.0"
 tracing-opentelemetry = "0.18.0"
 tantivy = { workspace = true }
 anyhow = { workspace = true }
+sysinfo = "0.29.8"
+rust-gpu-tools = "0.7.2"
 
 
 [dependencies.uuid]

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -1,7 +1,6 @@
 use std::{env::consts::ARCH, sync::Arc};
 
 use axum::{extract::State, Json};
-use rust_gpu_tools::Device;
 use serde::{Deserialize, Serialize};
 use sysinfo::{CpuExt, System, SystemExt};
 use utoipa::ToSchema;
@@ -31,29 +30,12 @@ impl CPUInfo {
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
-struct GPUInfo {
-    gpu_list: Vec<String>,
-}
-
-impl GPUInfo {
-    pub fn new() -> Self {
-        let mut gpu_list = vec![];
-        let devices = Device::all();
-        for device in devices.iter() {
-            gpu_list.push(device.name());
-        }
-        Self { gpu_list }
-    }
-}
-
-#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct HealthState {
     model: String,
     device: String,
     compute_type: String,
     architecture_info: String,
     cpu_info: CPUInfo,
-    gpu_info: GPUInfo,
 }
 
 impl HealthState {
@@ -64,7 +46,6 @@ impl HealthState {
             compute_type: args.compute_type.to_string(),
             architecture_info: ARCH.to_string(),
             cpu_info: CPUInfo::new(),
-            gpu_info: GPUInfo::new(),
         }
     }
 }

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -4,7 +4,7 @@ use std::env::consts::ARCH;
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use sysinfo::{System, SystemExt};
+use sysinfo::{System, SystemExt, CpuExt};
 use rust_gpu_tools::Device;
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
@@ -19,7 +19,8 @@ impl CPUInfo {
         sys.refresh_cpu();
         let cpus = sys.cpus();
         let brand = if cpus.len() > 0 {
-            cpus[0]
+            let cpu = cpus[0];
+            cpu.brand().to_string();
         } else {
             "no cpus assigned".to_string()
         };
@@ -38,7 +39,7 @@ struct GPUInfo {
 impl GPUInfo {
     pub fn new() -> Self {
         let mut gpu_list = vec![];
-        let devices = *Device::all();
+        let devices = Device::all();
         for device in devices.iter() {
             gpu_list.push(device.name());
         }
@@ -53,7 +54,7 @@ pub struct HealthState {
     compute_type: String,
     architecture_info: String,
     cpu_info: CPUInfo,
-    gpu_info: Vec<String>,
+    gpu_info: GPUInfo,
 }
 
 impl HealthState {

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -6,46 +6,34 @@ use sysinfo::{CpuExt, System, SystemExt};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
-struct CPUInfo {
-    brand: String,
-    number: usize,
-}
-
-impl CPUInfo {
-    pub fn new() -> Self {
-        let mut sys = System::new_all();
-        sys.refresh_cpu();
-        let cpus = sys.cpus();
-        let brand = if cpus.len() > 0 {
-            let cpu = &cpus[0];
-            cpu.brand().to_string()
-        } else {
-            "no cpus assigned".to_string()
-        };
-        Self {
-            brand,
-            number: cpus.len(),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct HealthState {
     model: String,
     device: String,
     compute_type: String,
-    architecture_info: String,
-    cpu_info: CPUInfo,
+    arch: String,
+    cpu_info: String,
+    cpu_count: u32,
 }
 
 impl HealthState {
     pub fn new(args: &super::ServeArgs) -> Self {
+        let mut sys = System::new_all();
+        sys.refresh_cpu();
+        let cpus = sys.cpus();
+        let cpu_info = if cpus.len() > 0 {
+            let cpu = &cpus[0];
+            cpu.brand().to_string()
+        } else {
+            "unknown cpu".to_string()
+        };
+
         Self {
             model: args.model.clone(),
             device: args.device.to_string(),
             compute_type: args.compute_type.to_string(),
-            architecture_info: ARCH.to_string(),
-            cpu_info: CPUInfo::new(),
+            arch: ARCH.to_string(),
+            cpu_info,
+            cpu_count: cpus.len() as u32,
         }
     }
 }

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -24,7 +24,7 @@ impl HealthState {
             let cpu = &cpus[0];
             cpu.brand().to_string()
         } else {
-            "unknown cpu".to_string()
+            "unknown".to_string()
         };
 
         Self {

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -3,7 +3,7 @@ use std::{env::consts::ARCH, sync::Arc};
 use axum::{extract::State, Json};
 use rust_gpu_tools::Device;
 use serde::{Deserialize, Serialize};
-use sysinfo::{System, SystemExt, CpuExt};
+use sysinfo::{CpuExt, System, SystemExt};
 use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -20,7 +20,7 @@ impl CPUInfo {
         let cpus = sys.cpus();
         let brand = if cpus.len() > 0 {
             let cpu = cpus[0];
-            cpu.brand().to_string();
+            cpu.brand().to_string()
         } else {
             "no cpus assigned".to_string()
         };

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -12,7 +12,7 @@ pub struct HealthState {
     compute_type: String,
     arch: String,
     cpu_info: String,
-    cpu_count: u32,
+    cpu_count: usize,
 }
 
 impl HealthState {
@@ -33,7 +33,7 @@ impl HealthState {
             compute_type: args.compute_type.to_string(),
             arch: ARCH.to_string(),
             cpu_info,
-            cpu_count: cpus.len() as u32,
+            cpu_count: cpus.len(),
         }
     }
 }

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -1,11 +1,10 @@
-use std::sync::Arc;
-use std::env::consts::ARCH;
+use std::{env::consts::ARCH, sync::Arc};
 
 use axum::{extract::State, Json};
-use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
-use sysinfo::{System, SystemExt, CpuExt};
 use rust_gpu_tools::Device;
+use serde::{Deserialize, Serialize};
+use sysinfo::{System, SystemExt, CpuExt};
+use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 struct CPUInfo {

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -19,7 +19,7 @@ impl CPUInfo {
         sys.refresh_cpu();
         let cpus = sys.cpus();
         let brand = if cpus.len() > 0 {
-            let cpu = cpus[0];
+            let cpu = &cpus[0];
             cpu.brand().to_string()
         } else {
             "no cpus assigned".to_string()


### PR DESCRIPTION
Tested locally with Postman:
```
{
    "model": "/data/models/TabbyML/T5P-220M",
    "device": "cpu",
    "compute_type": "auto",
    "arch": "x86_64",
    "cpu_info": "Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz",
    "cpu_count": 8
}
```