### PR TITLE
feat: add LLAMA_CPP_N_THREADS env

### DIFF
--- a/crates/llama-cpp-bindings/src/engine.cc
+++ b/crates/llama-cpp-bindings/src/engine.cc
@@ -316,11 +316,10 @@ std::unique_ptr<TextInferenceEngine> create_engine(bool use_gpu, rust::Str model
   llama_context_params ctx_params = llama_context_default_params();
   ctx_params.n_ctx = N_CTX * parallelism;
   ctx_params.n_batch = N_BATCH;
-  if (const char* n_threads = std::getenv("LLAMA_CPP_N_THREADS")) {
-    ctx_params.n_threads = std::stoi(n_threads);
-  }
-  if (const char* n_threads_batch = std::getenv("LLAMA_CPP_N_THREADS_BATCH")) {
-    ctx_params.n_threads_batch = std::stoi(n_threads_batch);
+  if (const char* _n_threads = std::getenv("LLAMA_CPP_N_THREADS")) {
+    int n_threads = std::stoi(_n_threads);
+    ctx_params.n_threads = n_threads;
+    ctx_params.n_threads_batch = n_threads;
   }
   llama_context* ctx = llama_new_context_with_model(model, ctx_params);
   return std::make_unique<TextInferenceEngineImpl>(

--- a/crates/llama-cpp-bindings/src/engine.cc
+++ b/crates/llama-cpp-bindings/src/engine.cc
@@ -316,8 +316,8 @@ std::unique_ptr<TextInferenceEngine> create_engine(bool use_gpu, rust::Str model
   llama_context_params ctx_params = llama_context_default_params();
   ctx_params.n_ctx = N_CTX * parallelism;
   ctx_params.n_batch = N_BATCH;
-  if (const char* _n_threads = std::getenv("LLAMA_CPP_N_THREADS")) {
-    int n_threads = std::stoi(_n_threads);
+  if (const char* n_thread_str = std::getenv("LLAMA_CPP_N_THREADS")) {
+    int n_threads = std::stoi(n_thread_str);
     ctx_params.n_threads = n_threads;
     ctx_params.n_threads_batch = n_threads;
   }

--- a/crates/llama-cpp-bindings/src/engine.cc
+++ b/crates/llama-cpp-bindings/src/engine.cc
@@ -315,9 +315,15 @@ std::unique_ptr<TextInferenceEngine> create_engine(bool use_gpu, rust::Str model
 
   llama_context_params ctx_params = llama_context_default_params();
   ctx_params.n_ctx = N_CTX * parallelism;
-  ctx_params.n_batch = N_BATCH;
+  ctx_params.n_batch = N_BATCH; 
+  if (const char* n_threads = std::getenv("LLAMA_CPP_N_THREADS")) {
+    ctx_params.n_threads = std::stoi(n_threads);
+  } 
+  if (const char* n_threads_batch = std::getenv("LLAMA_CPP_N_THREADS_BATCH")) {
+    ctx_params.n_threads_batch = std::stoi(n_threads_batch);
+  } 
   llama_context* ctx = llama_new_context_with_model(model, ctx_params);
-
+  
   return std::make_unique<TextInferenceEngineImpl>(
       owned<llama_model>(model, llama_free_model),
       owned<llama_context>(ctx, llama_free),

--- a/crates/llama-cpp-bindings/src/engine.cc
+++ b/crates/llama-cpp-bindings/src/engine.cc
@@ -315,15 +315,14 @@ std::unique_ptr<TextInferenceEngine> create_engine(bool use_gpu, rust::Str model
 
   llama_context_params ctx_params = llama_context_default_params();
   ctx_params.n_ctx = N_CTX * parallelism;
-  ctx_params.n_batch = N_BATCH; 
+  ctx_params.n_batch = N_BATCH;
   if (const char* n_threads = std::getenv("LLAMA_CPP_N_THREADS")) {
     ctx_params.n_threads = std::stoi(n_threads);
-  } 
+  }
   if (const char* n_threads_batch = std::getenv("LLAMA_CPP_N_THREADS_BATCH")) {
     ctx_params.n_threads_batch = std::stoi(n_threads_batch);
-  } 
+  }
   llama_context* ctx = llama_new_context_with_model(model, ctx_params);
-  
   return std::make_unique<TextInferenceEngineImpl>(
       owned<llama_model>(model, llama_free_model),
       owned<llama_context>(ctx, llama_free),


### PR DESCRIPTION
i think we don't need to use `llama_set_n_threads` method. it's likely used for runtime modifications. we only need to set ctx_params

fixes #738

