### PR TITLE
test: unit tests to prompt builder [TAB-180]

### DIFF
--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -205,7 +205,7 @@ lazy_static! {
 mod tests {
     use super::*;
 
-    fn init_prompt_builder(with_template: bool) -> PromptBuilder {
+    fn create_prompt_builder(with_template: bool) -> PromptBuilder {
         let prompt_template = if with_template {
             // Init prompt builder with codellama prompt template
             Some("<PRE> {prefix} <SUF>{suffix} <MID>".into())
@@ -218,8 +218,8 @@ mod tests {
     }
 
     #[test]
-    fn test_w_template() {
-        let pb = init_prompt_builder(true);
+    fn test_prompt_template() {
+        let pb = create_prompt_builder(true);
 
         // Rewrite disabled, so the language doesn't matter.
         let language = "python";
@@ -292,8 +292,8 @@ mod tests {
     }
 
     #[test]
-    fn test_wo_template() {
-        let pb = init_prompt_builder(false);
+    fn test_no_prompt_template() {
+        let pb = create_prompt_builder(false);
 
         // Rewrite disabled, so the language doesn't matter.
         let language = "python";

--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -200,3 +200,147 @@ lazy_static! {
     static ref LANGUAGE_LINE_COMMENT_CHAR: HashMap<&'static str, &'static str> =
         HashMap::from([("python", "#"), ("rust", "//"),]);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_prompt_builder(with_template: bool) -> PromptBuilder {
+        let prompt_template = if with_template {
+            // Init prompt builder with codellama prompt template 
+            Some("<PRE> {prefix} <SUF>{suffix} <MID>".into())
+        } else {
+            None
+        };
+
+        // Init prompt builder with prompt rewrite disabled.
+        PromptBuilder::new(
+            prompt_template,
+            false
+        )
+    }
+
+    #[test]
+    fn test_w_template() {
+        let pb = init_prompt_builder(true);
+
+        // Rewrite disabled, so the language doesn't matter.
+        let language = "python";
+
+        // Test w/ prefix, w/ suffix.
+        {
+            let segments = Segments {
+                prefix: "this is some prefix".into(),
+                suffix: Some("this is some suffix".into()),
+            };
+            assert_eq!(pb.build(language, segments), "<PRE> this is some prefix <SUF>this is some suffix <MID>");
+        }
+
+        // Test w/ prefix, w/o suffix.
+        {
+            let segments = Segments {
+                prefix: "this is some prefix".into(),
+                suffix: None,
+            };
+            assert_eq!(pb.build(language, segments), "<PRE> this is some prefix <SUF>\n <MID>");
+        }
+
+        // Test w/ prefix, w/ empty suffix.
+        {
+            let segments = Segments {
+                prefix: "this is some prefix".into(),
+                suffix: Some("".into()),
+            };
+            assert_eq!(pb.build(language, segments), "<PRE> this is some prefix <SUF> <MID>");
+        }
+
+        // Test w/ empty prefix, w/ suffix.
+        {
+            let segments = Segments {
+                prefix: "".into(),
+                suffix: Some("this is some suffix".into()),
+            };
+            assert_eq!(pb.build(language, segments), "<PRE>  <SUF>this is some suffix <MID>");
+        }
+
+        // Test w/ prefix, w/o suffix.
+        {
+            let segments = Segments {
+                prefix: "".into(),
+                suffix: None,
+            };
+            assert_eq!(pb.build(language, segments), "<PRE>  <SUF>\n <MID>");
+        }
+
+        // Test w/ prefix, w/ empty suffix.
+        {
+            let segments = Segments {
+                prefix: "".into(),
+                suffix: Some("".into()),
+            };
+            assert_eq!(pb.build(language, segments), "<PRE>  <SUF> <MID>");
+        }
+    }
+
+        #[test]
+    fn test_wo_template() {
+        let pb = init_prompt_builder(false);
+
+        // Rewrite disabled, so the language doesn't matter.
+        let language = "python";
+
+        // Test w/ prefix, w/ suffix.
+        {
+            let segments = Segments {
+                prefix: "this is some prefix".into(),
+                suffix: Some("this is some suffix".into()),
+            };
+            assert_eq!(pb.build(language, segments), "this is some prefix");
+        }
+
+        // Test w/ prefix, w/o suffix.
+        {
+            let segments = Segments {
+                prefix: "this is some prefix".into(),
+                suffix: None,
+            };
+            assert_eq!(pb.build(language, segments), "this is some prefix");
+        }
+
+        // Test w/ prefix, w/ empty suffix.
+        {
+            let segments = Segments {
+                prefix: "this is some prefix".into(),
+                suffix: Some("".into()),
+            };
+            assert_eq!(pb.build(language, segments), "this is some prefix");
+        }
+
+        // Test w/ empty prefix, w/ suffix.
+        {
+            let segments = Segments {
+                prefix: "".into(),
+                suffix: Some("this is some suffix".into()),
+            };
+            assert_eq!(pb.build(language, segments), "");
+        }
+
+        // Test w/ prefix, w/o suffix.
+        {
+            let segments = Segments {
+                prefix: "".into(),
+                suffix: None,
+            };
+            assert_eq!(pb.build(language, segments), "");
+        }
+
+        // Test w/ prefix, w/ empty suffix.
+        {
+            let segments = Segments {
+                prefix: "".into(),
+                suffix: Some("".into()),
+            };
+            assert_eq!(pb.build(language, segments), "");
+        }
+    }
+}

--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -263,7 +263,7 @@ mod tests {
             assert_eq!(pb.build(language, segments), "<PRE>  <SUF>this is some suffix <MID>");
         }
 
-        // Test w/ prefix, w/o suffix.
+        // Test w/ empty prefix, w/o suffix.
         {
             let segments = Segments {
                 prefix: "".into(),
@@ -272,7 +272,7 @@ mod tests {
             assert_eq!(pb.build(language, segments), "<PRE>  <SUF>\n <MID>");
         }
 
-        // Test w/ prefix, w/ empty suffix.
+        // Test w/ emtpy prefix, w/ empty suffix.
         {
             let segments = Segments {
                 prefix: "".into(),
@@ -325,7 +325,7 @@ mod tests {
             assert_eq!(pb.build(language, segments), "");
         }
 
-        // Test w/ prefix, w/o suffix.
+        // Test w/ empty prefix, w/o suffix.
         {
             let segments = Segments {
                 prefix: "".into(),
@@ -334,7 +334,7 @@ mod tests {
             assert_eq!(pb.build(language, segments), "");
         }
 
-        // Test w/ prefix, w/ empty suffix.
+        // Test w/ empty prefix, w/ empty suffix.
         {
             let segments = Segments {
                 prefix: "".into(),

--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -207,17 +207,14 @@ mod tests {
 
     fn init_prompt_builder(with_template: bool) -> PromptBuilder {
         let prompt_template = if with_template {
-            // Init prompt builder with codellama prompt template 
+            // Init prompt builder with codellama prompt template
             Some("<PRE> {prefix} <SUF>{suffix} <MID>".into())
         } else {
             None
         };
 
         // Init prompt builder with prompt rewrite disabled.
-        PromptBuilder::new(
-            prompt_template,
-            false
-        )
+        PromptBuilder::new(prompt_template, false)
     }
 
     #[test]
@@ -233,7 +230,10 @@ mod tests {
                 prefix: "this is some prefix".into(),
                 suffix: Some("this is some suffix".into()),
             };
-            assert_eq!(pb.build(language, segments), "<PRE> this is some prefix <SUF>this is some suffix <MID>");
+            assert_eq!(
+                pb.build(language, segments),
+                "<PRE> this is some prefix <SUF>this is some suffix <MID>"
+            );
         }
 
         // Test w/ prefix, w/o suffix.
@@ -242,7 +242,10 @@ mod tests {
                 prefix: "this is some prefix".into(),
                 suffix: None,
             };
-            assert_eq!(pb.build(language, segments), "<PRE> this is some prefix <SUF>\n <MID>");
+            assert_eq!(
+                pb.build(language, segments),
+                "<PRE> this is some prefix <SUF>\n <MID>"
+            );
         }
 
         // Test w/ prefix, w/ empty suffix.
@@ -251,7 +254,10 @@ mod tests {
                 prefix: "this is some prefix".into(),
                 suffix: Some("".into()),
             };
-            assert_eq!(pb.build(language, segments), "<PRE> this is some prefix <SUF> <MID>");
+            assert_eq!(
+                pb.build(language, segments),
+                "<PRE> this is some prefix <SUF> <MID>"
+            );
         }
 
         // Test w/ empty prefix, w/ suffix.
@@ -260,7 +266,10 @@ mod tests {
                 prefix: "".into(),
                 suffix: Some("this is some suffix".into()),
             };
-            assert_eq!(pb.build(language, segments), "<PRE>  <SUF>this is some suffix <MID>");
+            assert_eq!(
+                pb.build(language, segments),
+                "<PRE>  <SUF>this is some suffix <MID>"
+            );
         }
 
         // Test w/ empty prefix, w/o suffix.
@@ -282,7 +291,7 @@ mod tests {
         }
     }
 
-        #[test]
+    #[test]
     fn test_wo_template() {
         let pb = init_prompt_builder(false);
 


### PR DESCRIPTION
All tests passed.

### Covered:
`prompt rewrite` disabled
valid `prompt template` | no `prompt template`
some text `prefix` | empty `prefix`
some text `suffix` | none `suffix` | empty `suffix`