### PR TITLE
test: add build prefix test and debug chars counting [TAB-184]

### DIFF
--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -115,7 +115,6 @@ fn collect_snippets(index: &IndexState, language: &str, text: &str) -> Vec<Strin
         "language:{} AND kind:call AND ({})",
         language, sanitized_text
     );
-
     let query = match index.query_parser.parse_query(&query_text) {
         Ok(query) => query,
         Err(err) => {

--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -407,8 +407,6 @@ def this_is_prefix():\n";
 
         let generated_prompt = build_prefix("python", prefix, snippets);
 
-        println!("{}", generated_prompt);
-
         for i in 0..snippets_expected + 1 {
             let st = format!("# == Snippet {} ==", i + 1);
             if i < snippets_expected {

--- a/crates/tabby/src/serve/completions/prompt.rs
+++ b/crates/tabby/src/serve/completions/prompt.rs
@@ -389,7 +389,10 @@ mod tests {
 #     print(\"This is snipptet 5\")
 def this_is_prefix():\n";
 
-        assert_eq!(build_prefix("python", prefix, snippets), expected_built_prefix);
+        assert_eq!(
+            build_prefix("python", prefix, snippets),
+            expected_built_prefix
+        );
     }
 
     #[test]


### PR DESCRIPTION
# What this PR is about
1. Add unit testing to `PromptBuilder::build_prefix()` so that prompt rewriting could be fenced in a readable fashion.
2. Add unit testing to `PromptBuilder::build_prefix()` to guarantee the snippet count-and-select strategy works as expected. With doing this, also debug and remove a redundant counting line of code.