### PR TITLE
feat(agent): add experimental option: scope of indentation filter.

### DIFF
--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -20,6 +20,14 @@ export type AgentConfig = {
       manually: number;
     };
   };
+  postprocess: {
+    limitScopeByIndentation: {
+      // When completion is continuing the current line, limit the scope to:
+      // false(default): the line scope, meaning use the next indent level as the limit.
+      // true: the block scope, meaning use the current indent level as the limit.
+      keepBlockScopeWhenCompletingLine: boolean;
+    };
+  };
   logs: {
     level: "debug" | "error" | "silent";
   };
@@ -57,6 +65,11 @@ export const defaultAgentConfig: AgentConfig = {
     timeout: {
       auto: 4000, // 4s
       manually: 4000, // 4s
+    },
+  },
+  postprocess: {
+    limitScopeByIndentation: {
+      keepBlockScopeWhenCompletingLine: false,
     },
   },
   logs: {

--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -25,7 +25,7 @@ export type AgentConfig = {
       // When completion is continuing the current line, limit the scope to:
       // false(default): the line scope, meaning use the next indent level as the limit.
       // true: the block scope, meaning use the current indent level as the limit.
-      keepBlockScopeWhenCompletingLine: boolean;
+      experimentalKeepBlockScopeWhenCompletingLine: boolean;
     };
   };
   logs: {
@@ -69,7 +69,7 @@ export const defaultAgentConfig: AgentConfig = {
   },
   postprocess: {
     limitScopeByIndentation: {
-      keepBlockScopeWhenCompletingLine: false,
+      experimentalKeepBlockScopeWhenCompletingLine: false,
     },
   },
   logs: {

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -541,7 +541,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
             throw error;
           }
           // Postprocess (pre-cache)
-          completionResponse = await preCacheProcess(context, completionResponse);
+          completionResponse = await preCacheProcess(context, this.config.postprocess, completionResponse);
           if (options?.signal?.aborted) {
             throw options.signal.reason;
           }
@@ -550,7 +550,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
         }
       }
       // Postprocess (post-cache)
-      completionResponse = await postCacheProcess(context, completionResponse);
+      completionResponse = await postCacheProcess(context, this.config.postprocess, completionResponse);
       if (options?.signal?.aborted) {
         throw options.signal.reason;
       }

--- a/clients/tabby-agent/src/postprocess/index.ts
+++ b/clients/tabby-agent/src/postprocess/index.ts
@@ -1,4 +1,5 @@
 import { CompletionContext, CompletionResponse } from "../Agent";
+import { AgentConfig } from "../AgentConfig";
 import { applyFilter } from "./base";
 import { removeRepetitiveBlocks } from "./removeRepetitiveBlocks";
 import { removeRepetitiveLines } from "./removeRepetitiveLines";
@@ -10,6 +11,7 @@ import { dropBlank } from "./dropBlank";
 
 export async function preCacheProcess(
   context: CompletionContext,
+  config: AgentConfig["postprocess"],
   response: CompletionResponse,
 ): Promise<CompletionResponse> {
   return Promise.resolve(response)
@@ -21,12 +23,13 @@ export async function preCacheProcess(
 
 export async function postCacheProcess(
   context: CompletionContext,
+  config: AgentConfig["postprocess"],
   response: CompletionResponse,
 ): Promise<CompletionResponse> {
   return Promise.resolve(response)
     .then(applyFilter(removeRepetitiveBlocks(context), context))
     .then(applyFilter(removeRepetitiveLines(context), context))
-    .then(applyFilter(limitScopeByIndentation(context), context))
+    .then(applyFilter(limitScopeByIndentation(context, config["limitScopeByIndentation"]), context))
     .then(applyFilter(dropDuplicated(context), context))
     .then(applyFilter(trimSpace(context), context))
     .then(applyFilter(dropBlank(), context));

--- a/clients/tabby-agent/src/postprocess/limitScopeByIndentation.ts
+++ b/clients/tabby-agent/src/postprocess/limitScopeByIndentation.ts
@@ -59,7 +59,7 @@ function processContext(
   if (!isCurrentLineInCompletionBlank && !isCurrentLineInPrefixBlank) {
     // if two reference lines are contacted at current line, it is continuing uncompleted sentence
 
-    if (config.keepBlockScopeWhenCompletingLine) {
+    if (config.experimentalKeepBlockScopeWhenCompletingLine) {
       result.indentLevelLimit = referenceLineInPrefixIndent;
     } else {
       result.indentLevelLimit = referenceLineInPrefixIndent + 1; // + 1 for comparison, no matter how many spaces indent


### PR DESCRIPTION
Complete TAB-268

Add this config to enable experimental feature:
```
[postprocess.limitScopeByIndentation]
keepBlockScopeWhenCompletingLine = true
```
When completion is continuing the current line, limit the scope to:
- false(default): the line scope, meaning use the next indent level as the limit.
- true: the block scope, meaning use the current indent level as the limit.

Example:
off:
![Screenshot from 2023-10-27 19-30-49](https://github.com/TabbyML/tabby/assets/13573879/3258e0d6-9ec3-4d80-adc8-eec6f771e7b0)

on:
![Screenshot from 2023-10-27 19-30-17](https://github.com/TabbyML/tabby/assets/13573879/ccf384ef-c524-4fe8-8ef0-b2d7fe54e6e5)
