### PR TITLE
feat(vscode): support set auth token via vscode command.

### DIFF
--- a/clients/tabby-agent/src/Agent.ts
+++ b/clients/tabby-agent/src/Agent.ts
@@ -44,10 +44,7 @@ export type AgentIssue = SlowCompletionResponseTimeIssue | HighCompletionTimeout
  * @property {string} notInitialized - When the agent has not been initialized.
  * @property {string} ready - When the agent gets a valid response from the server.
  * @property {string} disconnected - When the agent fails to connect to the server.
- * @property {string} unauthorized - When the server is set to a Tabby Cloud endpoint that requires auth,
- *   and no `Authorization` request header is provided in the agent config,
- *   and the user has not completed the auth flow or the auth token is expired.
- *   See also `requestAuthUrl` and `waitForAuthToken`.
+ * @property {string} unauthorized - When the server requires authentication.
  * @property {string} finalized - When the agent is finalized.
  */
 export type AgentStatus = "notInitialized" | "ready" | "disconnected" | "unauthorized" | "finalized";
@@ -116,6 +113,8 @@ export interface AgentFunction {
   getServerHealthState(): ServerHealthState | null;
 
   /**
+   * @deprecated Tabby Cloud auth
+   *
    * Request auth url for Tabby Cloud endpoint. Only return value when the `AgentStatus` is `unauthorized`.
    * Otherwise, return null. See also `AgentStatus`.
    * @returns the auth url for redirecting, and the code for next step `waitingForAuth`
@@ -124,6 +123,8 @@ export interface AgentFunction {
   requestAuthUrl(options?: AbortSignalOption): Promise<{ authUrl: string; code: string } | null>;
 
   /**
+   * @deprecated Tabby Cloud auth
+   *
    * Wait for auth token to be ready after redirecting user to auth url,
    * returns nothing, but `AgentStatus` will change to `ready` if resolved successfully.
    * @param code from `requestAuthUrl`
@@ -158,8 +159,7 @@ export type ConfigUpdatedEvent = {
   config: AgentConfig;
 };
 /**
- * This event is emitted when the server is set to a Tabby Cloud endpoint that requires auth,
- * and no `Authorization` request header is provided in the agent config.
+ * This event is emitted when the server requires authentication.
  */
 export type AuthRequiredEvent = {
   event: "authRequired";

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -241,13 +241,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
       }
     } catch (error) {
       this.serverHealthState = undefined;
-      if (
-        error instanceof HttpError &&
-        [401, 403, 405].includes(error.status) &&
-        new URL(this.config.server.endpoint).hostname.endsWith("app.tabbyml.com") &&
-        isBlank(this.config.server.token) &&
-        this.config.server.requestHeaders["Authorization"] === undefined
-      ) {
+      if (error instanceof HttpError && [401, 403, 405].includes(error.status)) {
         this.logger.debug({ requestId, error }, "Health check error: unauthorized");
         this.changeStatus("unauthorized");
       } else {

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -48,7 +48,7 @@
       },
       {
         "command": "tabby.setApiToken",
-        "title": "Tabby: Set API Auth Token"
+        "title": "Tabby: Set API Token"
       },
       {
         "command": "tabby.openSettings",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -47,6 +47,10 @@
         "title": "Tabby: Specify API Endpoint of Tabby"
       },
       {
+        "command": "tabby.setApiToken",
+        "title": "Tabby: Set API Auth Token"
+      },
+      {
         "command": "tabby.openSettings",
         "title": "Tabby: Open Settings"
       },

--- a/clients/vscode/src/TabbyStatusBarItem.ts
+++ b/clients/vscode/src/TabbyStatusBarItem.ts
@@ -266,7 +266,7 @@ export class TabbyStatusBarItem {
     this.item.color = colorWarning;
     this.item.backgroundColor = backgroundColorWarning;
     this.item.text = `${iconUnauthorized} ${label}`;
-    this.item.tooltip = "Tabby Server requires authorization. Please set your auth token.";
+    this.item.tooltip = "Tabby Server requires authorization. Please set your personal token.";
     this.item.command = {
       title: "",
       command: "tabby.applyCallback",

--- a/clients/vscode/src/TabbyStatusBarItem.ts
+++ b/clients/vscode/src/TabbyStatusBarItem.ts
@@ -114,17 +114,8 @@ export class TabbyStatusBarItem {
         on: {
           ready: this.subStatusForReady,
           disconnected: "disconnected",
-          authStart: "unauthorizedAndAuthInProgress",
         },
         entry: () => this.toUnauthorized(),
-      },
-      unauthorizedAndAuthInProgress: {
-        on: {
-          ready: this.subStatusForReady,
-          disconnected: "disconnected",
-          authEnd: "unauthorized", // if auth succeeds, we will get `ready` before `authEnd` event
-        },
-        entry: () => this.toUnauthorizedAndAuthInProgress(),
       },
       issuesExist: {
         on: {
@@ -160,14 +151,7 @@ export class TabbyStatusBarItem {
 
     agent().on("authRequired", (event: AuthRequiredEvent) => {
       console.debug("Tabby agent authRequired", { event });
-      notifications.showInformationStartAuth({
-        onAuthStart: () => {
-          this.fsmService.send("authStart");
-        },
-        onAuthEnd: () => {
-          this.fsmService.send("authEnd");
-        },
-      });
+      notifications.showInformationWhenUnauthorized();
     });
 
     agent().on("issuesUpdated", (event: IssuesUpdatedEvent) => {
@@ -282,30 +266,12 @@ export class TabbyStatusBarItem {
     this.item.color = colorWarning;
     this.item.backgroundColor = backgroundColorWarning;
     this.item.text = `${iconUnauthorized} ${label}`;
-    this.item.tooltip = "Tabby Server requires authorization. Click to continue.";
+    this.item.tooltip = "Tabby Server requires authorization. Please set your auth token.";
     this.item.command = {
       title: "",
       command: "tabby.applyCallback",
-      arguments: [
-        () =>
-          notifications.showInformationStartAuth({
-            onAuthStart: () => {
-              this.fsmService.send("authStart");
-            },
-            onAuthEnd: () => {
-              this.fsmService.send("authEnd");
-            },
-          }),
-      ],
+      arguments: [() => notifications.showInformationWhenUnauthorized()],
     };
-  }
-
-  private toUnauthorizedAndAuthInProgress() {
-    this.item.color = colorWarning;
-    this.item.backgroundColor = backgroundColorWarning;
-    this.item.text = `${iconUnauthorized} ${label}`;
-    this.item.tooltip = "Waiting for authorization.";
-    this.item.command = undefined;
   }
 
   private toIssuesExist() {

--- a/clients/vscode/src/agent.ts
+++ b/clients/vscode/src/agent.ts
@@ -10,6 +10,16 @@ function buildInitOptions(context: ExtensionContext): AgentInitOptions {
       endpoint,
     };
   }
+  const token = context.globalState.get<string>("server.token");
+  if (token && token.trim().length > 0) {
+    if (config.server) {
+      config.server.token = token;
+    } else {
+      config.server = {
+        token,
+      };
+    }
+  }
   const anonymousUsageTrackingDisabled = configuration.get<boolean>("usage.anonymousUsageTracking", false);
   config.anonymousUsageTracking = {
     disable: anonymousUsageTrackingDisabled,

--- a/clients/vscode/src/commands.ts
+++ b/clients/vscode/src/commands.ts
@@ -79,7 +79,7 @@ const setApiToken = (context: ExtensionContext): Command => {
       const currentToken = agent().getConfig()["server"]["token"].trim();
       window
         .showInputBox({
-          prompt: "Enter the auth token",
+          prompt: "Enter your personal token",
           value: currentToken.length > 0 ? currentToken : undefined,
           password: true,
         })
@@ -88,11 +88,11 @@ const setApiToken = (context: ExtensionContext): Command => {
             return; // User canceled
           }
           if (token.length > 0) {
-            console.debug("Set auth token: ", token);
+            console.debug("Set token: ", token);
             context.globalState.update("server.token", token);
             agent().updateConfig("server.token", token);
           } else {
-            console.debug("Clear auth token.");
+            console.debug("Clear token.");
             context.globalState.update("server.token", undefined);
             agent().clearConfig("server.token");
           }

--- a/clients/vscode/src/commands.ts
+++ b/clients/vscode/src/commands.ts
@@ -72,6 +72,32 @@ const setApiEndpoint: Command = {
   },
 };
 
+const setApiToken = (context: ExtensionContext): Command => {
+  return {
+    command: "tabby.setApiToken",
+    callback: () => {
+      const currentToken = agent().getConfig()["server"]["token"].trim();
+      window
+        .showInputBox({
+          prompt: "Enter the auth token",
+          value: currentToken.length > 0 ? currentToken : undefined,
+          password: true,
+        })
+        .then((token) => {
+          if (token && token.length > 0) {
+            console.debug("Set auth token: ", token);
+            context.globalState.update("server.token", token);
+            agent().updateConfig("server.token", token);
+          } else {
+            console.debug("Clear auth token.");
+            context.globalState.update("server.token", undefined);
+            agent().clearConfig("server.token");
+          }
+        });
+    },
+  };
+};
+
 const openSettings: Command = {
   command: "tabby.openSettings",
   callback: () => {
@@ -114,6 +140,7 @@ const gettingStarted: Command = {
   },
 };
 
+/** @deprecated Tabby Cloud auth */
 const openAuthPage: Command = {
   command: "tabby.openAuthPage",
   callback: (callbacks?: { onAuthStart?: () => void; onAuthEnd?: () => void }) => {
@@ -290,6 +317,7 @@ export const tabbyCommands = (
   [
     toggleInlineCompletionTriggerMode,
     setApiEndpoint,
+    setApiToken(context),
     openSettings,
     openTabbyAgentSettings,
     openKeybindings,

--- a/clients/vscode/src/commands.ts
+++ b/clients/vscode/src/commands.ts
@@ -84,7 +84,10 @@ const setApiToken = (context: ExtensionContext): Command => {
           password: true,
         })
         .then((token) => {
-          if (token && token.length > 0) {
+          if (token === undefined) {
+            return; // User canceled
+          }
+          if (token.length > 0) {
             console.debug("Set auth token: ", token);
             context.globalState.update("server.token", token);
             agent().updateConfig("server.token", token);

--- a/clients/vscode/src/notifications.ts
+++ b/clients/vscode/src/notifications.ts
@@ -125,6 +125,24 @@ function showInformationWhenDisconnected(modal: boolean = false) {
   }
 }
 
+function showInformationWhenUnauthorized() {
+  let message = "Tabby server requires authentication, ";
+  const currentToken = agent().getConfig()["server"]["token"].trim();
+  if (currentToken.length > 0) {
+    message += ` but the current token is invalid.`;
+  } else {
+    message += ` please set your auth token.`;
+  }
+  window.showWarningMessage(message, "Set Token").then((selection) => {
+    switch (selection) {
+      case "Set Token":
+        commands.executeCommand("tabby.setApiToken");
+        break;
+    }
+  });
+}
+
+/** @deprecated Tabby Cloud auth */
 function showInformationStartAuth(callbacks?: { onAuthStart?: () => void; onAuthEnd?: () => void }) {
   window
     .showWarningMessage(
@@ -143,14 +161,17 @@ function showInformationStartAuth(callbacks?: { onAuthStart?: () => void; onAuth
     });
 }
 
+/** @deprecated Tabby Cloud auth */
 function showInformationAuthSuccess() {
   window.showInformationMessage("Congrats, you're authorized, start to use Tabby now.");
 }
 
+/** @deprecated Tabby Cloud auth */
 function showInformationWhenStartAuthButAlreadyAuthorized() {
   window.showInformationMessage("You are already authorized now.");
 }
 
+/** @deprecated Tabby Cloud auth */
 function showInformationWhenAuthFailed() {
   window.showWarningMessage("Cannot connect to server. Please check settings.", "Settings").then((selection) => {
     switch (selection) {
@@ -301,6 +322,7 @@ export const notifications = {
   showInformationWhenManualTriggerLoading,
   showInformationWhenInlineSuggestDisabled,
   showInformationWhenDisconnected,
+  showInformationWhenUnauthorized,
   showInformationStartAuth,
   showInformationAuthSuccess,
   showInformationWhenStartAuthButAlreadyAuthorized,

--- a/clients/vscode/src/notifications.ts
+++ b/clients/vscode/src/notifications.ts
@@ -131,11 +131,11 @@ function showInformationWhenUnauthorized() {
   if (currentToken.length > 0) {
     message += ` but the current token is invalid.`;
   } else {
-    message += ` please set your auth token.`;
+    message += ` please set your personal token.`;
   }
-  window.showWarningMessage(message, "Set Token").then((selection) => {
+  window.showWarningMessage(message, "Set Credentials").then((selection) => {
     switch (selection) {
-      case "Set Token":
+      case "Set Credentials":
         commands.executeCommand("tabby.setApiToken");
         break;
     }


### PR DESCRIPTION
Complete TAB-384

- Supported set auth token via VSCode command, should be useful for users connecting to a Tabby server running with `--webserver` option.  
  - Token set in IDE have higher priority than in `~/.tabby-client/agent/config.toml`
- **Removed** support for `open auth page` when using Tabby Cloud.

Preview:
![Screenshot from 2023-12-22 17-56-16](https://github.com/TabbyML/tabby/assets/13573879/8dc8a895-fde5-4c8a-8090-6b0f6cdcafd3)
![Screenshot from 2023-12-22 17-56-44](https://github.com/TabbyML/tabby/assets/13573879/359ef351-c22e-4835-8ad1-a85a93b3cd75)

