### PR TITLE
feat(agent): add auth token config.

### DIFF
--- a/clients/intellij/package.json
+++ b/clients/intellij/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "1.0.0"
+    "tabby-agent": "1.1.0-dev"
   }
 }

--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -44,7 +44,6 @@
     "openapi-fetch": "^0.7.6",
     "pino": "^8.14.1",
     "rotating-file-stream": "^3.1.0",
-    "semver-compare": "^1.0.0",
     "stats-logscale": "^1.0.7",
     "toml": "^3.0.0",
     "uuid": "^9.0.0"

--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabby-agent",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "description": "Generic client agent for Tabby AI coding assistant IDE extensions.",
   "repository": "https://github.com/TabbyML/tabby",
   "main": "./dist/index.js",
@@ -44,6 +44,7 @@
     "openapi-fetch": "^0.7.6",
     "pino": "^8.14.1",
     "rotating-file-stream": "^3.1.0",
+    "semver-compare": "^1.0.0",
     "stats-logscale": "^1.0.7",
     "toml": "^3.0.0",
     "uuid": "^9.0.0"

--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -94,8 +94,8 @@ function generateConfigFile(isMigrated: boolean, config: PartialAgentConfig) {
   file += "\n";
 
   if (isMigrated) {
-    file += `## This file is automatically updated by Tabby.\n`;
-    file += `## You configuration is migrated and the old config file is retained as ~/.tabby-client/agent/config.toml.{date}.\n`;
+    file += `## This file has been automatically updated by Tabby.\n`;
+    file += `## You configuration is migrated and the old config file is retained as ~/.tabby-client/agent/{date}-config.toml.\n`;
     file += "\n";
   }
   file += `## You can edit this file to customize your settings.\n`;
@@ -201,10 +201,11 @@ export const userAgentConfig = isBrowser
 
         async migrateConfig(config) {
           try {
-            const suffix = `.${new Date().toISOString().replace(/\D+/g, "")}`;
-            await fs.move(this.filepath, `${this.filepath}${suffix}`);
+            const prefix = new Date().toISOString().replace(/\D+/g, "");
+            const target = `${prefix}-${this.filepath}`;
+            await fs.move(this.filepath, target);
             await fs.outputFile(this.filepath, generateConfigFile(true, config));
-            this.logger.info(`Migrated config file to ${this.filepath}${suffix}.`);
+            this.logger.info(`Migrated config file to ${target}.`);
           } catch (error) {
             this.logger.error({ error }, "Failed to migrate config file");
           }
@@ -228,7 +229,7 @@ export const userAgentConfig = isBrowser
             if (!deepEqual(oldData, this.data)) {
               super.emit("updated", this.data);
             }
-          }
+          };
           this.watcher.on("add", onChanged);
           this.watcher.on("change", onChanged);
         }

