### PR TITLE
Add ssh-client to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ RUN apt-get update && \
         protobuf-compiler \
         git \
         cmake \
-        openssh-client \
-        ca-certificates \
-        && \
+       && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -43,6 +41,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp target/release/tabby /opt/tabby/bin/
 
 FROM ${BASE_CUDA_RUN_CONTAINER} as runtime
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        openssh-client \
+        ca-certificates \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Disable safe directory in docker
 # Context: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
         protobuf-compiler \
         git \
         cmake \
-       && \
+        && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && \
         protobuf-compiler \
         git \
         cmake \
+        openssh-client \
+        ca-certificates \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,13 +42,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM ${BASE_CUDA_RUN_CONTAINER} as runtime
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        git \
-        && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # Disable safe directory in docker
 # Context: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
 RUN git config --system --add safe.directory "*"

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -17,8 +17,12 @@ To enable repository level context for code completion, you can add the followin
 git_url = "https://github.com/TabbyML/tabby.git"
 
 [[repositories]]
-git_url = "https://github.com/OpenNMT/CTranslate2.git"
+git_url = "git@github.com:OpenNMT/CTranslate2.git"
 ```
+:::tip
+When fetching repositories via SSH, the ssh-client will look at `/root/.ssh` for ssh keys as well as
+the `know-hosts` file. To set the files, you can mount a directory by adding `-v <path_to_ssh_certs>:/root/.ssh` to your `docker run` command.
+:::
 
 Once this is set, you can run `tabby scheduler` to index the source code repository.
 
@@ -32,7 +36,7 @@ data.jsonl
 
 ~/.tabby % ls index
 1a8729fa34d844df984b444f4def1456.fast      2ed712d4a7a44ed797dd4ff5ceaf4312.fieldnorm
-b42ca53fe6f94d0c8e96f947318278ba.idx       1a8729fa34d844df984b444f4def1456.fieldnorm 
+b42ca53fe6f94d0c8e96f947318278ba.idx       1a8729fa34d844df984b444f4def1456.fieldnorm
 2ed712d4a7a44ed797dd4ff5ceaf4312.idx       b42ca53fe6f94d0c8e96f947318278ba.pos
 ...
 ```


### PR DESCRIPTION
This PR adds the ssh-client as well as the ca-certificates to the Dockerfile and updates the documentation accordingly to reflect the change.

With this change, the scheduler can now clone repositories via SSH rather than just HTTP.