### PR TITLE
feat(agent): add experimental option: strip auto-closing chars in prompt suffix.

### DIFF
--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -8,7 +8,7 @@ export type AgentConfig = {
   };
   completion: {
     prompt: {
-      stripAutoClosingCharacters: boolean;
+      experimentalStripAutoClosingCharacters: boolean;
       maxPrefixLines: number;
       maxSuffixLines: number;
     };
@@ -47,7 +47,7 @@ export const defaultAgentConfig: AgentConfig = {
   },
   completion: {
     prompt: {
-      stripAutoClosingCharacters: false,
+      experimentalStripAutoClosingCharacters: false,
       maxPrefixLines: 20,
       maxSuffixLines: 20,
     },

--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -8,6 +8,7 @@ export type AgentConfig = {
   };
   completion: {
     prompt: {
+      stripAutoClosingCharacters: boolean;
       maxPrefixLines: number;
       maxSuffixLines: number;
     };
@@ -46,6 +47,7 @@ export const defaultAgentConfig: AgentConfig = {
   },
   completion: {
     prompt: {
+      stripAutoClosingCharacters: false,
       maxPrefixLines: 20,
       maxSuffixLines: 20,
     },

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -264,10 +264,14 @@ export class TabbyAgent extends EventEmitter implements Agent {
     const maxPrefixLines = this.config.completion.prompt.maxPrefixLines;
     const maxSuffixLines = this.config.completion.prompt.maxSuffixLines;
     const { prefixLines, suffixLines } = context;
-    return {
-      prefix: prefixLines.slice(Math.max(prefixLines.length - maxPrefixLines, 0)).join(""),
-      suffix: suffixLines.slice(0, maxSuffixLines).join(""),
-    };
+    const prefix = prefixLines.slice(Math.max(prefixLines.length - maxPrefixLines, 0)).join("");
+    let suffix;
+    if (this.config.completion.prompt.stripAutoClosingCharacters && context.mode !== "fill-in-line") {
+      suffix = "\n" + suffixLines.slice(1, maxSuffixLines).join("");
+    } else {
+      suffix = suffixLines.slice(0, maxSuffixLines).join("");
+    }
+    return { prefix, suffix };
   }
 
   private calculateReplaceRange(response: CompletionResponse, context: CompletionContext): CompletionResponse {

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -266,7 +266,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
     const { prefixLines, suffixLines } = context;
     const prefix = prefixLines.slice(Math.max(prefixLines.length - maxPrefixLines, 0)).join("");
     let suffix;
-    if (this.config.completion.prompt.stripAutoClosingCharacters && context.mode !== "fill-in-line") {
+    if (this.config.completion.prompt.experimentalStripAutoClosingCharacters && context.mode !== "fill-in-line") {
       suffix = "\n" + suffixLines.slice(1, maxSuffixLines).join("");
     } else {
       suffix = suffixLines.slice(0, maxSuffixLines).join("");


### PR DESCRIPTION
Complete TAB-268

Add this config to enable experimental feature:
```
[completion.prompt]
stripAutoClosingCharacters = true
```

Example:
For this case:
```js
function fib(n) {║}

```
off(default):
```
// prompt
{
  prefix: "function fib(n) {",
  suffix: "}\n",
}
```
on:
```
// prompt
{
  prefix: "function fib(n) {",
  suffix: "\n",
}
```