### PR TITLE
fix(vim): error parsing tabby-agent.js path

### DIFF
--- a/clients/vim/autoload/tabby.vim
+++ b/clients/vim/autoload/tabby.vim
@@ -202,7 +202,7 @@ function! tabby#Start()
     return
   endif
 
-  let tabby_root = expand('<script>:h:h')
+  let tabby_root = expand('<sfile>:h:h')
   let node_script = tabby_root . '/node_scripts/tabby-agent.js'
   if !filereadable(node_script)
     let s:errmsg = 'Tabby node script should be download first. Try to run `yarn upgrade-agent`.'


### PR DESCRIPTION
keep getting error below, even after yarn upgrade-agent manully:

> Tabby node script should be download first. Try to run `yarn upgrade-agent`.