### PR TITLE
chore: update rusqlite, rusqlite_migration and tokio-rusqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -1814,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2976,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
 dependencies = [
  "bitflags 2.4.0",
  "chrono",
@@ -2991,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "1.1.0-alpha.2"
+version = "1.1.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef119690ca6bac53498f4478badf364840780248132ab5097891d0cfdf42eda"
+checksum = "b5767f8cb28e54d1ed745f072b72c6e68bfa6179fabb4cd15bdb8575858e301d"
 dependencies = [
  "log",
  "rusqlite",
@@ -4119,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa66395f5ff117faee90c9458232c936405f9227ad902038000b74b3bc1feac"
+checksum = "dc785c98d0c872455381e59be1f33a8f3a6b4e852544212e37601cc2ccb21d39"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/ee/tabby-webserver/Cargo.toml
+++ b/ee/tabby-webserver/Cargo.toml
@@ -20,9 +20,9 @@ juniper-axum = { path = "../../crates/juniper-axum" }
 lazy_static = "1.4.0"
 mime_guess = "2.0.4"
 pin-project = "1.1.3"
-rusqlite = { version = "0.29.0", features = ["bundled", "chrono"] }
-# `async-tokio-rusqlite` is only available from 1.1.0-alpha.2, will bump up version when it's stable
-rusqlite_migration = { version = "1.1.0-alpha.2", features = ["async-tokio-rusqlite"] }
+rusqlite = { version = "0.30.0", features = ["bundled", "chrono"] }
+# `alpha-async-tokio-rusqlite` is only available from 1.1.0-alpha.2, will bump up version when it's stable
+rusqlite_migration = { version = "1.1.0-beta.1", features = ["alpha-async-tokio-rusqlite"] }
 rust-embed = "8.0.0"
 serde.workspace = true
 tabby-common = { path = "../../crates/tabby-common" }
@@ -30,7 +30,7 @@ tarpc = { version = "0.33.0", features = ["serde-transport"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 tokio-cron-scheduler = "0.9.4"
-tokio-rusqlite = "0.4.0"
+tokio-rusqlite = "0.5.0"
 tokio-tungstenite = "0.20.1"
 tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.4.0", features = ["fs", "trace"] }

--- a/ee/tabby-webserver/src/service/db/invitations.rs
+++ b/ee/tabby-webserver/src/service/db/invitations.rs
@@ -37,16 +37,17 @@ impl DbConn {
         let token = self
             .conn
             .call(|conn| {
-                conn.query_row(
-                    r#"SELECT id, email, code, created_at FROM invitations WHERE code = ?"#,
-                    [code],
-                    Invitation::from_row,
-                )
-                .optional()
+                Ok(conn
+                    .query_row(
+                        r#"SELECT id, email, code, created_at FROM invitations WHERE code = ?"#,
+                        [code],
+                        Invitation::from_row,
+                    )
+                    .optional())
             })
             .await?;
 
-        Ok(token)
+        Ok(token?)
     }
 
     pub async fn create_invitation(&self, email: String) -> Result<i32> {
@@ -81,9 +82,9 @@ impl DbConn {
     pub async fn delete_invitation(&self, id: i32) -> Result<i32> {
         let res = self
             .conn
-            .call(move |c| c.execute(r#"DELETE FROM invitations WHERE id = ?"#, params![id]))
+            .call(move |c| Ok(c.execute(r#"DELETE FROM invitations WHERE id = ?"#, params![id])))
             .await?;
-        if res != 1 {
+        if res != Ok(1) {
             return Err(anyhow!("failed to delete invitation"));
         }
 

--- a/ee/tabby-webserver/src/service/db/mod.rs
+++ b/ee/tabby-webserver/src/service/db/mod.rs
@@ -104,12 +104,12 @@ impl DbConn {
 
         let token = uuid::Uuid::new_v4().to_string();
         conn.call(move |c| {
-            c.execute(
+            Ok(c.execute(
                 r#"INSERT OR IGNORE INTO registration_token (id, token) VALUES (1, ?)"#,
                 params![token],
-            )
+            ))
         })
-        .await?;
+        .await??;
 
         let res = Self {
             conn: Arc::new(conn),
@@ -128,15 +128,15 @@ impl DbConn {
         let token = self
             .conn
             .call(|conn| {
-                conn.query_row(
+                Ok(conn.query_row(
                     r#"SELECT token FROM registration_token WHERE id = 1"#,
                     [],
                     |row| row.get(0),
-                )
+                ))
             })
             .await?;
 
-        Ok(token)
+        Ok(token?)
     }
 
     /// Update token in database.
@@ -148,13 +148,13 @@ impl DbConn {
         let res = self
             .conn
             .call(move |conn| {
-                conn.execute(
+                Ok(conn.execute(
                     r#"UPDATE registration_token SET token = ?, updated_at = ? WHERE id = 1"#,
                     params![token, updated_at],
-                )
+                ))
             })
             .await?;
-        if res != 1 {
+        if res != Ok(1) {
             return Err(anyhow::anyhow!("failed to update token"));
         }
 

--- a/ee/tabby-webserver/src/service/db/refresh_tokens.rs
+++ b/ee/tabby-webserver/src/service/db/refresh_tokens.rs
@@ -43,13 +43,13 @@ impl DbConn {
         let res = self
             .conn
             .call(move |c| {
-                c.execute(
+                Ok(c.execute(
                     r#"INSERT INTO refresh_tokens (user_id, token, expires_at) VALUES (?, ?, datetime('now', '+7 days'))"#,
                     params![user_id, token],
-                )
+                ))
             })
             .await?;
-        if res != 1 {
+        if res != Ok(1) {
             return Err(anyhow::anyhow!("failed to create refresh token"));
         }
 
@@ -62,13 +62,13 @@ impl DbConn {
         let res = self
             .conn
             .call(move |c| {
-                c.execute(
+                Ok(c.execute(
                     r#"UPDATE refresh_tokens SET token = ? WHERE token = ?"#,
                     params![new, old],
-                )
+                ))
             })
             .await?;
-        if res != 1 {
+        if res != Ok(1) {
             return Err(anyhow::anyhow!("failed to replace refresh token"));
         }
 
@@ -79,14 +79,14 @@ impl DbConn {
         let res = self
             .conn
             .call(move |c| {
-                c.execute(
+                Ok(c.execute(
                     r#"DELETE FROM refresh_tokens WHERE expires_at < ?"#,
                     params![Utc::now()],
-                )
+                ))
             })
             .await?;
 
-        Ok(res as i32)
+        Ok(res? as i32)
     }
 
     pub async fn get_refresh_token(&self, token: &str) -> Result<Option<RefreshToken>> {
@@ -94,16 +94,16 @@ impl DbConn {
         let token = self
             .conn
             .call(move |c| {
-                c.query_row(
+                Ok(c.query_row(
                     RefreshToken::select("token = ?").as_str(),
                     params![token],
                     RefreshToken::from_row,
                 )
-                .optional()
+                .optional())
             })
             .await?;
 
-        Ok(token)
+        Ok(token?)
     }
 }
 


### PR DESCRIPTION
I’ve released a new beta version of rusqlite_migration today and I’ve
renamed the `async-tokio-rusqlite` feature that you use to
`alpha-async-tokio-rusqlite`. I suggest updating dependencies as done in
this PR. By the way, if you would like to share feedback on the async
APIs, feel free to use this conversation:
https://github.com/cljoly/rusqlite_migration/discussions/127

Reading the release notes from [tokio-rusqlite][1], the main breaking
change is to the method `Connection::call`:

> - **breaking:** `Connection::call` now takes `tokio_rusqlite::Result` instead
>   of `rusqlite::Result`.

My understanding is that we can either deal with a `Result<Result<…>>`
or call `Connection::call_unwrap`, which could panic if the connection
is closed. I’ve opted for using only `Connection::call` and,
effectively, flattening the `Result<Result<…>>`, to limit the potential
for panics.

[1]: https://github.com/programatik29/tokio-rusqlite/blob/master/CHANGELOG.md#050-25-nov-2023
