### PR TITLE
fix: Update docker.mdx to add arm64 entry to doc

### DIFF
--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -56,13 +56,13 @@
     <p>To use this fix:</p>
     <ol>
       <li>Clone the tabby repo</li>
-      <li>Build the docker image locally with <code>--build-arg ARCHTARGET=amd64</code></li>
+      <li>Build the docker image locally with <code>--platform linux/amd64</code></li>
       <li>Run the docker image</li>
     </ol>
     <pre>
       <code>git clone https://github.com/TabbyML/tabby.git</code>
       <code>cd tabby</code>
-      <code>docker build -t tabby:latest --build-arg ARCHTARGET=amd64 .</code>
+      <code>docker build -t tabby:latest --platform linux/amd64 .</code>
       <code>docker run -dt -p 8080:8080 -v $HOME/.tabby:/data --name tabby tabby:latest serve --model TabbyML/StarCoder-1B</code>
     </pre>
   </div>

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -47,3 +47,22 @@
     <p>For details on the registry format, please refer to <a href="https://github.com/TabbyML/registry-tabby/blob/main/models.json">models.json</a></p>
   </div>
 </details>
+
+<details>
+  <summary>Does Tabby currently support arm64/v8 CPUs?</summary>
+  <div>
+    <p>No, we don't have an official fix <b>yet</b>, however we have an experimental <a href="https://github.com/TabbyML/tabby/pull/1022/files">fix</a> available</p>
+    <p>To use this fix:</p>
+    <ol>
+      <li>Clone the tabby repo</li>
+      <li>Build the docker image locally with <code>--build-arg ARCHTARGET=amd64</code></li>
+      <li>Run the docker image</li>
+    </ol>
+    <pre>
+      <code>git clone https://github.com/TabbyML/tabby.git</code>
+      <code>cd tabby</code>
+      <code>docker build -t tabby:latest --build-arg ARCHTARGET=amd64 .</code>
+      <code>docker run -dt -p 8080:8080 -v $HOME/.tabby:/data --name tabby tabby:latest serve --model TabbyML/StarCoder-1B</code>
+    </pre>
+  </div>
+</details>

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -51,7 +51,8 @@
 <details>
   <summary>Does Tabby currently support arm64/v8 CPUs?</summary>
   <div>
-    <p>No, we don't have an official fix <b>yet</b>, however we have an experimental <a href="https://github.com/TabbyML/tabby/pull/1022/files">fix</a> available</p>
+    <p>We don't officially support it yet, but we do have an experimental feature that can be accessed using the Docker command.</p>
+    <p>For more context, see <a href="https://github.com/TabbyML/tabby/pull/1022/files">this pull request</a></p>
     <p>To use this fix:</p>
     <ol>
       <li>Clone the tabby repo</li>

--- a/website/docs/installation/docker.mdx
+++ b/website/docs/installation/docker.mdx
@@ -23,5 +23,11 @@ import TabItem from '@theme/TabItem';
   docker run -it -p 8080:8080 -v $HOME/.tabby:/data tabbyml/tabby serve --model TabbyML/StarCoder-1B
   ```
 
+  For `arm64` CPUs, please clone the repository to your machine, then run these commands inside the repository:
+  ```bash title="run.sh"
+  docker build -t tabby:latest --build-arg ARCHTARGET=amd64 .
+  docker run -dt -p 8080:8080 -v $HOME/.tabby:/data --name tabby tabby:latest serve --model TabbyML/StarCoder-1B
+  ```
+
   </TabItem>
 </Tabs>

--- a/website/docs/installation/docker.mdx
+++ b/website/docs/installation/docker.mdx
@@ -23,11 +23,5 @@ import TabItem from '@theme/TabItem';
   docker run -it -p 8080:8080 -v $HOME/.tabby:/data tabbyml/tabby serve --model TabbyML/StarCoder-1B
   ```
 
-  For `arm64` CPUs, please clone the repository to your machine, then run these commands inside the repository:
-  ```bash title="run.sh"
-  docker build -t tabby:latest --build-arg ARCHTARGET=amd64 .
-  docker run -dt -p 8080:8080 -v $HOME/.tabby:/data --name tabby tabby:latest serve --model TabbyML/StarCoder-1B
-  ```
-
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Added `arm64` entry to documentation

This change is related to [fix](https://github.com/TabbyML/tabby/pull/1022)