### PR TITLE
docs: add alternative submodule fetching to contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ brew install protobuf
 apt-get install protobuf-compiler libopenblas-dev
 ```
 
-3. Now, you can build Tabby by running the command `cargo build`.
+3. Clone all submoudles to local enviorment if you forget to use `recurse-submodules` at the first step:
+```bash
+git submodule update --recursive --init
+```
+
+4. Now, you can build Tabby by running the command `cargo build`.
 
 ### Start Hacking!
 ... and don't forget to submit a [Pull Request](https://github.com/TabbyML/tabby/compare)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ git clone --recurse-submodules https://github.com/TabbyML/tabby
 cd tabby
 ```
 
+If you have already cloned the repository, you could run the `git submodule update --recursive --init` command to fetch all submodules.
+
 ### Build
 
 1. Set up the Rust environment by following this [tutorial](https://www.rust-lang.org/learn/get-started).
@@ -64,12 +66,7 @@ brew install protobuf
 apt-get install protobuf-compiler libopenblas-dev
 ```
 
-3. Clone all submoudles to local enviorment if you forget to use `recurse-submodules` at the first step:
-```bash
-git submodule update --recursive --init
-```
-
-4. Now, you can build Tabby by running the command `cargo build`.
+3. Now, you can build Tabby by running the command `cargo build`.
 
 ### Start Hacking!
 ... and don't forget to submit a [Pull Request](https://github.com/TabbyML/tabby/compare)


### PR DESCRIPTION
Hi Guys,

I faced an issue while trying to clone code and compile it on my Mac. I realized that I had forgotten to include the recurse-submodules option during the initial cloning process. As a result, I received an error message indicating that the `llma.cpp` directory was empty.

To improve the process and help others avoid this issue, it might be beneficial to add an additional step, advising users to clone submodules using the following command:

```
git submodule update --recursive --init
```

This will ensure that all necessary submodules are fetched and initialized, preventing similar problems in the future.

If you have any further suggestions or need additional assistance, please feel free to let me know.
