### PR TITLE
fix: 🐛 Couldn't find package "tabby-agent@0.0.1"

### DIFF
--- a/clients/intellij/package.json
+++ b/clients/intellij/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "0.0.1"
+    "tabby-agent": "0.1.0-dev"
   }
 }

--- a/clients/vim/package.json
+++ b/clients/vim/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "0.0.1"
+    "tabby-agent": "0.1.0-dev"
   }
 }

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -197,6 +197,6 @@
   },
   "dependencies": {
     "@xstate/fsm": "^2.0.1",
-    "tabby-agent": "0.0.1"
+    "tabby-agent": "0.1.0-dev"
   }
 }


### PR DESCRIPTION
Fix `error Couldn't find package "tabby-agent@0.0.1" required by "vscode-tabby@0.3.0" on the "npm" registry.` issue due to tabby-agent version #389 update.

```shell
$ yarn install
yarn install v1.22.10
[1/4] 🔍  Resolving packages...
error Couldn't find package "tabby-agent@0.0.1" required by "vscode-tabby@0.3.0" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Couldn't find package "tabby-agent@0.0.1" required by "vim-tabby@0.0.1" on the "npm" registry.
    at MessageError.ExtendableBuiltin (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:721:66)
    at new MessageError (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:750:123)
    at PackageRequest.<anonymous> (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:36539:17)
    at Generator.throw (<anonymous>)
    at step (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:310:30)
    at /Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:323:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Error: Couldn't find package "tabby-agent@0.0.1" required by "intellij-tabby@0.0.1" on the "npm" registry.
    at MessageError.ExtendableBuiltin (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:721:66)
    at new MessageError (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:750:123)
    at PackageRequest.<anonymous> (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:36539:17)
    at Generator.throw (<anonymous>)
    at step (/Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:310:30)
    at /Users/guoxudong/.asdf/installs/yarn/1.22.10/lib/cli.js:323:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
