### PR TITLE
fix(ui): fix gradient in darkmode playground chat box

### DIFF
--- a/ee/tabby-ui/components/chat-panel.tsx
+++ b/ee/tabby-ui/components/chat-panel.tsx
@@ -44,7 +44,7 @@ export function ChatPanel({
   return (
     <div
       className={cn(
-        'bg-gradient-to-b from-muted/10 from-10% to-muted/30 to-50%',
+        'bg-gradient-to-b from-transparent from-0% to-muted/25 to-100%',
         className
       )}
     >


### PR DESCRIPTION
Before:

<img width="487" alt="image" src="https://github.com/TabbyML/tabby/assets/388154/1658a32a-63c4-461b-b95b-70773c0f0270">


After:

<img width="444" alt="image" src="https://github.com/TabbyML/tabby/assets/388154/6619a77c-9300-4cba-9dc1-6a3da73b0eca">