--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -161,6 +161,7 @@ export const userAgentConfig = isBrowser
   : (() => {
       const EventEmitter = require("events");
       const fs = require("fs-extra");
+      const path = require("path");
       const toml = require("toml");
       const chokidar = require("chokidar");
       const deepEqual = require("deep-equal");
@@ -202,7 +203,7 @@ export const userAgentConfig = isBrowser
         async migrateConfig(config) {
           try {
             const prefix = new Date().toISOString().replace(/\D+/g, "");
-            const target = `${prefix}-${this.filepath}`;
+            const target = path.join(path.dirname(this.filepath), `${prefix}-config.toml`);
             await fs.move(this.filepath, target);
             await fs.outputFile(this.filepath, generateConfigFile(true, config));
             this.logger.info(`Migrated config file to ${target}.`);

--- a/clients/tabby-agent/src/Auth.ts
+++ b/clients/tabby-agent/src/Auth.ts
@@ -54,7 +54,16 @@ export class Auth extends EventEmitter {
   constructor(options: { endpoint: string; dataStore?: DataStore }) {
     super();
     this.endpoint = options.endpoint;
-    this.dataStore = options.dataStore || dataStore;
+    if (options.dataStore) {
+      this.dataStore = options.dataStore;
+    } else {
+      this.dataStore = dataStore;
+      dataStore.on("updated", async () => {
+        await this.load();
+        super.emit("updated", this.jwt);
+      });
+      dataStore.watch();
+    }
     this.authApi = createClient<CloudApi>({ baseUrl: "https://app.tabbyml.com/api" });
     this.scheduleRefreshToken();
   }

--- a/clients/tabby-agent/src/dataStore.ts
+++ b/clients/tabby-agent/src/dataStore.ts
@@ -11,28 +11,48 @@ export interface DataStore {
   save(): PromiseLike<void>;
 }
 
-export const dataStore: DataStore = isBrowser
+export const dataStore = isBrowser
   ? null
   : (() => {
-      const dataFile = require("path").join(require("os").homedir(), ".tabby-client", "agent", "data.json");
+      const EventEmitter = require("events");
       const fs = require("fs-extra");
-      return {
-        data: {},
-        load: async function () {
-          await this.migrateFrom_0_3_0();
+      const deepEqual = require("deep-equal");
+      const chokidar = require("chokidar");
+
+      class FileDataStore extends EventEmitter implements FileDataStore {
+        filepath: string;
+        data: Partial<StoredData> = {};
+        watcher: ReturnType<typeof chokidar.watch> | null = null;
+
+        constructor(filepath: string) {
+          super();
+          this.filepath = filepath;
+        }
+
+        async load() {
           this.data = (await fs.readJson(dataFile, { throws: false })) || {};
-        },
-        save: async function () {
+        }
+
+        async save() {
           await fs.outputJson(dataFile, this.data);
-        },
-        migrateFrom_0_3_0: async function () {
-          const dataFile_0_3_0 = require("path").join(require("os").homedir(), ".tabby", "agent", "data.json");
-          const migratedFlag = require("path").join(require("os").homedir(), ".tabby", "agent", ".data_json_migrated");
-          if ((await fs.pathExists(dataFile_0_3_0)) && !(await fs.pathExists(migratedFlag))) {
-            const data = await fs.readJson(dataFile_0_3_0);
-            await fs.outputJson(dataFile, data);
-            await fs.outputFile(migratedFlag, "");
+        }
+
+        watch() {
+          this.watcher = chokidar.watch(this.filepath, {
+            interval: 1000,
+          });
+          const onChanged = async () => {
+            const oldData = this.data;
+            await this.load();
+            if (!deepEqual(oldData, this.data)) {
+              super.emit("updated", this.data);
+            }
           }
-        },
-      };
+          this.watcher.on("add", onChanged);
+          this.watcher.on("change", onChanged);
+        }
+      }
+
+      const dataFile = require("path").join(require("os").homedir(), ".tabby-client", "agent", "data.json");
+      return new FileDataStore(dataFile);
     })();

--- a/clients/tabby-agent/src/dataStore.ts
+++ b/clients/tabby-agent/src/dataStore.ts
@@ -47,7 +47,7 @@ export const dataStore = isBrowser
             if (!deepEqual(oldData, this.data)) {
               super.emit("updated", this.data);
             }
-          }
+          };
           this.watcher.on("add", onChanged);
           this.watcher.on("change", onChanged);
         }

--- a/clients/vim/package.json
+++ b/clients/vim/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "cpy-cli": "^4.2.0",
     "rimraf": "^5.0.1",
-    "tabby-agent": "1.0.0"
+    "tabby-agent": "1.1.0-dev"
   }
 }

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/TabbyML/tabby",
   "bugs": "https://github.com/TabbyML/tabby/issues",
   "license": "Apache-2.0",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "keywords": [
     "ai",
     "autocomplete",
@@ -217,6 +217,6 @@
   },
   "dependencies": {
     "@xstate/fsm": "^2.0.1",
-    "tabby-agent": "1.0.0"
+    "tabby-agent": "1.1.0-dev"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,6 +3529,11 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
+
 semver@^5.1.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,11 +3529,6 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
-
 semver@^5.1.0:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"


### PR DESCRIPTION
Complete: TAB-235

* Added `token` in `server` section, updated config template:
  ```toml
  ## Tabby agent configuration file
  
  ## You can uncomment any block to enable settings.
  ## Configurations in this file has lower priority than in IDE settings.
  
  ## Server
  ## You can set the server endpoint and authentication token here.
  # [server]
  # endpoint = "http://localhost:8080" # http or https URL
  # token = "your-token-here" # if server requires authentication
  
  ## You can add custom request headers.
  # [server.requestHeaders]
  # Header1 = "Value1" # list your custom headers here
  # Header2 = "Value2" # value can be string, number or boolean
  # Authorization = "Bearer your-token-here" # if Authorization header is set, server.token will be ignored
  
  ## Logs
  ## You can set the log level here. The log file is located at ~/.tabby-client/agent/logs/.
  # [logs]
  # level = "silent" # "silent" or "error" or "debug"
  
  ## Anonymous usage tracking
  ## You can disable anonymous usage tracking here.
  # [anonymousUsageTracking]
  # disable = false # set to true to disable

  ``` 
* Fix datastore to watch file changes