### PR TITLE
fix: run container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,10 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1 \
 COPY --from=build /opt/tabby /opt/tabby
 
 ENV TABBY_ROOT=/data
+ARG WRITE_DIRS="${TABBY_ROOT} ${TABBY_ROOT}/events"
+RUN useradd -u 1001 tabby && \
+    mkdir -p ${WRITE_DIRS} && \
+    chown tabby ${WRITE_DIRS}
+USER tabby
 
 ENTRYPOINT ["/opt/tabby/bin/tabby"]


### PR DESCRIPTION
First stab at running the Tabby container as non-root. 

I've not explored thoroughly if there are other directories that needs to be owned by the `tabby` user. I am able to run a simple serve (`tabby serve --model ...`) with this setup.

Hoping CI will tell me more, if there is more.