### PR TITLE
feat: add Prometheus support to Tabby.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixes and Improvements
 * Fix the slow repository indexing due to constraint memory arena in tantivy index writer.
 * Make `--model` optional, so users can create a chat only instance.
+* Add `/v1/metrics` endpoint for prometheus metrics collection. 
 
 # v0.5.5
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-prometheus"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97def327c5481791abb57ac295bfc70f2e1a0727675b7dbf74bd1b27a72b6fd8"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures",
+ "futures-core",
+ "http",
+ "http-body",
+ "matchit",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "pin-project",
+ "tokio",
+ "tower",
+ "tower-http 0.4.0",
+]
+
+[[package]]
 name = "axum-streams"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1814,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash 0.8.3",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -2434,6 +2466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2573,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash 0.8.3",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+dependencies = [
+ "base64 0.21.2",
+ "hyper",
+ "indexmap 1.9.3",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -3294,6 +3390,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "question"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4424,6 +4545,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "axum-prometheus",
  "axum-streams",
  "axum-tracing-opentelemetry",
  "chrono",

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,9 @@ bump-release-version:
 	cargo ws version --allow-branch "r*" --no-individual-tags --force "*"
 
 update-openapi-doc:
-	curl http://localhost:8080/api-docs/openapi.json | jq '                                                       \
-	  delpaths([                                                                                                  \
+	curl http://localhost:8080/api-docs/openapi.json | jq '                                                             \
+	  delpaths([                                                                                                        \
+		  ["paths", "/v1/metrics"],                                                                                 \
 		  ["paths", "/v1beta/chat/completions"],                                                                    \
 		  ["paths", "/v1beta/search"],                                                                              \
 		  ["components", "schemas", "CompletionRequest", "properties", "prompt"],                                   \

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ bump-release-version:
 	cargo ws version --allow-branch "r*" --no-individual-tags --force "*"
 
 update-openapi-doc:
-	curl http://localhost:8080/api-docs/openapi.json | jq '                                                         \
-	  delpaths([                                                                                                    \
+	curl http://localhost:8080/api-docs/openapi.json | jq '                                                       \
+	  delpaths([                                                                                                  \
 		  ["paths", "/v1beta/chat/completions"],                                                                    \
 		  ["paths", "/v1beta/search"],                                                                              \
 		  ["components", "schemas", "CompletionRequest", "properties", "prompt"],                                   \

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,10 @@ bump-release-version:
 	cargo ws version --allow-branch "r*" --no-individual-tags --force "*"
 
 update-openapi-doc:
-	curl http://localhost:8080/api-docs/openapi.json | jq '                                                             \
-	  delpaths([                                                                                                        \
+	curl http://localhost:8080/api-docs/openapi.json | jq '                                                         \
+	  delpaths([                                                                                                    \
 		  ["paths", "/v1beta/chat/completions"],                                                                    \
 		  ["paths", "/v1beta/search"],                                                                              \
-		  ["paths", "/metrics"],                                                                                    \
 		  ["components", "schemas", "CompletionRequest", "properties", "prompt"],                                   \
 		  ["components", "schemas", "CompletionRequest", "properties", "debug_options"],                            \
 		  ["components", "schemas", "CompletionResponse", "properties", "debug_data"],                              \

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,11 @@ bump-release-version:
 	cargo ws version --allow-branch "r*" --no-individual-tags --force "*"
 
 update-openapi-doc:
-	curl http://localhost:8080/api-docs/openapi.json | jq '                                                       \
-	  delpaths([                                                                                                  \
+	curl http://localhost:8080/api-docs/openapi.json | jq '                                                             \
+	  delpaths([                                                                                                        \
 		  ["paths", "/v1beta/chat/completions"],                                                                    \
 		  ["paths", "/v1beta/search"],                                                                              \
+		  ["paths", "/metrics"],                                                                                    \
 		  ["components", "schemas", "CompletionRequest", "properties", "prompt"],                                   \
 		  ["components", "schemas", "CompletionRequest", "properties", "debug_options"],                            \
 		  ["components", "schemas", "CompletionResponse", "properties", "debug_data"],                              \

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -49,6 +49,7 @@ async-trait.workspace = true
 tabby-webserver = { path = "../../ee/tabby-webserver", optional = true }
 thiserror.workspace = true
 chrono = "0.4.31"
+axum-prometheus = "0.4.0"
 
 [dependencies.uuid]
 version = "1.3.3"

--- a/crates/tabby/src/routes/metrics.rs
+++ b/crates/tabby/src/routes/metrics.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+
 use axum::extract::State;
 use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
 

--- a/crates/tabby/src/routes/metrics.rs
+++ b/crates/tabby/src/routes/metrics.rs
@@ -7,7 +7,7 @@ use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
     path = "/v1/metrics",
     tag = "v1",
     responses(
-        (status = 200, description = "Success", body = String, content_type = "application/text"),
+        (status = 200, description = "Success", body = String, content_type = "text/plain"),
     )
 )]
 pub async fn metrics(State(state): State<Arc<PrometheusHandle>>) -> String {

--- a/crates/tabby/src/routes/metrics.rs
+++ b/crates/tabby/src/routes/metrics.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+use axum::extract::State;
+use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
+
+#[utoipa::path(
+    get,
+    path = "/v1/metrics",
+    tag = "v1",
+    responses(
+        (status = 200, description = "Success", body = String, content_type = "application/text"),
+    )
+)]
+pub async fn metrics(State(state): State<Arc<PrometheusHandle>>) -> String {
+    state.render()
+}

--- a/crates/tabby/src/routes/mod.rs
+++ b/crates/tabby/src/routes/mod.rs
@@ -2,13 +2,12 @@ mod chat;
 mod completions;
 mod events;
 mod health;
-mod search;
 mod metrics;
-
+mod search;
 
 pub use chat::*;
 pub use completions::*;
 pub use events::*;
 pub use health::*;
-pub use search::*;
 pub use metrics::*;
+pub use search::*;

--- a/crates/tabby/src/routes/mod.rs
+++ b/crates/tabby/src/routes/mod.rs
@@ -3,9 +3,12 @@ mod completions;
 mod events;
 mod health;
 mod search;
+mod metrics;
+
 
 pub use chat::*;
 pub use completions::*;
 pub use events::*;
 pub use health::*;
 pub use search::*;
+pub use metrics::*;

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use axum::{routing, Router, Server};
-use axum_prometheus::{PrometheusMetricLayer, metrics_exporter_prometheus::PrometheusHandle};
+use axum_prometheus::{metrics_exporter_prometheus::PrometheusHandle, PrometheusMetricLayer};
 use axum_tracing_opentelemetry::opentelemetry_tracing_layer;
 use clap::Args;
 use tabby_common::{
@@ -152,7 +152,7 @@ async fn api_router(
     config: &Config,
     logger: Arc<dyn EventLogger>,
     code: Arc<dyn CodeSearch>,
-    metrics_handle: Arc<PrometheusHandle>
+    metrics_handle: Arc<PrometheusHandle>,
 ) -> Router {
     let completion_state = if let Some(model) = &args.model {
         Some(Arc::new(

--- a/crates/tabby/src/worker.rs
+++ b/crates/tabby/src/worker.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::Result;
 use axum::{routing, Router};
-use axum_prometheus::{PrometheusMetricLayer, metrics_exporter_prometheus::PrometheusHandle};
+use axum_prometheus::{metrics_exporter_prometheus::PrometheusHandle, PrometheusMetricLayer};
 use axum_tracing_opentelemetry::opentelemetry_tracing_layer;
 use clap::Args;
 use hyper::Server;
@@ -64,7 +64,11 @@ async fn make_chat_route(context: WorkerContext, args: &WorkerArgs) -> Router {
     )
 }
 
-async fn make_completion_route(context: WorkerContext, args: &WorkerArgs, metrics_handle: PrometheusHandle) -> Router {
+async fn make_completion_route(
+    context: WorkerContext,
+    args: &WorkerArgs,
+    metrics_handle: PrometheusHandle,
+) -> Router {
     context.register(WorkerKind::Completion, args).await;
 
     let code = Arc::new(context.client.clone());

--- a/crates/tabby/src/worker.rs
+++ b/crates/tabby/src/worker.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::Result;
 use axum::{routing, Router};
-use axum_prometheus::{PrometheusMetricLayer};
+use axum_prometheus::PrometheusMetricLayer;
 use axum_tracing_opentelemetry::opentelemetry_tracing_layer;
 use clap::Args;
 use hyper::Server;

--- a/crates/tabby/src/worker.rs
+++ b/crates/tabby/src/worker.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::Result;
 use axum::{routing, Router};
-use axum_prometheus::{metrics_exporter_prometheus::PrometheusHandle, PrometheusMetricLayer};
+use axum_prometheus::{PrometheusMetricLayer};
 use axum_tracing_opentelemetry::opentelemetry_tracing_layer;
 use clap::Args;
 use hyper::Server;


### PR DESCRIPTION
1) Added `axum-prometheus` to Cargo.toml

2) Added `metrics.rs` as a simple route to produce a metrics endpoint with prometheus-formatted events

3) Added `/v1/metrics` endpoint with API doc entry

4) Added the `PrometheusLayer` to the root layers.

This change effectively allows for external Prometheus to scrape metrics from Tabby during execution in order to monitor operations (resources, timings and overall usage).

Metrics can be viewed from the API docs and by calling `/v1/metrics` on a running instance.