### PR TITLE
feat: add single line comment to languages so they can be used in prompting [TAB-181]

### DIFF
--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -200,7 +200,7 @@ lazy_static! {
     static ref LANGUAGE_LINE_COMMENT_CHAR: HashMap<&'static str, &'static str> = HashMap::from([
         ("python", "#"),
         ("rust", "//"),
-        ("js_ts", "//"),
+        ("javascript-typescript", "//"),
         ("go", "//"),
         ("java", "//"),
         ("lua", "--"),

--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -197,6 +197,12 @@ impl IndexState {
 }
 
 lazy_static! {
-    static ref LANGUAGE_LINE_COMMENT_CHAR: HashMap<&'static str, &'static str> =
-        HashMap::from([("python", "#"), ("rust", "//"),]);
+    static ref LANGUAGE_LINE_COMMENT_CHAR: HashMap<&'static str, &'static str> = HashMap::from([
+        ("python", "#"),
+        ("rust", "//"),
+        ("js_ts", "//"),
+        ("go", "//"),
+        ("java", "//"),
+        ("lua", "--"),
+    ]);
 }


### PR DESCRIPTION
Add comment signs to extended languages, so that prompt rewrite could be used on these languages