### PR TITLE
Updated completion function name

### DIFF
--- a/clients/vim/autoload/tabby.vim
+++ b/clients/vim/autoload/tabby.vim
@@ -282,7 +282,7 @@ function! s:GetCompletion(id)
   endif
 
   let s:pending_request_id = tabby#job#Send(s:tabby, #{
-    \ func: 'getCompletions',
+    \ func: 'provideCompletions',
     \ args: [s:CreateCompletionRequest()],
     \ }, #{
     \ callback: function('s:HandleCompletion', [a:id]),


### PR DESCRIPTION
`getCompletions` was changed to `provideCompletions` in commit #1c1cf44639d436078db82758baea457326b8a77d