### PR TITLE
chore: add support for building on jetson device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "cxx-build",
  "derive_builder",
  "futures",
+ "regex",
  "rust-cxx-cmake-bridge",
  "tabby-inference",
  "tokenizers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,6 @@ dependencies = [
  "cxx-build",
  "derive_builder",
  "futures",
- "regex",
  "rust-cxx-cmake-bridge",
  "tabby-inference",
  "tokenizers",

--- a/crates/ctranslate2-bindings/Cargo.toml
+++ b/crates/ctranslate2-bindings/Cargo.toml
@@ -23,3 +23,4 @@ rust-cxx-cmake-bridge = { path = "../rust-cxx-cmake-bridge", optional = true }
 [features]
 default = ["dep:cmake", "dep:rust-cxx-cmake-bridge"]
 link_shared = []
+link_static_cuda = []

--- a/crates/ctranslate2-bindings/Cargo.toml
+++ b/crates/ctranslate2-bindings/Cargo.toml
@@ -16,6 +16,7 @@ async-stream.workspace = true
 
 [build-dependencies]
 cxx-build = "1.0"
+regex = { workspace = true }
 cmake = { version = "0.1", optional = true }
 rust-cxx-cmake-bridge = { path = "../rust-cxx-cmake-bridge", optional = true }
 

--- a/crates/ctranslate2-bindings/Cargo.toml
+++ b/crates/ctranslate2-bindings/Cargo.toml
@@ -16,7 +16,6 @@ async-stream.workspace = true
 
 [build-dependencies]
 cxx-build = "1.0"
-regex = { workspace = true }
 cmake = { version = "0.1", optional = true }
 rust-cxx-cmake-bridge = { path = "../rust-cxx-cmake-bridge", optional = true }
 

--- a/crates/ctranslate2-bindings/build.rs
+++ b/crates/ctranslate2-bindings/build.rs
@@ -42,15 +42,13 @@ fn link_static() -> PathBuf {
         if cfg!(target_feature = "sse4.1") {
             config.cxxflag("-msse4.1");
         }
-        
+
         if cfg!(feature = "link_static_cuda") {
-            config
-                .define("WITH_CUDA", "ON")
-                .define("WITH_CUDNN", "ON");
-                
+            config.define("WITH_CUDA", "ON").define("WITH_CUDNN", "ON");
+
             if cfg!(target_arch = "aarch64") {
                 config.cxxflag("-mcpu=native");
-            } 
+            }
         } else {
             config.define("WITH_OPENBLAS", "ON");
         }

--- a/crates/ctranslate2-bindings/build.rs
+++ b/crates/ctranslate2-bindings/build.rs
@@ -28,7 +28,7 @@ fn main() {
 }
 
 fn check_jetson() -> bool {
-    if Path::new("/etc/hosts").exists() {
+    if Path::new("/proc/device-tree/model").exists() {
         let contents = fs::read_to_string("/proc/device-tree/model").expect("read /proc/device-tree/model failed");
         let matched = Regex::new(r"^NVIDIA.*Developer Kit").unwrap().is_match(&contents);
         if matched {

--- a/crates/ctranslate2-bindings/build.rs
+++ b/crates/ctranslate2-bindings/build.rs
@@ -54,18 +54,20 @@ fn link_static() -> PathBuf {
             .define("WITH_MKL", "OFF")
             .define("OPENMP_RUNTIME", "NONE");
 
-        if cfg!(target_arch = "aarch64") && check_jetson() {
-            config
-               .define("WITH_CUDA", "ON")
-               .define("WITH_CUDNN", "ON")
-               .cxxflag("-mcpu=native")
-        } else if cfg!(target_feature = "sse4.1") {
-            config
-                .define("WITH_OPENBLAS", "ON")
-                .cxxflag("-msse4.1")
+        if cfg!(target_feature = "sse4.1") {
+            config.cxxflag("-msse4.1");
+        }
+        
+        if cfg!(feature = "link_static_cuda") {
+            config.define("WITH_CUDA", "ON");
+            
+            if cfg!(target_arch = "aarch64") && check_jetson() {
+                config
+                   .define("WITH_CUDNN", "ON")
+                   .cxxflag("-mcpu=native");
+            } 
         } else {
-            config
-                .define("WITH_CUDA", "ON")
+            config.define("WITH_OPENBLAS", "ON");
         }
     } else if cfg!(target_os = "macos") {
         config
@@ -73,7 +75,7 @@ fn link_static() -> PathBuf {
             .define("WITH_ACCELERATE", "ON")
             .define("WITH_MKL", "OFF")
             .define("OPENMP_RUNTIME", "NONE")
-            .define("WITH_RUY", "ON")
+            .define("WITH_RUY", "ON");
     } else {
         panic!("Invalid target")
     };

--- a/crates/ctranslate2-bindings/build.rs
+++ b/crates/ctranslate2-bindings/build.rs
@@ -1,5 +1,4 @@
-use std::{env, path::PathBuf, path::Path, fs};
-use regex::Regex;
+use std::{env, path::PathBuf};
 
 use cmake::Config;
 use rust_cxx_cmake_bridge::read_cmake_generated;
@@ -27,20 +26,6 @@ fn main() {
     lib.compile("cxxbridge");
 }
 
-fn check_jetson() -> bool {
-    if Path::new("/proc/device-tree/model").exists() {
-        let contents = fs::read_to_string("/proc/device-tree/model").expect("read /proc/device-tree/model failed");
-        let matched = Regex::new(r"^NVIDIA.*Developer Kit").unwrap().is_match(&contents);
-        if matched {
-            return true;
-        } else {
-            return false;
-        }
-    } else {
-        return false;
-    }
-}
-
 fn link_static() -> PathBuf {
     let mut config = Config::new(".");
     config
@@ -59,12 +44,12 @@ fn link_static() -> PathBuf {
         }
         
         if cfg!(feature = "link_static_cuda") {
-            config.define("WITH_CUDA", "ON");
-            
-            if cfg!(target_arch = "aarch64") && check_jetson() {
-                config
-                   .define("WITH_CUDNN", "ON")
-                   .cxxflag("-mcpu=native");
+            config
+                .define("WITH_CUDA", "ON")
+                .define("WITH_CUDNN", "ON");
+                
+            if cfg!(target_arch = "aarch64") {
+                config.cxxflag("-mcpu=native");
             } 
         } else {
             config.define("WITH_OPENBLAS", "ON");


### PR DESCRIPTION
The current building flow will fail on Jetson, because the CTranslate2 binding turns the "sse4.1" flag on while it's not available on Jetson.

I've added a function to check whether it's building on the NVIDIA Jetson device or not. If true, it will turn on CUDA and CUDNN flags of CTranslate2.

I've tested building on Intel CPU, AMD CPU, Jetson Orin Nano, Jetson Orin AGX.