### PR TITLE
fix(agent): hotfix vscode extension 0.6.1. Filter out no data AgentStats event.

### DIFF
--- a/clients/intellij/package.json
+++ b/clients/intellij/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "0.3.0"
+    "tabby-agent": "0.3.1"
   }
 }

--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabby-agent",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Generic client agent for Tabby AI coding assistant IDE extensions.",
   "repository": "https://github.com/TabbyML/tabby",
   "main": "./dist/index.js",

--- a/clients/tabby-agent/src/CompletionProviderStats.ts
+++ b/clients/tabby-agent/src/CompletionProviderStats.ts
@@ -20,7 +20,10 @@ class Average {
     this.quantity += 1;
   }
 
-  mean(): number {
+  mean(): number | undefined {
+    if (this.quantity === 0) {
+      return undefined;
+    }
     return this.sum / this.quantity;
   }
 

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -70,7 +70,6 @@ export class TabbyAgent extends EventEmitter implements Agent {
 
     this.submitStatsTimer = setInterval(async () => {
       await this.submitStats();
-      this.logger.debug("Stats submitted");
     }, TabbyAgent.submitStatsInterval);
   }
 
@@ -185,8 +184,11 @@ export class TabbyAgent extends EventEmitter implements Agent {
 
   private async submitStats() {
     const stats = this.completionProviderStats.stats();
-    await this.anonymousUsageLogger.event("AgentStats", { stats, config: this.config.completion });
-    this.completionProviderStats.reset();
+    if (stats.completion_request.count > 0) {
+      await this.anonymousUsageLogger.event("AgentStats", { stats });
+      this.completionProviderStats.reset();
+      this.logger.debug({ stats }, "Stats submitted");
+    }
   }
 
   private async post<T extends Parameters<typeof this.api.POST>[0]>(

--- a/clients/vim/package.json
+++ b/clients/vim/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "0.3.0"
+    "tabby-agent": "0.3.1"
   }
 }

--- a/clients/vscode/CHANGELOG.md
+++ b/clients/vscode/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.1
+
+### Fixes:
+
+- Reduced the frequency of event submissions for anonymous usage tracking.
+
 ## 0.6.0
 
 ### Features:

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/TabbyML/tabby",
   "bugs": "https://github.com/TabbyML/tabby/issues",
   "license": "Apache-2.0",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "keywords": [
     "ai",
     "autocomplete",
@@ -217,6 +217,6 @@
   },
   "dependencies": {
     "@xstate/fsm": "^2.0.1",
-    "tabby-agent": "0.3.0"
+    "tabby-agent": "0.3.1"
   }
 }


### PR DESCRIPTION
Fixes:

- Filtered out `AgentStats` events with no data.
- Removed debouncing and timeout config data in AgentStats events.
- Fixed the issue where `stats.completion_request_canceled.latency_avg` was displayed as null when not available. It has now been set to `undefined` and will no longer be displayed when not available.
- Fixed a bug that could cause incorrect user properties value when user settings `inlineCompletion.triggerMode` and `keybindings` were updated.