### PR TITLE
feat: display job run results in page

### DIFF
--- a/ee/tabby-webserver/graphql/schema.graphql
+++ b/ee/tabby-webserver/graphql/schema.graphql
@@ -28,6 +28,16 @@ type JWTPayload {
   isAdmin: Boolean!
 }
 
+type JobRun {
+  id: ID!
+  jobName: String!
+  startTime: DateTimeUtc!
+  finishTime: DateTimeUtc
+  exitCode: Int
+  stdout: String!
+  stderr: String!
+}
+
 type Query {
   workers: [Worker!]!
   registrationToken: String!
@@ -37,11 +47,17 @@ type Query {
   users: [User!]!
   usersNext(after: String, before: String, first: Int, last: Int): UserConnection!
   invitationsNext(after: String, before: String, first: Int, last: Int): InvitationConnection!
+  jobRuns(after: String, before: String, first: Int, last: Int): JobRunConnection!
 }
 
 type UserEdge {
   node: User!
   cursor: String!
+}
+
+type JobRunConnection {
+  edges: [JobRunEdge!]!
+  pageInfo: PageInfo!
 }
 
 type RefreshTokenResponse {
@@ -112,6 +128,11 @@ type PageInfo {
   hasNextPage: Boolean!
   startCursor: String
   endCursor: String
+}
+
+type JobRunEdge {
+  node: JobRun!
+  cursor: String!
 }
 
 type InvitationConnection {

--- a/ee/tabby-webserver/src/schema/auth.rs
+++ b/ee/tabby-webserver/src/schema/auth.rs
@@ -385,7 +385,7 @@ pub trait AuthenticationService: Send + Sync {
         last: Option<usize>,
     ) -> Result<Vec<InvitationNext>>;
 
-    async fn list_job_runs_in_page(
+    async fn list_job_runs(
         &self,
         after: Option<String>,
         before: Option<String>,

--- a/ee/tabby-webserver/src/schema/auth.rs
+++ b/ee/tabby-webserver/src/schema/auth.rs
@@ -13,7 +13,7 @@ use tracing::{error, warn};
 use uuid::Uuid;
 use validator::ValidationErrors;
 
-use super::{from_validation_errors};
+use super::from_validation_errors;
 use crate::schema::Context;
 
 lazy_static! {

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -13,11 +13,11 @@ use tabby_common::api::{code::CodeSearch, event::RawEventLogger};
 use tracing::error;
 use validator::ValidationErrors;
 
-pub use crate::schema::auth::{Invitation, InvitationNext, JobRun, User};
 use crate::schema::{
     auth::{
-        validate_jwt, RefreshTokenError, RefreshTokenResponse, RegisterError, RegisterResponse,
-        TokenAuthError, TokenAuthResponse, VerifyTokenResponse,
+        validate_jwt, Invitation, InvitationNext, JobRun, RefreshTokenError, RefreshTokenResponse,
+        RegisterError, RegisterResponse, TokenAuthError, TokenAuthResponse, User,
+        VerifyTokenResponse,
     },
     worker::{Worker, WorkerService},
 };
@@ -212,7 +212,7 @@ impl Query {
                         match ctx
                             .locator
                             .auth()
-                            .list_job_runs_in_page(after, before, first, last)
+                            .list_job_runs(after, before, first, last)
                             .await
                         {
                             Ok(job_runs) => Ok(job_runs),

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -5,24 +5,22 @@ use std::sync::Arc;
 
 use auth::AuthenticationService;
 use juniper::{
-    graphql_object, graphql_value, EmptySubscription, FieldError, FieldResult,
-    IntoFieldError, Object, RootNode, ScalarValue, Value,
+    graphql_object, graphql_value, EmptySubscription, FieldError, FieldResult, IntoFieldError,
+    Object, RootNode, ScalarValue, Value,
 };
-use tracing::error;
 use juniper_axum::{relay, FromAuth};
 use tabby_common::api::{code::CodeSearch, event::RawEventLogger};
+use tracing::error;
 use validator::ValidationErrors;
 
+pub use crate::schema::auth::{Invitation, InvitationNext, JobRun, User};
 use crate::schema::{
     auth::{
-        validate_jwt, RegisterError, TokenAuthError,
-        RefreshTokenError, RefreshTokenResponse, RegisterResponse,
-        TokenAuthResponse, VerifyTokenResponse,
+        validate_jwt, RefreshTokenError, RefreshTokenResponse, RegisterError, RegisterResponse,
+        TokenAuthError, TokenAuthResponse, VerifyTokenResponse,
     },
-    worker::Worker,
-    worker::WorkerService,
+    worker::{Worker, WorkerService},
 };
-pub use crate::schema::auth::{Invitation, InvitationNext, JobRun, User};
 
 pub trait ServiceLocator: Send + Sync {
     fn auth(&self) -> &dyn AuthenticationService;

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -4,26 +4,25 @@ pub mod worker;
 use std::sync::Arc;
 
 use auth::AuthenticationService;
-use chrono::{DateTime, Utc};
 use juniper::{
-    graphql_object, graphql_value, EmptySubscription, FieldError, FieldResult, GraphQLObject,
+    graphql_object, graphql_value, EmptySubscription, FieldError, FieldResult,
     IntoFieldError, Object, RootNode, ScalarValue, Value,
 };
+use tracing::error;
 use juniper_axum::{relay, FromAuth};
 use tabby_common::api::{code::CodeSearch, event::RawEventLogger};
 use validator::ValidationErrors;
 
-use self::{
-    auth::{validate_jwt, Invitation, RegisterError, TokenAuthError},
-    worker::WorkerService,
-};
 use crate::schema::{
     auth::{
-        InvitationNext, RefreshTokenError, RefreshTokenResponse, RegisterResponse,
+        validate_jwt, RegisterError, TokenAuthError,
+        RefreshTokenError, RefreshTokenResponse, RegisterResponse,
         TokenAuthResponse, VerifyTokenResponse,
     },
     worker::Worker,
+    worker::WorkerService,
 };
+pub use crate::schema::auth::{Invitation, InvitationNext, JobRun, User};
 
 pub trait ServiceLocator: Send + Sync {
     fn auth(&self) -> &dyn AuthenticationService;
@@ -196,31 +195,39 @@ impl Query {
             "Only admin is able to query users",
         )))
     }
-}
 
-#[derive(Debug, GraphQLObject)]
-#[graphql(context = Context)]
-pub struct User {
-    pub id: juniper::ID,
-    pub email: String,
-    pub is_admin: bool,
-    pub auth_token: String,
-    pub created_at: DateTime<Utc>,
-}
-
-impl relay::NodeType for User {
-    type Cursor = String;
-
-    fn cursor(&self) -> Self::Cursor {
-        self.id.to_string()
-    }
-
-    fn connection_type_name() -> &'static str {
-        "UserConnection"
-    }
-
-    fn edge_type_name() -> &'static str {
-        "UserEdge"
+    async fn job_runs(
+        ctx: &Context,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<i32>,
+        last: Option<i32>,
+    ) -> FieldResult<relay::Connection<JobRun>> {
+        if let Some(claims) = &ctx.claims {
+            if claims.is_admin {
+                return relay::query_async(
+                    after,
+                    before,
+                    first,
+                    last,
+                    |after, before, first, last| async move {
+                        match ctx
+                            .locator
+                            .auth()
+                            .list_job_runs_in_page(after, before, first, last)
+                            .await
+                        {
+                            Ok(job_runs) => Ok(job_runs),
+                            Err(err) => Err(FieldError::from(err)),
+                        }
+                    },
+                )
+                .await;
+            }
+        }
+        Err(FieldError::from(CoreError::Unauthorized(
+            "Only admin is able to query job runs",
+        )))
     }
 }
 

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -11,12 +11,12 @@ use validator::{Validate, ValidationError};
 
 use super::db::DbConn;
 use crate::schema::{
+    Invitation, InvitationNext, JobRun, User,
     auth::{
-        generate_jwt, generate_refresh_token, validate_jwt, AuthenticationService, Invitation,
-        InvitationNext, JWTPayload, RefreshTokenError, RefreshTokenResponse, RegisterError,
+        generate_jwt, generate_refresh_token, validate_jwt, AuthenticationService,
+        JWTPayload, RefreshTokenError, RefreshTokenResponse, RegisterError,
         RegisterResponse, TokenAuthError, TokenAuthResponse, VerifyTokenResponse,
     },
-    User,
 };
 
 /// Input parameters for register mutation
@@ -348,6 +348,30 @@ impl AuthenticationService for DbConn {
         };
 
         Ok(invitations.into_iter().map(|x| x.into()).collect())
+    }
+
+    async fn list_job_runs_in_page(
+        &self,
+        after: Option<String>,
+        before: Option<String>,
+        first: Option<usize>,
+        last: Option<usize>,
+    ) -> Result<Vec<JobRun>> {
+        let runs = match (first, last) {
+            (Some(first), None) => {
+                let after = after.map(|x| x.parse::<i32>()).transpose()?;
+                self.list_job_runs_with_filter(Some(first), after, false)
+                    .await?
+            }
+            (None, Some(last)) => {
+                let before = before.map(|x| x.parse::<i32>()).transpose()?;
+                self.list_job_runs_with_filter(Some(last), before, true)
+                    .await?
+            }
+            _ => self.list_job_runs_with_filter(None, None, false).await?,
+        };
+
+        Ok(runs.into_iter().map(|x| x.into()).collect())
     }
 }
 

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -11,12 +11,12 @@ use validator::{Validate, ValidationError};
 
 use super::db::DbConn;
 use crate::schema::{
-    Invitation, InvitationNext, JobRun, User,
     auth::{
-        generate_jwt, generate_refresh_token, validate_jwt, AuthenticationService,
-        JWTPayload, RefreshTokenError, RefreshTokenResponse, RegisterError,
-        RegisterResponse, TokenAuthError, TokenAuthResponse, VerifyTokenResponse,
+        generate_jwt, generate_refresh_token, validate_jwt, AuthenticationService, JWTPayload,
+        RefreshTokenError, RefreshTokenResponse, RegisterError, RegisterResponse, TokenAuthError,
+        TokenAuthResponse, VerifyTokenResponse,
     },
+    Invitation, InvitationNext, JobRun, User,
 };
 
 /// Input parameters for register mutation

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -10,13 +10,10 @@ use async_trait::async_trait;
 use validator::{Validate, ValidationError};
 
 use super::db::DbConn;
-use crate::schema::{
-    auth::{
-        generate_jwt, generate_refresh_token, validate_jwt, AuthenticationService, JWTPayload,
-        RefreshTokenError, RefreshTokenResponse, RegisterError, RegisterResponse, TokenAuthError,
-        TokenAuthResponse, VerifyTokenResponse,
-    },
-    Invitation, InvitationNext, JobRun, User,
+use crate::schema::auth::{
+    generate_jwt, generate_refresh_token, validate_jwt, AuthenticationService, Invitation,
+    InvitationNext, JWTPayload, JobRun, RefreshTokenError, RefreshTokenResponse, RegisterError,
+    RegisterResponse, TokenAuthError, TokenAuthResponse, User, VerifyTokenResponse,
 };
 
 /// Input parameters for register mutation
@@ -350,7 +347,7 @@ impl AuthenticationService for DbConn {
         Ok(invitations.into_iter().map(|x| x.into()).collect())
     }
 
-    async fn list_job_runs_in_page(
+    async fn list_job_runs(
         &self,
         after: Option<String>,
         before: Option<String>,

--- a/ee/tabby-webserver/src/service/db/job_runs.rs
+++ b/ee/tabby-webserver/src/service/db/job_runs.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 
-use crate::schema;
 use super::DbConn;
+use crate::schema;
 
 #[derive(Default, Clone)]
 pub struct JobRun {
@@ -118,7 +118,17 @@ impl DbConn {
     ) -> Result<Vec<JobRun>> {
         let query = Self::make_pagination_query(
             "job_runs",
-            &["id", "job", "start_ts", "end_ts", "exit_code", "stdout", "stderr", "created_at", "updated_at"],
+            &[
+                "id",
+                "job",
+                "start_ts",
+                "end_ts",
+                "exit_code",
+                "stdout",
+                "stderr",
+                "created_at",
+                "updated_at",
+            ],
             limit,
             skip_id,
             backwards,

--- a/ee/tabby-webserver/src/service/db/job_runs.rs
+++ b/ee/tabby-webserver/src/service/db/job_runs.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 
 use super::DbConn;
-use crate::schema;
+use crate::schema::auth;
 
 #[derive(Default, Clone)]
 pub struct JobRun {
@@ -29,7 +29,7 @@ impl JobRun {
     }
 }
 
-impl From<JobRun> for schema::JobRun {
+impl From<JobRun> for auth::JobRun {
     fn from(run: JobRun) -> Self {
         Self {
             id: juniper::ID::new(run.id.to_string()),
@@ -126,8 +126,6 @@ impl DbConn {
                 "exit_code",
                 "stdout",
                 "stderr",
-                "created_at",
-                "updated_at",
             ],
             limit,
             skip_id,

--- a/ee/tabby-webserver/src/service/db/job_runs.rs
+++ b/ee/tabby-webserver/src/service/db/job_runs.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 
+use crate::schema;
 use super::DbConn;
 
-#[derive(Default, Clone, Serialize, Deserialize)]
+#[derive(Default, Clone)]
 pub struct JobRun {
     pub id: i32,
     pub job_name: String,
@@ -13,6 +13,34 @@ pub struct JobRun {
     pub exit_code: Option<i32>,
     pub stdout: String,
     pub stderr: String,
+}
+
+impl JobRun {
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            job_name: row.get(1)?,
+            start_time: row.get(2)?,
+            finish_time: row.get(3)?,
+            exit_code: row.get(4)?,
+            stdout: row.get(5)?,
+            stderr: row.get(6)?,
+        })
+    }
+}
+
+impl From<JobRun> for schema::JobRun {
+    fn from(run: JobRun) -> Self {
+        Self {
+            id: juniper::ID::new(run.id.to_string()),
+            job_name: run.job_name,
+            start_time: run.start_time,
+            finish_time: run.finish_time,
+            exit_code: run.exit_code,
+            stdout: run.stdout,
+            stderr: run.stderr,
+        }
+    }
 }
 
 /// db read/write operations for `job_runs` table
@@ -80,6 +108,32 @@ impl DbConn {
             })
             .await?;
         Ok(())
+    }
+
+    pub async fn list_job_runs_with_filter(
+        &self,
+        limit: Option<usize>,
+        skip_id: Option<i32>,
+        backwards: bool,
+    ) -> Result<Vec<JobRun>> {
+        let query = Self::make_pagination_query(
+            "job_runs",
+            &["id", "job", "start_ts", "end_ts", "exit_code", "stdout", "stderr", "created_at", "updated_at"],
+            limit,
+            skip_id,
+            backwards,
+        );
+
+        let runs = self
+            .conn
+            .call(move |c| {
+                let mut stmt = c.prepare(&query)?;
+                let run_iter = stmt.query_map([], JobRun::from_row)?;
+                Ok(run_iter.filter_map(|x| x.ok()).collect::<Vec<_>>())
+            })
+            .await?;
+
+        Ok(runs)
     }
 }
 

--- a/ee/tabby-webserver/src/service/db/users.rs
+++ b/ee/tabby-webserver/src/service/db/users.rs
@@ -4,7 +4,7 @@ use rusqlite::{params, OptionalExtension, Row};
 use uuid::Uuid;
 
 use super::DbConn;
-use crate::schema;
+use crate::schema::auth;
 
 #[allow(unused)]
 pub struct User {
@@ -40,9 +40,9 @@ impl User {
     }
 }
 
-impl From<User> for schema::User {
+impl From<User> for auth::User {
     fn from(val: User) -> Self {
-        schema::User {
+        auth::User {
             id: juniper::ID::new(val.id.to_string()),
             email: val.email,
             is_admin: val.is_admin,


### PR DESCRIPTION
For closing issue: https://github.com/TabbyML/tabby/issues/1117

- Add `job_runs` api + service implementation + db query, similar to the `usersNext` & `invitationsNext`
- move `User` object to `auth` mod, together with the other type definitions, then re-export in the `mod.rs`