### PR TITLE
fix(tabby): fix swagger's local server use local port

### DIFF
--- a/crates/tabby/src/serve/mod.rs
+++ b/crates/tabby/src/serve/mod.rs
@@ -161,10 +161,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
 
     info!("Starting server, this might takes a few minutes...");
 
-    // swagger add local server
-    let mut doc = ApiDoc::openapi();
-    add_localhost_server(&mut doc, args.port);
-
+    let doc = add_localhost_server(ApiDoc::openapi(), args.port);
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", doc))
         .nest("/v1", api_router(args, config))
@@ -228,8 +225,9 @@ fn start_heartbeat(args: &ServeArgs) {
     });
 }
 
-fn add_localhost_server(api: &mut utoipa::openapi::OpenApi, port: u16) {
-    if let Some(servers) = api.servers.as_mut() {
+fn add_localhost_server(doc: utoipa::openapi::OpenApi, port: u16) -> utoipa::openapi::OpenApi {
+    let mut doc = doc;
+    if let Some(servers) = doc.servers.as_mut() {
         servers.push(
             ServerBuilder::new()
                 .url(format!("http://localhost:{}", port))
@@ -237,4 +235,6 @@ fn add_localhost_server(api: &mut utoipa::openapi::OpenApi, port: u16) {
                 .build(),
         );
     }
+
+    doc
 }

--- a/crates/tabby/src/serve/mod.rs
+++ b/crates/tabby/src/serve/mod.rs
@@ -163,14 +163,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
 
     // swagger add local server
     let mut doc = ApiDoc::openapi();
-    if let Some(servers) = doc.servers.as_mut() {
-        servers.push(
-            ServerBuilder::new()
-                .url(format!("http://localhost:{}", args.port))
-                .description(Some("Local server"))
-                .build(),
-        );
-    }
+    add_localhost_server(&mut doc, args.port);
 
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", doc))
@@ -233,4 +226,15 @@ fn start_heartbeat(args: &ServeArgs) {
             sleep(Duration::from_secs(300)).await;
         }
     });
+}
+
+fn add_localhost_server(api: &mut utoipa::openapi::OpenApi, port: u16) {
+    if let Some(servers) = api.servers.as_mut() {
+        servers.push(
+            ServerBuilder::new()
+                .url(format!("http://localhost:{}", port))
+                .description(Some("Local server"))
+                .build(),
+        );
+    }
 }


### PR DESCRIPTION
```
 servers(
        (url = "https://playground.app.tabbyml.com", description = "Playground server"),
        (url = "http://localhost:8080", description = "Local server"),
    ),
```
The default is to use port 8080, but serve can customize the port through --port, resulting in request errors