### PR TITLE
Don't get stuck in 'initializing' when script not found

### DIFF
--- a/clients/vim/autoload/tabby.vim
+++ b/clients/vim/autoload/tabby.vim
@@ -79,6 +79,7 @@ function! tabby#OnVimEnter()
   endif
 
   if !filereadable(g:tabby_node_script)
+    let s:status = "initialization_failed"
     let s:message = 'Tabby agent script not found. Please reinstall Tabby plugin.'
     return
   endif


### PR DESCRIPTION
I've found this when wondering why I'm not getting any completion and status was saying "Tabby is initializing"