### PR TITLE
feat: support streaming process output into db

### DIFF
--- a/ee/tabby-webserver/src/service/cron/job_utils.rs
+++ b/ee/tabby-webserver/src/service/cron/job_utils.rs
@@ -6,11 +6,7 @@ use tracing::error;
 
 use crate::service::db::{DbConn, JobRun};
 
-pub async fn repository_job(
-    db_conn: DbConn,
-    job_name: String,
-    schedule: &str,
-) -> anyhow::Result<Job> {
+pub async fn run_job(db_conn: DbConn, job_name: String, schedule: &str) -> anyhow::Result<Job> {
     let job = Job::new_async(schedule, move |_, _| {
         let job_name = job_name.clone();
         let db_conn = db_conn.clone();

--- a/ee/tabby-webserver/src/service/cron/mod.rs
+++ b/ee/tabby-webserver/src/service/cron/mod.rs
@@ -1,5 +1,5 @@
 mod db;
-mod repository;
+mod job_utils;
 
 use std::time::Duration;
 
@@ -26,15 +26,14 @@ pub fn run_cron(db_conn: &DbConn) {
         };
         // run every 5 minutes
         let Ok(job2) =
-            repository::repository_job(db_conn.clone(), "sync".to_owned(), "0 1/5 * * * * *").await
+            job_utils::run_job(db_conn.clone(), "sync".to_owned(), "0 1/5 * * * * *").await
         else {
             error!("failed to create sync job");
             return;
         };
         // run every 5 hours
         let Ok(job3) =
-            repository::repository_job(db_conn.clone(), "index".to_owned(), "0 0 1/5 * * * *")
-                .await
+            job_utils::run_job(db_conn.clone(), "index".to_owned(), "0 0 1/5 * * * *").await
         else {
             error!("failed to create index job");
             return;

--- a/ee/tabby-webserver/src/service/cron/mod.rs
+++ b/ee/tabby-webserver/src/service/cron/mod.rs
@@ -1,11 +1,12 @@
 mod db;
+mod repository;
 
 use std::time::Duration;
 
 use tokio_cron_scheduler::{Job, JobScheduler};
 use tracing::error;
 
-use crate::service::db::{DbConn, JobRun};
+use crate::service::db::DbConn;
 
 async fn new_job_scheduler(jobs: Vec<Job>) -> anyhow::Result<JobScheduler> {
     let scheduler = JobScheduler::new().await?;
@@ -24,13 +25,16 @@ pub fn run_cron(db_conn: &DbConn) {
             return;
         };
         // run every 5 minutes
-        let Ok(job2) = repository_job(db_conn.clone(), "sync".to_owned(), "0 1/5 * * * * *").await
+        let Ok(job2) =
+            repository::repository_job(db_conn.clone(), "sync".to_owned(), "0 1/5 * * * * *").await
         else {
             error!("failed to create sync job");
             return;
         };
         // run every 5 hours
-        let Ok(job3) = repository_job(db_conn.clone(), "index".to_owned(), "0 0 1/5 * * * *").await
+        let Ok(job3) =
+            repository::repository_job(db_conn.clone(), "index".to_owned(), "0 0 1/5 * * * *")
+                .await
         else {
             error!("failed to create index job");
             return;
@@ -57,42 +61,4 @@ pub fn run_cron(db_conn: &DbConn) {
             }
         }
     });
-}
-
-async fn repository_job(db_conn: DbConn, job_name: String, schedule: &str) -> anyhow::Result<Job> {
-    let job = Job::new_async(schedule, move |_, _| {
-        let job_name = job_name.clone();
-        let db_conn = db_conn.clone();
-        Box::pin(async move {
-            // run command as a child process
-            let start_time = chrono::Utc::now();
-            let exe = std::env::current_exe().unwrap();
-            let output = tokio::process::Command::new(exe)
-                .arg(&format!("job::{}", &job_name))
-                .output()
-                .await;
-            let Ok(output) = output else {
-                error!("`{}` failed: {:?}", &job_name, output.unwrap_err());
-                return;
-            };
-            let finish_time = chrono::Utc::now();
-
-            // save run result to db
-            let run = JobRun {
-                id: 0,
-                job_name,
-                start_time,
-                finish_time: Some(finish_time),
-                exit_code: output.status.code(),
-                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            };
-            let res = db_conn.create_job_run(run).await;
-            if let Err(e) = res {
-                error!("failed to save job run result: {}", e);
-            }
-        })
-    })?;
-
-    Ok(job)
 }

--- a/ee/tabby-webserver/src/service/cron/repository.rs
+++ b/ee/tabby-webserver/src/service/cron/repository.rs
@@ -1,0 +1,87 @@
+use std::process::Stdio;
+
+use tokio::{io::AsyncBufReadExt, process::Child};
+use tokio_cron_scheduler::Job;
+use tracing::error;
+
+use crate::service::db::{DbConn, JobRun};
+
+pub async fn repository_job(
+    db_conn: DbConn,
+    job_name: String,
+    schedule: &str,
+) -> anyhow::Result<Job> {
+    let job = Job::new_async(schedule, move |_, _| {
+        let job_name = job_name.clone();
+        let db_conn = db_conn.clone();
+        Box::pin(async move {
+            // create job run record
+            let mut run = JobRun {
+                job_name: job_name.clone(),
+                start_time: chrono::Utc::now(),
+                ..Default::default()
+            };
+            let res = db_conn.create_job_run(run.clone()).await;
+            let Ok(job_id) = res else {
+                error!(
+                    "failed to create `{}` run record: {}",
+                    job_name,
+                    res.unwrap_err()
+                );
+                return;
+            };
+            run.id = job_id;
+
+            // run command as a child process
+            let exe = std::env::current_exe().unwrap();
+            let mut child = tokio::process::Command::new(exe)
+                .arg(&format!("job::{}", &job_name))
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+
+            // spawn task to save stdout/stderr
+            save_job_output(db_conn.clone(), job_id, &mut child);
+
+            // wait process to exit
+            run.exit_code = child.wait().await.ok().map(|s| s.code()).flatten();
+            run.finish_time = Some(chrono::Utc::now());
+            db_conn
+                .update_job_status(run.clone())
+                .await
+                .unwrap_or_else(|e| {
+                    error!("failed to update `{}` run record: {}", job_name, e);
+                });
+        })
+    })?;
+
+    Ok(job)
+}
+
+/// Create two tasks to stream stdout/stderr from child process, into database
+///
+/// `child` must have piped stdout/stderr, or `unwrap` will panic on a `None` value
+fn save_job_output(db_conn: DbConn, job_id: i32, child: &mut Child) {
+    let stdout = child.stdout.take().unwrap();
+    let stdout = tokio::io::BufReader::new(stdout);
+    let mut stdout = stdout.lines();
+    let db = db_conn.clone();
+    tokio::spawn(async move {
+        while let Ok(Some(mut line)) = stdout.next_line().await {
+            line.push('\n');
+            db.update_job_stdout(job_id, line).await.unwrap_or_default();
+        }
+    });
+
+    let stderr = child.stderr.take().unwrap();
+    let stderr = tokio::io::BufReader::new(stderr);
+    let mut stderr = stderr.lines();
+    let db = db_conn.clone();
+    tokio::spawn(async move {
+        while let Ok(Some(mut line)) = stderr.next_line().await {
+            line.push('\n');
+            db.update_job_stderr(job_id, line).await.unwrap_or_default();
+        }
+    });
+}

--- a/ee/tabby-webserver/src/service/cron/repository.rs
+++ b/ee/tabby-webserver/src/service/cron/repository.rs
@@ -45,7 +45,7 @@ pub async fn repository_job(
             save_job_output(db_conn.clone(), job_id, &mut child);
 
             // wait process to exit
-            run.exit_code = child.wait().await.ok().map(|s| s.code()).flatten();
+            run.exit_code = child.wait().await.ok().and_then(|s| s.code());
             run.finish_time = Some(chrono::Utc::now());
             db_conn
                 .update_job_status(run.clone())


### PR DESCRIPTION
Follow up of PR: https://github.com/TabbyML/tabby/pull/1064#discussion_r1431078578

Main changes:

- Add db update for `job_runs` table
- Refactor `repository_job` method
  - take `stdout` & `stderr` from child process, create separate tasks to read from them, for each line, save into db