### PR TITLE
fix: minor ts and eslint errors

### DIFF
--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -43,6 +43,7 @@
     "object-hash": "^3.0.0",
     "openapi-fetch": "^0.7.6",
     "pino": "^8.14.1",
+    "pino-std-serializers": "^6.2.2",
     "rotating-file-stream": "^3.1.0",
     "stats-logscale": "^1.0.7",
     "toml": "^3.0.0",

--- a/clients/tabby-agent/src/logger.ts
+++ b/clients/tabby-agent/src/logger.ts
@@ -1,4 +1,5 @@
 import pino from "pino";
+import { err as pinoStdSerializersError } from "pino-std-serializers";
 import { isBrowser, isTest, testLogDebug } from "./env";
 
 /**
@@ -16,7 +17,7 @@ const stream =
         interval: "1d",
       });
 
-const options = { serializers: { error: pino.stdSerializers.err } };
+const options = { serializers: { error: pinoStdSerializersError } };
 export const rootLogger = !!stream ? pino(options, stream) : pino(options);
 if (isTest && testLogDebug) {
   rootLogger.level = "debug";

--- a/clients/vscode/src/TabbyStatusBarItem.ts
+++ b/clients/vscode/src/TabbyStatusBarItem.ts
@@ -3,6 +3,7 @@ import { createMachine, interpret } from "@xstate/fsm";
 import { agent } from "./agent";
 import { notifications } from "./notifications";
 import { TabbyCompletionProvider } from "./TabbyCompletionProvider";
+import { StatusChangedEvent, AuthRequiredEvent, IssuesUpdatedEvent } from "tabby-agent";
 
 const label = "Tabby";
 const iconLoading = "$(loading~spin)";
@@ -137,12 +138,12 @@ export class TabbyStatusBarItem {
     this.completionProvider.on("loadingStatusUpdated", () => {
       this.fsmService.send(agent().getStatus());
     });
-    agent().on("statusChanged", (event) => {
+    agent().on("statusChanged", (event: StatusChangedEvent) => {
       console.debug("Tabby agent statusChanged", { event });
       this.fsmService.send(event.status);
     });
 
-    agent().on("authRequired", (event) => {
+    agent().on("authRequired", (event: AuthRequiredEvent) => {
       console.debug("Tabby agent authRequired", { event });
       notifications.showInformationStartAuth({
         onAuthStart: () => {
@@ -154,7 +155,7 @@ export class TabbyStatusBarItem {
       });
     });
 
-    agent().on("issuesUpdated", (event) => {
+    agent().on("issuesUpdated", (event: IssuesUpdatedEvent) => {
       console.debug("Tabby agent issuesUpdated", { event });
       this.fsmService.send(agent().getStatus());
       if (event.issues.length > 0 && !this.completionResponseWarningShown) {

--- a/clients/vscode/src/commands.ts
+++ b/clients/vscode/src/commands.ts
@@ -49,7 +49,7 @@ const setApiEndpoint: Command = {
         validateInput: (input: string) => {
           try {
             let url = new URL(input);
-            assert(url.protocol == "http:" || url.protocol == "https:");
+            assert(url.protocol === "http:" || url.protocol === "https:");
           } catch (_) {
             return {
               message: "Please enter a validate http or https URL.",

--- a/clients/vscode/src/notifications.ts
+++ b/clients/vscode/src/notifications.ts
@@ -143,7 +143,7 @@ function getHelpMessageForCompletionResponseTimeIssue() {
   }
   let commonHelpMessage = "";
   const host = new URL(agent().getConfig().server.endpoint).host;
-  if (helpMessageForRunningLargeModelOnCPU.length == 0) {
+  if (helpMessageForRunningLargeModelOnCPU.length === 0) {
     commonHelpMessage += ` - The running model ${
       serverHealthState?.model ?? ""
     } may be performing poorly due to its large parameter size. `;


### PR DESCRIPTION
- replace "pino.stdSerializers.err" by import it directly since it is been imported by pino, so sometime Typescript can not resolve the type reference (https://github.com/microsoft/TypeScript/issues/42873)
- fix some obvious TS errors

By the way, should we add ESLint to the package.json script commands? I noticed that the ESLint and Prettier configration files exist, but it seems they've never been run. After triggering the Prettier command, many files changed, so I haven't included these changes in the PR until I receive confirmation from you.