### PR TITLE
fix: pass ee root when call create_dir_all

### DIFF
--- a/ee/tabby-webserver/src/path.rs
+++ b/ee/tabby-webserver/src/path.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tabby_common::path::tabby_root;
 
-pub fn tabby_ee_root() -> PathBuf {
+fn tabby_ee_root() -> PathBuf {
     tabby_root().join("ee")
 }
 

--- a/ee/tabby-webserver/src/path.rs
+++ b/ee/tabby-webserver/src/path.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tabby_common::path::tabby_root;
 
-fn tabby_ee_root() -> PathBuf {
+pub fn tabby_ee_root() -> PathBuf {
     tabby_root().join("ee")
 }
 

--- a/ee/tabby-webserver/src/service/db/mod.rs
+++ b/ee/tabby-webserver/src/service/db/mod.rs
@@ -11,7 +11,10 @@ use rusqlite::params;
 use rusqlite_migration::AsyncMigrations;
 use tokio_rusqlite::Connection;
 
-use crate::{path::db_file, service::cron::run_offline_job};
+use crate::{
+    path::{db_file, tabby_ee_root},
+    service::cron::run_offline_job,
+};
 
 static MIGRATIONS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/migrations");
 
@@ -33,9 +36,8 @@ impl DbConn {
     }
 
     pub async fn new() -> Result<Self> {
-        let db_path = db_file();
-        tokio::fs::create_dir_all(db_path.as_path()).await?;
-        let conn = Connection::open(db_path).await?;
+        tokio::fs::create_dir_all(tabby_ee_root()).await?;
+        let conn = Connection::open(db_file()).await?;
         Self::init_db(conn).await
     }
 

--- a/ee/tabby-webserver/src/service/db/mod.rs
+++ b/ee/tabby-webserver/src/service/db/mod.rs
@@ -11,10 +11,7 @@ use rusqlite::params;
 use rusqlite_migration::AsyncMigrations;
 use tokio_rusqlite::Connection;
 
-use crate::{
-    path::{db_file, tabby_ee_root},
-    service::cron::run_offline_job,
-};
+use crate::{path::db_file, service::cron::run_offline_job};
 
 static MIGRATIONS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/migrations");
 
@@ -36,7 +33,7 @@ impl DbConn {
     }
 
     pub async fn new() -> Result<Self> {
-        tokio::fs::create_dir_all(tabby_ee_root()).await?;
+        tokio::fs::create_dir_all(db_file().parent().unwrap()).await?;
         let conn = Connection::open(db_file()).await?;
         Self::init_db(conn).await
     }


### PR DESCRIPTION
Follow up of https://github.com/TabbyML/tabby/pull/1057

In that PR, we pass the db file path for `create_dir_all` which will cause the exception when run the webserver.

This PR fix it.