### PR TITLE
refactor: add experimental-http feature

### DIFF
--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 cuda = ["llama-cpp-bindings/cuda"]
-experimental-http = []
+experimental-http = ["dep:http-api-bindings"]
 
 [dependencies]
 tabby-common = { path = "../tabby-common" }
@@ -37,7 +37,7 @@ tantivy = { workspace = true }
 anyhow = { workspace = true }
 sysinfo = "0.29.8"
 nvml-wrapper = "0.9.0"
-http-api-bindings = { path = "../http-api-bindings" }
+http-api-bindings = { path = "../http-api-bindings", optional = true } # included when build with `experimental-http` feature
 async-stream = { workspace = true }
 axum-streams = { version = "0.9.1", features = ["json"] }
 minijinja = { version = "1.0.8", features = ["loader"] }

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 cuda = ["llama-cpp-bindings/cuda"]
+experimental-http = []
 
 [dependencies]
 tabby-common = { path = "../tabby-common" }

--- a/crates/tabby/src/serve/engine.rs
+++ b/crates/tabby/src/serve/engine.rs
@@ -11,7 +11,7 @@ pub async fn create_engine(
     args: &crate::serve::ServeArgs,
 ) -> (Box<dyn TextGeneration>, EngineInfo) {
     #[cfg(feature = "experimental-http")]
-    if args.device == super::Device::ExperimentalHttp {
+    if args.device == crate::serve::Device::ExperimentalHttp {
         let (engine, prompt_template) = http_api_bindings::create(model_id);
         return (
             engine,

--- a/crates/tabby/src/serve/engine.rs
+++ b/crates/tabby/src/serve/engine.rs
@@ -10,38 +10,39 @@ pub async fn create_engine(
     model_id: &str,
     args: &crate::serve::ServeArgs,
 ) -> (Box<dyn TextGeneration>, EngineInfo) {
-    if args.device != super::Device::ExperimentalHttp {
-        if fs::metadata(model_id).is_ok() {
-            let path = PathBuf::from(model_id);
-            let model_path = path.join(GGML_MODEL_RELATIVE_PATH);
-            let engine = create_ggml_engine(
-                &args.device,
-                model_path.display().to_string().as_str(),
-                args.parallelism,
-            );
-            let engine_info = EngineInfo::read(path.join("tabby.json"));
-            (engine, engine_info)
-        } else {
-            let (registry, name) = parse_model_id(model_id);
-            let registry = ModelRegistry::new(registry).await;
-            let model_path = registry.get_model_path(name).display().to_string();
-            let model_info = registry.get_model_info(name);
-            let engine = create_ggml_engine(&args.device, &model_path, args.parallelism);
-            (
-                engine,
-                EngineInfo {
-                    prompt_template: model_info.prompt_template.clone(),
-                    chat_template: model_info.chat_template.clone(),
-                },
-            )
-        }
-    } else {
+    #[cfg(feature = "experimental-http")]
+    if args.device == super::Device::ExperimentalHttp {
         let (engine, prompt_template) = http_api_bindings::create(model_id);
-        (
+        return (
             engine,
             EngineInfo {
                 prompt_template: Some(prompt_template),
                 chat_template: None,
+            },
+        );
+    }
+
+    if fs::metadata(model_id).is_ok() {
+        let path = PathBuf::from(model_id);
+        let model_path = path.join(GGML_MODEL_RELATIVE_PATH);
+        let engine = create_ggml_engine(
+            &args.device,
+            model_path.display().to_string().as_str(),
+            args.parallelism,
+        );
+        let engine_info = EngineInfo::read(path.join("tabby.json"));
+        (engine, engine_info)
+    } else {
+        let (registry, name) = parse_model_id(model_id);
+        let registry = ModelRegistry::new(registry).await;
+        let model_path = registry.get_model_path(name).display().to_string();
+        let model_info = registry.get_model_info(name);
+        let engine = create_ggml_engine(&args.device, &model_path, args.parallelism);
+        (
+            engine,
+            EngineInfo {
+                prompt_template: model_info.prompt_template.clone(),
+                chat_template: model_info.chat_template.clone(),
             },
         )
     }

--- a/crates/tabby/src/serve/mod.rs
+++ b/crates/tabby/src/serve/mod.rs
@@ -20,7 +20,7 @@ use tabby_common::{config::Config, usage};
 use tabby_download::download_model;
 use tokio::time::sleep;
 use tower_http::{cors::CorsLayer, timeout::TimeoutLayer};
-use tracing::{info, warn};
+use tracing::info;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -129,8 +129,8 @@ pub struct ServeArgs {
 
 pub async fn main(config: &Config, args: &ServeArgs) {
     #[cfg(feature = "experimental-http")]
-    if args.device == super::Device::ExperimentalHttp {
-        warn!("HTTP device is unstable and does not comply with semver expectations.");
+    if args.device == Device::ExperimentalHttp {
+        tracing::warn!("HTTP device is unstable and does not comply with semver expectations.");
     } else {
         load_model(args).await;
     }


### PR DESCRIPTION
This PR is for closing https://github.com/TabbyML/tabby/issues/735

Changes include:
-  Add `experimental-http` feature in `Cargo.toml`
- Make dependency `http-api-bindings` as `optional`
- Update `create_engine` method, only when `experimental-http is enabled` **AND** `tabby serve --device experimental-http`, call `http_api_bindings::create`, other cases go to normal flow
- Update `main` method, only when `experimental-http is enabled` **AND** `tabby serve --device experimental-http`, just log message without loading model, other cases load model normally.