### PR TITLE
feat: Add support for 7840U iGPU type

### DIFF
--- a/crates/llama-cpp-bindings/build.rs
+++ b/crates/llama-cpp-bindings/build.rs
@@ -49,6 +49,7 @@ fn main() {
             "gfx1100",
             "gfx1101",
             "gfx1102",
+            "gfx1103",
         ];
 
         let rocm_root = env::var("ROCM_ROOT").unwrap_or("/opt/rocm".to_string());


### PR DESCRIPTION
rocminfo reports that my AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics gpu version is gfx1103