### PR TITLE
feat(scheduler): only display tqdm progress bar in interactive terminal (tty)

### DIFF
--- a/crates/tabby-scheduler/src/index.rs
+++ b/crates/tabby-scheduler/src/index.rs
@@ -41,7 +41,7 @@ pub fn index_repositories(_config: &Config) -> Result<()> {
 
     let mut pb = std::io::stdout()
         .is_terminal()
-        .then(|| SourceFile::all())
+        .then(SourceFile::all)
         .transpose()?
         .map(|iter| tqdm(iter.count()));
     for file in SourceFile::all()? {


### PR DESCRIPTION
Follow up of PR: https://github.com/TabbyML/tabby/pull/1064

`atty` lacks maintenance, latest version was almost 4 years ago.

Luckily, from rust v1.70.0, std provides `IsTerminal` [trait](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html#tymethod.is_terminal)

Test if stdout refers to an terminal/tty, only display progress bar if it does.

