### PR TITLE
refactor(webserver db): tokio_rusqlite uses an underlying sender, so …

### DIFF
--- a/ee/tabby-webserver/src/service/db/mod.rs
+++ b/ee/tabby-webserver/src/service/db/mod.rs
@@ -3,8 +3,6 @@ mod job_runs;
 mod refresh_tokens;
 mod users;
 
-
-
 use anyhow::Result;
 use include_dir::{include_dir, Dir};
 pub use job_runs::JobRun;

--- a/ee/tabby-webserver/src/service/db/mod.rs
+++ b/ee/tabby-webserver/src/service/db/mod.rs
@@ -3,7 +3,7 @@ mod job_runs;
 mod refresh_tokens;
 mod users;
 
-use std::sync::Arc;
+
 
 use anyhow::Result;
 use include_dir::{include_dir, Dir};
@@ -24,7 +24,7 @@ lazy_static! {
 
 #[derive(Clone)]
 pub struct DbConn {
-    conn: Arc<Connection>,
+    conn: Connection,
 }
 
 impl DbConn {
@@ -53,9 +53,7 @@ impl DbConn {
         })
         .await??;
 
-        let res = Self {
-            conn: Arc::new(conn),
-        };
+        let res = Self { conn };
         run_cron(res.clone());
 
         Ok(res)


### PR DESCRIPTION
…Arc is not necessary (connection is cheap to clone)

@darknight 