### PR TITLE
fix: prevent early return of cron job

### DIFF
--- a/ee/tabby-webserver/src/schema/auth.rs
+++ b/ee/tabby-webserver/src/schema/auth.rs
@@ -39,21 +39,18 @@ pub fn validate_jwt(token: &str) -> jwt::errors::Result<JWTPayload> {
 }
 
 fn jwt_token_secret() -> String {
-    let jwt_secret = match std::env::var("TABBY_WEBSERVER_JWT_TOKEN_SECRET") {
-        Ok(x) => x,
-        Err(_) => {
-            eprintln!("
+    let jwt_secret = std::env::var("TABBY_WEBSERVER_JWT_TOKEN_SECRET").unwrap_or_else(|_| {
+        eprintln!("
     \x1b[93;1mJWT secret is not set\x1b[0m
 
     Tabby server will generate a one-time (non-persisted) JWT secret for the current process.
     Please set the \x1b[94mTABBY_WEBSERVER_JWT_TOKEN_SECRET\x1b[0m environment variable for production usage.
 "
-            );
-            Uuid::new_v4().to_string()
-        }
-    };
+        );
+        Uuid::new_v4().to_string()
+    });
 
-    if uuid::Uuid::parse_str(&jwt_secret).is_err() {
+    if Uuid::parse_str(&jwt_secret).is_err() {
         warn!("JWT token secret needs to be in standard uuid format to ensure its security, you might generate one at https://www.uuidgenerator.net");
         std::process::exit(1)
     }


### PR DESCRIPTION
When I run webserver locally, I found `Ok(None)` condition is triggered.

I shortern the job run from `2 hours` to `2 minutes`, comment out `return` from `Ok(None)` condition, observed it might be triggered once or twice from time to time.

Originally, I put `return` here because if scheduler has no job added, `time_till_next_job` will always return `Ok(None)`.

But since this condition can be reached even when job exists in scheduler, we shouldn't return directly.

This pr fixes it.

==

Track down `time_till_next_job` a bit, internally job's `next_tick` is compared with current timestamp, if next_tick < now, `Ok(None)` is returned.

Based on the [doc](https://docs.rs/tokio-cron-scheduler/0.9.4/tokio_cron_scheduler/struct.JobScheduler.html#method.start), a tokio task will run tick method every 500ms, so here we can just sleep 500ms to let scheduler do its job.

Since we call `time_till_next_job` in a loop, if there's no sleep, we'll keep entering `Ok(None)` branch for a short period of time, until job tick get updated.

