### PR TITLE
feat: tune llama metal backend performance

### DIFF
--- a/crates/llama-cpp-bindings/include/engine.h
+++ b/crates/llama-cpp-bindings/include/engine.h
@@ -11,6 +11,8 @@ class TextInferenceEngine {
 
   virtual uint32_t start(const rust::Str prompt) const = 0;
   virtual uint32_t step(uint32_t next_token_id) const = 0;
+
+  virtual uint32_t eos_token() const = 0;
 };
 
 std::shared_ptr<TextInferenceEngine> create_engine(rust::Str model_path);

--- a/crates/llama-cpp-bindings/include/engine.h
+++ b/crates/llama-cpp-bindings/include/engine.h
@@ -11,6 +11,7 @@ class TextInferenceEngine {
 
   virtual uint32_t start(const rust::Str prompt) const = 0;
   virtual uint32_t step(uint32_t next_token_id) const = 0;
+  virtual void end() const = 0;
 
   virtual uint32_t eos_token() const = 0;
 };

--- a/crates/llama-cpp-bindings/src/engine.cc
+++ b/crates/llama-cpp-bindings/src/engine.cc
@@ -47,6 +47,11 @@ class TextInferenceEngineImpl : public TextInferenceEngine {
     return sample();
   }
 
+
+  uint32_t eos_token() const override {
+    return llama_token_eos(ctx_.get());
+  }
+
  private:
   uint32_t sample() const {
     auto* ctx = ctx_.get();


### PR DESCRIPTION
Chip: Apple M2 Max
Memory: 96 GB

All tests all done with `TabbyML/CodeLlama-7B`

Request
```
curl -X 'POST' \
  'http://localhost:8080/v1/completions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "language": "python",
  "segments": {
    "prefix": "def fib(n):\n    ",
    "suffix": "\n        return fib(n - 1) + fib(n - 2)"
  }
}'
```

## float16
```
llama_print_timings:        load time = 18446.19 ms
llama_print_timings:      sample time =     0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings: prompt eval time =   450.79 ms /    29 tokens (   15.54 ms per token,    64.33 tokens per second)
llama_print_timings:        eval time =  2345.53 ms /    29 runs   (   80.88 ms per token,    12.36 tokens per second)
llama_print_timings:       total time =  2799.79 ms
```

## q8_0
```
llama_print_timings:        load time =  8801.08 ms
llama_print_timings:      sample time =     0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_print_timings: prompt eval time =   302.13 ms /    29 tokens (   10.42 ms per token,    95.98 tokens per second)
llama_print_timings:        eval time =   724.88 ms /    29 runs   (   25.00 ms per token,    40.01 tokens per second)
llama_print_timings:       total time =  1030.47 ms
```
