### PR TITLE
fix(vscode): Hotfix 1.1.3.  Do not show disconnected notification when initializing

### DIFF
--- a/clients/vscode/CHANGELOG.md
+++ b/clients/vscode/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 1.1.3
+
+### Fixes:
+
+- Fixed a bug that caused the disconnected notification to show up every time when VSCode is started. Now, the notification will only appear after the user modifies the server endpoint settings and the connection fails.
+
 ## 1.1.2
 
 ### Fixes:
 
-- Fix a bug cause the completion does not show up if the completion cache is missing.
+- Fixed a bug that caused the completion to not show up when the completion cache is missing.
 
 ## 1.1.0
 

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/TabbyML/tabby",
   "bugs": "https://github.com/TabbyML/tabby/issues",
   "license": "Apache-2.0",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "ai",
     "autocomplete",

--- a/clients/vscode/src/TabbyStatusBarItem.ts
+++ b/clients/vscode/src/TabbyStatusBarItem.ts
@@ -172,14 +172,19 @@ export class TabbyStatusBarItem {
 
     agent().on("issuesUpdated", (event: IssuesUpdatedEvent) => {
       console.debug("Tabby agent issuesUpdated", { event });
-      this.fsmService.send(agent().getStatus());
+      const status = agent().getStatus();
+      this.fsmService.send(status);
       const showCompletionResponseWarnings =
         !this.completionResponseWarningShown &&
         !this.extensionContext.globalState
           .get<string[]>("notifications.muted", [])
           .includes("completionResponseTimeIssues");
       if (event.issues.includes("connectionFailed")) {
-        notifications.showInformationWhenDisconnected();
+        // Only show this notification when user modifies the settings, do not show it when initializing
+        // FIXME: refactor this use a flag marks the event is trigger by modifying settings or initializing
+        if (status !== "notInitialized") {
+          notifications.showInformationWhenDisconnected();
+        }
       } else if (showCompletionResponseWarnings && event.issues.includes("highCompletionTimeoutRate")) {
         this.completionResponseWarningShown = true;
         notifications.showInformationWhenHighCompletionTimeoutRate();


### PR DESCRIPTION
FIX TAB-350

- Fixed a bug that caused the disconnected notification to show up every time when VSCode is started. Now, the notification will only appear after the user modifies the server endpoint settings and the connection fails.