### PR TITLE
feat: proxy server address mapping to the model server

### DIFF
--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -15,12 +15,20 @@ pub struct Config {
 
     #[serde(default)]
     pub experimental: Experimental,
+
+    #[serde(default)]
+    pub swagger: SwaggerConfig,
 }
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct Experimental {
     #[serde(default = "default_as_false")]
     pub enable_prompt_rewrite: bool,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct SwaggerConfig {
+    pub server_url: Option<String>,
 }
 
 impl Config {

--- a/crates/tabby-scheduler/tests/integration_test.rs
+++ b/crates/tabby-scheduler/tests/integration_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use std::fs::create_dir_all;
 
     use tabby_common::{
-        config::{Config, Experimental, Repository},
+        config::{Config, Experimental, Repository, SwaggerConfig},
         path::set_tabby_root,
     };
     use temp_testdir::*;
@@ -20,6 +20,7 @@ mod tests {
             repositories: vec![Repository {
                 git_url: "https://github.com/TabbyML/interview-questions".to_owned(),
             }],
+            swagger: SwaggerConfig { server_url: None },
             experimental: Experimental::default(),
         };
 

--- a/crates/tabby/src/serve/mod.rs
+++ b/crates/tabby/src/serve/mod.rs
@@ -244,11 +244,11 @@ fn add_proxy_server(
     doc: utoipa::openapi::OpenApi,
     server_url: Option<String>,
 ) -> utoipa::openapi::OpenApi {
-    let server_url: String = server_url.unwrap_or_default();
-    if server_url.is_empty() {
-        return doc;
+    if server_url.is_none() {
+        return doc
     }
 
+    let server_url: String = server_url.unwrap();
     let mut doc = doc;
     if let Some(servers) = doc.servers.as_mut() {
         servers.push(

--- a/crates/tabby/src/serve/mod.rs
+++ b/crates/tabby/src/serve/mod.rs
@@ -103,10 +103,6 @@ pub struct ServeArgs {
     #[clap(long)]
     model: String,
 
-    /// proxy server address mapping to the model server.
-    #[clap(long, default_value_t = String::from(""))]
-    proxy_server: String,
-
     #[clap(long, default_value_t = 8080)]
     port: u16,
 
@@ -166,7 +162,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
     info!("Starting server, this might takes a few minutes...");
 
     let doc = add_localhost_server(ApiDoc::openapi(), args.port);
-    let doc = add_proxy_server(doc, &args.proxy_server);
+    let doc = add_proxy_server(doc, config.swagger.server_url.clone());
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", doc))
         .nest("/v1", api_router(args, config))
@@ -218,13 +214,6 @@ fn valid_args(args: &ServeArgs) {
             _ => fatal!("CPU device only supports int8 compute type"),
         }
     }
-
-    if !args.proxy_server.is_empty()
-        && !args.proxy_server.starts_with("http://")
-        && !args.proxy_server.starts_with("https://")
-    {
-        fatal!("proxy server should start with https:// or http://");
-    }
 }
 
 fn start_heartbeat(args: &ServeArgs) {
@@ -251,8 +240,12 @@ fn add_localhost_server(doc: utoipa::openapi::OpenApi, port: u16) -> utoipa::ope
     doc
 }
 
-fn add_proxy_server(doc: utoipa::openapi::OpenApi, proxy_server: &str) -> utoipa::openapi::OpenApi {
-    if proxy_server.is_empty() {
+fn add_proxy_server(
+    doc: utoipa::openapi::OpenApi,
+    server_url: Option<String>,
+) -> utoipa::openapi::OpenApi {
+    let server_url: String = server_url.unwrap_or_default();
+    if server_url.is_empty() {
         return doc;
     }
 
@@ -260,8 +253,8 @@ fn add_proxy_server(doc: utoipa::openapi::OpenApi, proxy_server: &str) -> utoipa
     if let Some(servers) = doc.servers.as_mut() {
         servers.push(
             ServerBuilder::new()
-                .url(proxy_server.to_string())
-                .description(Some("Proxy server"))
+                .url(server_url)
+                .description(Some("Swagger Server"))
                 .build(),
         );
     }

--- a/crates/tabby/src/serve/mod.rs
+++ b/crates/tabby/src/serve/mod.rs
@@ -245,7 +245,7 @@ fn add_proxy_server(
     server_url: Option<String>,
 ) -> utoipa::openapi::OpenApi {
     if server_url.is_none() {
-        return doc
+        return doc;
     }
 
     let server_url: String = server_url.unwrap();


### PR DESCRIPTION
![image](https://github.com/TabbyML/tabby/assets/533008/8ec41f3e-f2e3-4c5b-92a8-f7301f5f888d)

Before the Tabby service, if there is nginx's reverse proxy service, users can access Tabby's services through domain names. Currently, swagger only has https://playground.app.tabbyml.com and local service options, and cannot perform service completion through domain names.

current server：
![image](https://github.com/TabbyML/tabby/assets/533008/149aa46a-4da0-4733-b7f6-a117ded2cdeb)

add proxy server
![image](https://github.com/TabbyML/tabby/assets/533008/bf261ec3-0267-4e32-a693-b94d88d13e95)
