### PR TITLE
fix: move db to `ee` directory

### DIFF
--- a/crates/tabby/src/services/model.rs
+++ b/crates/tabby/src/services/model.rs
@@ -14,7 +14,7 @@ pub async fn load_text_generation(
     parallelism: u8,
 ) -> (Arc<dyn TextGeneration>, PromptInfo) {
     #[cfg(feature = "experimental-http")]
-    if args.device == crate::serve::Device::ExperimentalHttp {
+    if device == &Device::ExperimentalHttp {
         let (engine, prompt_template) = http_api_bindings::create(model_id);
         return (
             engine,

--- a/ee/tabby-webserver/src/db.rs
+++ b/ee/tabby-webserver/src/db.rs
@@ -21,8 +21,10 @@ lazy_static! {
     ),]);
 }
 
-fn db_file() -> PathBuf {
-    tabby_root().join("db.sqlite3")
+async fn db_path() -> Result<PathBuf> {
+    let db_dir = tabby_root().join("ee");
+    tokio::fs::create_dir_all(db_dir.clone()).await?;
+    Ok(db_dir.join("db.sqlite"))
 }
 
 pub struct DbConn {
@@ -31,7 +33,8 @@ pub struct DbConn {
 
 impl DbConn {
     pub async fn new() -> Result<Self> {
-        let conn = Connection::open(db_file()).await?;
+        let db_path = db_path().await?;
+        let conn = Connection::open(db_path).await?;
         Self::init_db(conn).await
     }
 


### PR DESCRIPTION
- Move db file from `~/.tabby/db.sqlite3` to `~/.tabby/ee/db.sqlite`

- Fix compile error when `experimental-http` feature is enabled