### PR TITLE
fix: Update docker.mdx to add arm64 entry to documentation

### DIFF
--- a/website/docs/installation/docker.mdx
+++ b/website/docs/installation/docker.mdx
@@ -23,5 +23,11 @@ import TabItem from '@theme/TabItem';
   docker run -it -p 8080:8080 -v $HOME/.tabby:/data tabbyml/tabby serve --model TabbyML/StarCoder-1B
   ```
 
+  For `arm64` CPUs, please clone the repository to your machine, then run these commands inside the repository:
+  ```bash title="run.sh"
+  docker build -t tabby:latest --build-arg ARCHTARGET=amd64 .
+  docker run -dt -p 8080:8080 -v $HOME/.tabby:/data --name tabby tabby:latest serve --model TabbyML/StarCoder-1B
+  ```
+
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Adding `arm64` CPU entry to documentation

These changes are part of this [fix](https://github.com/TabbyML/tabby/pull/1022)