### PR TITLE
fix: Source code index is not ready

### DIFF
--- a/crates/tabby-scheduler/src/lib.rs
+++ b/crates/tabby-scheduler/src/lib.rs
@@ -4,6 +4,7 @@ mod repository;
 mod utils;
 
 use anyhow::Result;
+pub use index::open_or_create_index;
 use job_scheduler::{Job, JobScheduler};
 use tabby_common::config::Config;
 use tracing::{error, info};

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -8,6 +8,7 @@ use tabby_common::{
 };
 use tantivy::{
     collector::{Count, TopDocs},
+    directory::MmapDirectory,
     query::{BooleanQuery, QueryParser},
     query_grammar::Occur,
     schema::Field,
@@ -28,7 +29,8 @@ struct CodeSearchImpl {
 impl CodeSearchImpl {
     fn load() -> Result<Self> {
         let code_schema = index::CodeSearchSchema::new();
-        let index = Index::open_in_dir(path::index_dir())?;
+        let index_dir = MmapDirectory::open(path::index_dir())?;
+        let index = Index::open_or_create(index_dir, code_schema.schema.clone())?;
         register_tokenizers(&index);
 
         let query_parser = QueryParser::new(

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -2,17 +2,14 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use tabby_common::{
-    index::{self, register_tokenizers, CodeSearchSchema},
-    path,
-};
+use tabby_common::index::{self, CodeSearchSchema};
+use tabby_scheduler::open_or_create_index;
 use tantivy::{
     collector::{Count, TopDocs},
-    directory::MmapDirectory,
     query::{BooleanQuery, QueryParser},
     query_grammar::Occur,
     schema::Field,
-    DocAddress, Document, Index, IndexReader,
+    DocAddress, Document, IndexReader,
 };
 use tokio::{sync::Mutex, time::sleep};
 use tracing::{debug, log::info};
@@ -29,9 +26,7 @@ struct CodeSearchImpl {
 impl CodeSearchImpl {
     fn load() -> Result<Self> {
         let code_schema = index::CodeSearchSchema::new();
-        let index_dir = MmapDirectory::open(path::index_dir())?;
-        let index = Index::open_or_create(index_dir, code_schema.schema.clone())?;
-        register_tokenizers(&index);
+        let index = open_or_create_index(code_schema.schema.clone())?;
 
         let query_parser = QueryParser::new(
             code_schema.schema.clone(),


### PR DESCRIPTION
When start `tabby serve` with debug log level, I saw debug log like below:

```
2023-11-13T12:29:04.341206Z DEBUG tabby::services::code: crates/tabby/src/services/code.rs:61: Source code index is not ready `Directory does not exist: '/home/<user>/.tabby/index'.`
```

After creating `index` dir manually, still got unexpected log like:

```
2023-11-13T08:06:39.550986Z DEBUG tabby::services::code: crates/tabby/src/services/code.rs:58: Source code index is not ready `Failed to open file for read: 'FileDoesNotExist("meta.json")'`
```

Turns out, `tabby serve` starts with the call of `CodeSearchService::new()`, inside which it spawns a task to call `CodeSearchImpl::load()` method. This `load` method tries to open directory `~/.tabby/index/` and read `meta.json` file.

Both file and directory do not exist at all **UNLESS** we run `tabby scheduler` first, which will create them for writing.

`tabby serve` is independent of `tabby scheduler`, so running `tabby scheduler` before `tabby serve` makes no sense.

This PR is to fix this issue by reusing `create or open` logic for `tabby serve`
