### PR TITLE
feat: add ability to only serve chat model

### DIFF
--- a/crates/tabby/src/serve/health.rs
+++ b/crates/tabby/src/serve/health.rs
@@ -9,7 +9,8 @@ use utoipa::ToSchema;
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct HealthState {
-    model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     chat_model: Option<String>,
     device: String,

--- a/experimental/eval/tabby-python-client/tabby_python_client/models/health_state.py
+++ b/experimental/eval/tabby-python-client/tabby_python_client/models/health_state.py
@@ -15,7 +15,7 @@ T = TypeVar("T", bound="HealthState")
 class HealthState:
     """
     Attributes:
-        model (str):
+        model (Union[Unset, None, str]):
         device (str):
         arch (str):
         cpu_info (str):
@@ -25,7 +25,7 @@ class HealthState:
         chat_model (Union[Unset, None, str]):
     """
 
-    model: str
+    model: Union[Unset, None, str] = UNSET
     device: str
     arch: str
     cpu_info: str
@@ -60,6 +60,9 @@ class HealthState:
                 "version": version,
             }
         )
+        if model is not UNSET:
+            field_dict["model"] = model        
+        
         if chat_model is not UNSET:
             field_dict["chat_model"] = chat_model
 
@@ -70,7 +73,7 @@ class HealthState:
         from ..models.version import Version
 
         d = src_dict.copy()
-        model = d.pop("model")
+        model = d.pop("model", UNSET)
 
         device = d.pop("device")
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -89,7 +89,7 @@ As of the date 10/07/2023, the following information has been collected:
 
 ```rust
 struct HealthState {
-    model: String,
+    model: Option<String>,
     chat_model: Option<String>,
     device: String,
     arch: String,

--- a/website/static/openapi.json
+++ b/website/static/openapi.json
@@ -227,7 +227,8 @@
         ],
         "properties": {
           "model": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "chat_model": {
             "type": "string",


### PR DESCRIPTION
I don't have enough VRAM to deploy both models in the same machine. so i think it's a good idea to be able to deploy normal model and chat model separately.  