### PR TITLE
feat: add version information in health state.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -2833,6 +2851,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid 1.4.1",
+ "vergen",
 ]
 
 [[package]]
@@ -2943,7 +2962,7 @@ dependencies = [
  "tantivy-query-grammar",
  "tempfile",
  "thiserror",
- "time 0.3.21",
+ "time 0.3.26",
  "uuid 1.4.1",
  "winapi",
 ]
@@ -3068,11 +3087,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
 dependencies = [
+ "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -3086,9 +3108,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "75c65469ed6b3a4809d987a41eb1dc918e9bc1d92211cbad7ae82931846f7451"
 dependencies = [
  "time-core",
 ]
@@ -3768,6 +3790,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "8.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time 0.3.26",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,7 +4168,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.21",
+ "time 0.3.26",
  "zstd",
 ]
 

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -45,6 +45,9 @@ features = [
 ]
 
 [features]
-default = [ "scheduler" ]
+default = ["scheduler"]
 link_shared = ["ctranslate2-bindings/link_shared"]
-scheduler = [ "tabby-scheduler" ]
+scheduler = ["tabby-scheduler"]
+
+[build-dependencies]
+vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }

--- a/crates/tabby/build.rs
+++ b/crates/tabby/build.rs
@@ -1,0 +1,8 @@
+use std::process::Command;
+
+fn main() {
+    // note: add error checking yourself.
+    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/crates/tabby/build.rs
+++ b/crates/tabby/build.rs
@@ -1,8 +1,8 @@
-use std::process::Command;
+use std::error::Error;
 
-fn main() {
-    // note: add error checking yourself.
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    EmitBuilder::builder().all_build().all_git().emit()?;
+    Ok(())
 }

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -13,7 +13,7 @@ pub struct HealthState {
     arch: String,
     cpu_info: String,
     cpu_count: usize,
-    git_hash: String,
+    version: Version,
 }
 
 impl HealthState {
@@ -21,7 +21,7 @@ impl HealthState {
         let mut sys = System::new_all();
         sys.refresh_cpu();
         let cpus = sys.cpus();
-        let cpu_info = if cpus.len() > 0 {
+        let cpu_info = if !cpus.is_empty() {
             let cpu = &cpus[0];
             cpu.brand().to_string()
         } else {
@@ -35,7 +35,26 @@ impl HealthState {
             arch: ARCH.to_string(),
             cpu_info,
             cpu_count: cpus.len(),
-            git_hash: env!("GIT_HASH").to_string()
+            version: Version::new(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
+pub struct Version {
+    build_date: String,
+    build_timestamp: String,
+    git_sha: String,
+    git_describe: String,
+}
+
+impl Version {
+    fn new() -> Self {
+        Self {
+            build_date: env!("VERGEN_BUILD_DATE").to_string(),
+            build_timestamp: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
+            git_sha: env!("VERGEN_GIT_SHA").to_string(),
+            git_describe: env!("VERGEN_GIT_DESCRIBE").to_string(),
         }
     }
 }

--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -13,6 +13,7 @@ pub struct HealthState {
     arch: String,
     cpu_info: String,
     cpu_count: usize,
+    git_hash: String,
 }
 
 impl HealthState {
@@ -34,6 +35,7 @@ impl HealthState {
             arch: ARCH.to_string(),
             cpu_info,
             cpu_count: cpus.len(),
+            git_hash: env!("GIT_HASH").to_string()
         }
     }
 }


### PR DESCRIPTION
Example:
```json
{
  "model": "TabbyML/SantaCoder-1B",
  "device": "cpu",
  "compute_type": "auto",
  "arch": "aarch64",
  "cpu_info": "Apple M2 Max",
  "cpu_count": 12,
  "version": {
    "build_date": "2023-08-20",
    "build_timestamp": "2023-08-20T15:11:31.236276000Z",
    "git_sha": "84c1673c6701aeb6d5779b04a29d891b74e417a6",
    "git_describe": "84c1673c6"
  }
}
```