### PR TITLE
fix(vscode): completion view/select event.

### DIFF
--- a/clients/intellij/package.json
+++ b/clients/intellij/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "0.2.0"
+    "tabby-agent": "0.3.0-dev"
   }
 }

--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabby-agent",
-  "version": "0.2.0",
+  "version": "0.3.0-dev",
   "description": "Generic client agent for Tabby AI coding assistant IDE extensions.",
   "repository": "https://github.com/TabbyML/tabby",
   "main": "./dist/index.js",

--- a/clients/tabby-agent/src/Agent.ts
+++ b/clients/tabby-agent/src/Agent.ts
@@ -19,7 +19,9 @@ export type CompletionRequest = {
 
 export type CompletionResponse = ApiComponents["schemas"]["CompletionResponse"];
 
-export type LogEventRequest = ApiComponents["schemas"]["LogEventRequest"];
+export type LogEventRequest = ApiComponents["schemas"]["LogEventRequest"] & {
+  select_kind?: "line";
+};
 
 export type AbortSignalOption = { signal: AbortSignal };
 

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -429,7 +429,19 @@ export class TabbyAgent extends EventEmitter implements Agent {
     if (this.status === "notInitialized") {
       throw new Error("Agent is not initialized");
     }
-    await this.post("/v1/events", { body: request, parseAs: "text" }, options);
+    await this.post(
+      "/v1/events",
+      {
+        body: request,
+        params: {
+          query: {
+            select_kind: request.select_kind,
+          },
+        },
+        parseAs: "text",
+      },
+      options,
+    );
     return true;
   }
 }

--- a/clients/vim/package.json
+++ b/clients/vim/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "0.2.0"
+    "tabby-agent": "0.3.0-dev"
   }
 }

--- a/clients/vscode/README.md
+++ b/clients/vscode/README.md
@@ -25,6 +25,6 @@ Once you have installed the Tabby VSCode extension, you can easily get started b
 1. **Setup the Tabby server**: You have two options to set up your Tabby server. You can either get a Tabby Cloud hosted server [here](https://app.tabbyml.com) or build your own self-hosted Tabby server following [this guide](https://tabby.tabbyml.com/docs/installation).
 2. **Connect the extension to your Tabby server**: Use the command `Tabby: Specify API Endpoint of Tabby` to connect the extension to your Tabby server. If you are using a Tabby Cloud server endpoint, follow the instructions provided in the popup messages to complete the authorization process.
 
-Once the setup is complete, Tabby will automatically provide inline suggestions. You can accept the suggestions by simply pressing the `Tab` key. Hovering over the inline suggestion text will display additional useful actions, such as partially accepting suggestions by word or by line.
+Once the setup is complete, Tabby will automatically provide inline suggestions. You can accept the suggestions by simply pressing the `Tab` key.
 
 If you prefer to trigger code completion manually, you can select the manual trigger option in the settings. After that, use the shortcut `Alt + \` to trigger code completion. To access the settings page, use the command `Tabby: Open Settings`.

--- a/clients/vscode/assets/walkthroughs/codeCompletion.md
+++ b/clients/vscode/assets/walkthroughs/codeCompletion.md
@@ -10,10 +10,6 @@ Tabby will show inline suggestions when you stop typing, and you can accept sugg
 
 If you select manual trigger in the [settings](command:tabby.openSettings), you can trigger code completion by pressing `Alt + \`.
 
-## Cycling Through Choices
-
-When multiple choices are available, you can cycle through them by pressing `Alt + [` and `Alt + ]`.
-
 ## Keybindings
 
 You can select a keybinding profile in the [settings](command:tabby.openSettings), or customize your own [keybindings](command:tabby.openKeybindings).

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -216,6 +216,6 @@
   },
   "dependencies": {
     "@xstate/fsm": "^2.0.1",
-    "tabby-agent": "0.2.0"
+    "tabby-agent": "0.3.0-dev"
   }
 }

--- a/clients/vscode/src/commands.ts
+++ b/clients/vscode/src/commands.ts
@@ -11,6 +11,7 @@ import {
 import { strict as assert } from "assert";
 import { agent } from "./agent";
 import { notifications } from "./notifications";
+import { TabbyCompletionProvider } from "./TabbyCompletionProvider";
 
 const configTarget = ConfigurationTarget.Global;
 
@@ -109,14 +110,6 @@ const gettingStarted: Command = {
   },
 };
 
-const emitEvent: Command = {
-  command: "tabby.emitEvent",
-  callback: (event) => {
-    console.debug("Emit Event: ", event);
-    agent().postEvent(event);
-  },
-};
-
 const openAuthPage: Command = {
   command: "tabby.openAuthPage",
   callback: (callbacks?: { onAuthStart?: () => void; onAuthEnd?: () => void }) => {
@@ -185,7 +178,7 @@ const acceptInlineCompletion: Command = {
 const acceptInlineCompletionNextWord: Command = {
   command: "tabby.inlineCompletion.acceptNextWord",
   callback: () => {
-    // FIXME: sent event when partially accept?
+    TabbyCompletionProvider.getInstance().postEvent("accept_word");
     commands.executeCommand("editor.action.inlineSuggest.acceptNextWord");
   },
 };
@@ -193,7 +186,8 @@ const acceptInlineCompletionNextWord: Command = {
 const acceptInlineCompletionNextLine: Command = {
   command: "tabby.inlineCompletion.acceptNextLine",
   callback: () => {
-    // FIXME: sent event when partially accept?
+    TabbyCompletionProvider.getInstance().postEvent("accept_line");
+    // FIXME: this command move cursor to next line, but we want to move cursor to the end of current line
     commands.executeCommand("editor.action.inlineSuggest.acceptNextLine");
   },
 };
@@ -206,7 +200,6 @@ export const tabbyCommands = () =>
     openTabbyAgentSettings,
     openKeybindings,
     gettingStarted,
-    emitEvent,
     openAuthPage,
     applyCallback,
     triggerInlineCompletion,

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -11,7 +11,7 @@ import { TabbyStatusBarItem } from "./TabbyStatusBarItem";
 export async function activate(context: ExtensionContext) {
   console.debug("Activating Tabby extension", new Date());
   await createAgentInstance(context);
-  const completionProvider = new TabbyCompletionProvider();
+  const completionProvider = TabbyCompletionProvider.getInstance();
   const statusBarItem = new TabbyStatusBarItem(completionProvider);
   context.subscriptions.push(
     languages.registerInlineCompletionItemProvider({ pattern: "**" }, completionProvider),


### PR DESCRIPTION
Fix TAB-19 
Fix TAB-133
Fix #103 

As mentioned in issue #103, the Tabby extension returns a list of choices (InlineCompletionItems) to the vscode completion engine for each call. Without registering a callback using the [proposed VSCode API](https://github.com/microsoft/vscode/blob/e3da120e0808f36e45e6783b611cc943d7fdd61c/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts#L20), it is uncertain which choice is currently being viewed.

The Tabby server api schema allows generating multiple choices at once, but the Tabby server only generates one choice per request. In this PR, the extension is modified to return only one choice to the vscode completion engine, assuming that this choice is viewed immediately. The extension send the `view` event before return each choice, as a workaround for the lack of the mentioned proposed VSCode API.
