### PR TITLE
refactor(agent): move calcReplaceRange to a postprocess filter.

### DIFF
--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -27,7 +27,7 @@ import { configFile } from "./configFile";
 import { CompletionCache } from "./CompletionCache";
 import { CompletionDebounce } from "./CompletionDebounce";
 import { CompletionContext } from "./CompletionContext";
-import { preCacheProcess, postCacheProcess, calculateReplaceRange } from "./postprocess";
+import { preCacheProcess, postCacheProcess } from "./postprocess";
 import { rootLogger, allLoggers } from "./logger";
 import { AnonymousUsageLogger } from "./AnonymousUsageLogger";
 import { CompletionProviderStats, CompletionProviderStatsEntry } from "./CompletionProviderStats";
@@ -553,11 +553,6 @@ export class TabbyAgent extends EventEmitter implements Agent {
       }
       // Postprocess (post-cache)
       completionResponse = await postCacheProcess(context, this.config.postprocess, completionResponse);
-      if (signal.aborted) {
-        throw signal.reason;
-      }
-      // Calculate replace range
-      completionResponse = await calculateReplaceRange(context, this.config.postprocess, completionResponse);
       if (signal.aborted) {
         throw signal.reason;
       }

--- a/clients/tabby-agent/src/postprocess/base.ts
+++ b/clients/tabby-agent/src/postprocess/base.ts
@@ -1,13 +1,20 @@
-import { CompletionResponse, CompletionContext } from "../CompletionContext";
+import { CompletionResponse, CompletionResponseChoice, CompletionContext } from "../CompletionContext";
 import { rootLogger } from "../logger";
 
-export type PostprocessFilter = (item: string, context: CompletionContext) => string | null | Promise<string | null>;
+type PostprocessFilterBase<T extends string | CompletionResponseChoice> = (
+  input: T,
+  context: CompletionContext,
+) => T | null | Promise<T | null>;
+
+export type PostprocessFilter = PostprocessFilterBase<string>;
+export type PostprocessChoiceFilter = PostprocessFilterBase<CompletionResponseChoice>;
 
 export const logger = rootLogger.child({ component: "Postprocess" });
 
 declare global {
   interface Array<T> {
     distinct(identity?: (x: T) => any): Array<T>;
+    mapAsync<U>(callbackfn: (value: T, index: number, array: T[]) => U | Promise<U>, thisArg?: any): Promise<U[]>;
   }
 }
 
@@ -17,22 +24,43 @@ if (!Array.prototype.distinct) {
   };
 }
 
+if (!Array.prototype.mapAsync) {
+  Array.prototype.mapAsync = async function <T, U>(
+    this: T[],
+    callbackfn: (value: T, index: number, array: T[]) => U | Promise<U>,
+    thisArg?: any,
+  ): Promise<U[]> {
+    return await Promise.all(this.map((item, index) => callbackfn.call(thisArg, item, index, this)));
+  };
+}
+
 export function applyFilter(
   filter: PostprocessFilter,
   context: CompletionContext,
 ): (response: CompletionResponse) => Promise<CompletionResponse> {
+  return applyChoiceFilter(async (choice) => {
+    const replaceLength = context.position - choice.replaceRange.start;
+    const input = choice.text.slice(replaceLength);
+    const filtered = await filter(input, context);
+    choice.text = choice.text.slice(0, replaceLength) + (filtered ?? "");
+    return choice;
+  }, context);
+}
+
+export function applyChoiceFilter(
+  choiceFilter: PostprocessChoiceFilter,
+  context: CompletionContext,
+): (response: CompletionResponse) => Promise<CompletionResponse> {
   return async (response: CompletionResponse) => {
     response.choices = (
-      await Promise.all(
-        response.choices.map(async (choice) => {
-          const replaceLength = context.position - choice.replaceRange.start;
-          const filtered = await filter(choice.text.slice(replaceLength), context);
-          choice.text = choice.text.slice(0, replaceLength) + (filtered ?? "");
-          return choice;
-        }),
-      )
+      await response.choices.mapAsync(async (choice) => {
+        return await choiceFilter(choice, context);
+      })
     )
-      .filter((choice) => !!choice.text)
+      .filter<CompletionResponseChoice>((choice): choice is NonNullable<CompletionResponseChoice> => {
+        // Filter out empty choices.
+        return !!choice && !!choice.text;
+      })
       .distinct((choice) => choice.text);
     return response;
   };

--- a/clients/tabby-agent/src/postprocess/calculateReplaceRange.ts
+++ b/clients/tabby-agent/src/postprocess/calculateReplaceRange.ts
@@ -1,0 +1,24 @@
+import { AgentConfig } from "../AgentConfig";
+import { isBrowser } from "../env";
+import { PostprocessChoiceFilter, logger } from "./base";
+import { calculateReplaceRangeByBracketStack } from "./calculateReplaceRangeByBracketStack";
+import { calculateReplaceRangeBySyntax } from "./calculateReplaceRangeBySyntax";
+
+export function calculateReplaceRange(
+  config: AgentConfig["postprocess"]["calculateReplaceRange"],
+): PostprocessChoiceFilter {
+  return async (choice, context) => {
+    const preferSyntaxParser =
+      !isBrowser && // syntax parser is not supported in browser yet
+      config.experimentalSyntax;
+
+    if (preferSyntaxParser) {
+      try {
+        return await calculateReplaceRangeBySyntax(choice, context);
+      } catch (error) {
+        logger.debug({ error }, "Failed to calculate replace range by syntax parser");
+      }
+    }
+    return calculateReplaceRangeByBracketStack(choice, context);
+  };
+}

--- a/clients/tabby-agent/src/postprocess/calculateReplaceRangeByBracketStack.test.ts
+++ b/clients/tabby-agent/src/postprocess/calculateReplaceRangeByBracketStack.test.ts
@@ -11,37 +11,27 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                        ├hello";┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                        ├hello";┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 1,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 1,
+        },
       };
-      expect(calculateReplaceRangeByBracketStack(response, context)).to.deep.equal(expected);
+      expect(calculateReplaceRangeByBracketStack(choice, context)).to.deep.equal(expected);
     });
 
     it("should handle auto closing quotes", () => {
@@ -51,37 +41,27 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                            ├<h1>\${message}</h1>\`;┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                            ├<h1>\${message}</h1>\`;┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 1,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 1,
+        },
       };
-      expect(calculateReplaceRangeByBracketStack(response, context)).to.deep.equal(expected);
+      expect(calculateReplaceRangeByBracketStack(choice, context)).to.deep.equal(expected);
     });
 
     it("should handle multiple auto closing brackets", () => {
@@ -91,41 +71,31 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                                       ├
-              console.log(data);
-            });┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+          console.log(data);
+        });┤
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                                       ├
-              console.log(data);
-            });┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 2,
-            },
-          },
-        ],
+          console.log(data);
+        });┤
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 2,
+        },
       };
-      expect(calculateReplaceRangeByBracketStack(response, context)).to.deep.equal(expected);
+      expect(calculateReplaceRangeByBracketStack(choice, context)).to.deep.equal(expected);
     });
 
     it("should handle multiple auto closing brackets", () => {
@@ -135,37 +105,27 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                                    ├1, 2], [3, 4]], [[5, 6], [7, 8]]];┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                                    ├1, 2], [3, 4]], [[5, 6], [7, 8]]];┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 3,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 3,
+        },
       };
-      expect(calculateReplaceRangeByBracketStack(response, context)).to.deep.equal(expected);
+      expect(calculateReplaceRangeByBracketStack(choice, context)).to.deep.equal(expected);
     });
   });
 
@@ -179,37 +139,27 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                                    ├n, max), min┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                                    ├n, max), min┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
-      expect(calculateReplaceRangeByBracketStack(response, context)).not.to.deep.equal(expected);
+      expect(calculateReplaceRangeByBracketStack(choice, context)).not.to.deep.equal(expected);
     });
   });
 });

--- a/clients/tabby-agent/src/postprocess/calculateReplaceRangeBySyntax.test.ts
+++ b/clients/tabby-agent/src/postprocess/calculateReplaceRangeBySyntax.test.ts
@@ -11,37 +11,27 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                        ├hello";┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                        ├hello";┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 1,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 1,
+        },
       };
-      expect(await calculateReplaceRangeBySyntax(response, context)).to.deep.equal(expected);
+      expect(await calculateReplaceRangeBySyntax(choice, context)).to.deep.equal(expected);
     });
 
     it("should handle auto closing quotes", async () => {
@@ -51,37 +41,27 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                            ├<h1>\${message}</h1>\`;┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                            ├<h1>\${message}</h1>\`;┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 1,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 1,
+        },
       };
-      expect(await calculateReplaceRangeBySyntax(response, context)).to.deep.equal(expected);
+      expect(await calculateReplaceRangeBySyntax(choice, context)).to.deep.equal(expected);
     });
 
     it("should handle multiple auto closing brackets", async () => {
@@ -91,41 +71,31 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                                       ├
-              console.log(data);
-            });┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+          console.log(data);
+        });┤
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                                       ├
-              console.log(data);
-            });┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 2,
-            },
-          },
-        ],
+          console.log(data);
+        });┤
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 2,
+        },
       };
-      expect(await calculateReplaceRangeBySyntax(response, context)).to.deep.equal(expected);
+      expect(await calculateReplaceRangeBySyntax(choice, context)).to.deep.equal(expected);
     });
 
     it("should handle multiple auto closing brackets", async () => {
@@ -135,37 +105,27 @@ describe("postprocess", () => {
         `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                                    ├1, 2], [3, 4]], [[5, 6], [7, 8]]];┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                                    ├1, 2], [3, 4]], [[5, 6], [7, 8]]];┤
-            `,
-            replaceRange: {
-              start: context.position,
-              end: context.position + 3,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position + 3,
+        },
       };
-      expect(await calculateReplaceRangeBySyntax(response, context)).to.deep.equal(expected);
+      expect(await calculateReplaceRangeBySyntax(choice, context)).to.deep.equal(expected);
     });
 
     it("should handle the bad case of calculateReplaceRangeByBracketStack", async () => {
@@ -177,37 +137,27 @@ describe("postprocess", () => {
       `,
         language: "typescript",
       };
-      const response = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+      const choice = {
+        index: 0,
+        text: inline`
                                  ├n, max), min┤
-          `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
       const expected = {
-        id: "",
-        choices: [
-          {
-            index: 0,
-            text: inline`
+        index: 0,
+        text: inline`
                                  ├n, max), min┤
-          `,
-            replaceRange: {
-              start: context.position,
-              end: context.position,
-            },
-          },
-        ],
+        `,
+        replaceRange: {
+          start: context.position,
+          end: context.position,
+        },
       };
-      expect(await calculateReplaceRangeBySyntax(response, context)).to.deep.equal(expected);
+      expect(await calculateReplaceRangeBySyntax(choice, context)).to.deep.equal(expected);
     });
   });
 });

--- a/clients/tabby-agent/src/postprocess/calculateReplaceRangeBySyntax.ts
+++ b/clients/tabby-agent/src/postprocess/calculateReplaceRangeBySyntax.ts
@@ -1,52 +1,58 @@
 import { getParser, languagesConfigs } from "../syntax/parser";
-import { CompletionContext, CompletionResponse } from "../CompletionContext";
+import { CompletionContext, CompletionResponseChoice } from "../CompletionContext";
 import { isBlank, splitLines } from "../utils";
 import { logger } from "./base";
 
 export const supportedLanguages = Object.keys(languagesConfigs);
 
+/**
+ * @throws {Error} if language is not supported
+ * @throws {Error} if syntax error when parsing completion
+ */
 export async function calculateReplaceRangeBySyntax(
-  response: CompletionResponse,
+  choice: CompletionResponseChoice,
   context: CompletionContext,
-): Promise<CompletionResponse> {
-  const { position, prefix, suffix, prefixLines, currentLineSuffix, currentLinePrefix, language } = context;
+): Promise<CompletionResponseChoice> {
+  const { position, prefix, suffix, prefixLines, currentLinePrefix, currentLineSuffix, language } = context;
+  const suffixText = currentLineSuffix.trimEnd();
+  if (isBlank(suffixText)) {
+    return choice;
+  }
+
   if (!supportedLanguages.includes(language)) {
-    return response;
+    throw new Error(`Language ${language} is not supported`);
   }
   const languageConfig = languagesConfigs[language]!;
   const parser = await getParser(languageConfig);
-  const suffixText = currentLineSuffix.trimEnd();
-  if (isBlank(suffixText)) {
-    return response;
-  }
-  for (const choice of response.choices) {
-    const completionText = choice.text.slice(position - choice.replaceRange.start);
-    const completionLines = splitLines(completionText);
-    let replaceLength = 0;
-    let tree = parser.parse(prefix + completionText + suffix);
-    let node = tree.rootNode.namedDescendantForIndex(prefix.length + completionText.length);
-    while (node.hasError() && replaceLength < suffixText.length) {
-      replaceLength++;
-      const row = prefixLines.length - 1 + completionLines.length - 1;
-      let column = completionLines[completionLines.length - 1]?.length ?? 0;
-      if (completionLines.length == 1) {
-        column += currentLinePrefix.length;
-      }
-      tree.edit({
-        startIndex: prefix.length + completionText.length,
-        oldEndIndex: prefix.length + completionText.length + 1,
-        newEndIndex: prefix.length + completionText.length,
-        startPosition: { row, column },
-        oldEndPosition: { row, column: column + 1 },
-        newEndPosition: { row, column },
-      });
-      tree = parser.parse(prefix + completionText + suffix.slice(replaceLength), tree);
-      node = tree.rootNode.namedDescendantForIndex(prefix.length + completionText.length);
+
+  const completionText = choice.text.slice(position - choice.replaceRange.start);
+  const completionLines = splitLines(completionText);
+  let replaceLength = 0;
+  let tree = parser.parse(prefix + completionText + suffix);
+  let node = tree.rootNode.namedDescendantForIndex(prefix.length + completionText.length);
+  while (node.hasError() && replaceLength < suffixText.length) {
+    replaceLength++;
+    const row = prefixLines.length - 1 + completionLines.length - 1;
+    let column = completionLines[completionLines.length - 1]?.length ?? 0;
+    if (completionLines.length == 1) {
+      column += currentLinePrefix.length;
     }
-    if (!node.hasError()) {
-      choice.replaceRange.end = position + replaceLength;
-      logger.trace({ context, completion: choice.text, range: choice.replaceRange }, "Adjust replace range by syntax");
-    }
+    tree.edit({
+      startIndex: prefix.length + completionText.length,
+      oldEndIndex: prefix.length + completionText.length + 1,
+      newEndIndex: prefix.length + completionText.length,
+      startPosition: { row, column },
+      oldEndPosition: { row, column: column + 1 },
+      newEndPosition: { row, column },
+    });
+    tree = parser.parse(prefix + completionText + suffix.slice(replaceLength), tree);
+    node = tree.rootNode.namedDescendantForIndex(prefix.length + completionText.length);
   }
-  return response;
+  if (node.hasError()) {
+    throw new Error("Syntax error when parsing completion");
+  }
+
+  choice.replaceRange.end = position + replaceLength;
+  logger.trace({ context, completion: choice.text, range: choice.replaceRange }, "Adjust replace range by syntax");
+  return choice;
 }

--- a/clients/tabby-agent/src/postprocess/golden/limit_scope/experimental_block_01.toml
+++ b/clients/tabby-agent/src/postprocess/golden/limit_scope/experimental_block_01.toml
@@ -1,4 +1,4 @@
-description = 'Limit scope experimental: limit to block when completing a line'
+description = 'Limit scope experimental: limit to block when completing a line: case 01'
 
 [config.limitScope.indentation]
 experimentalKeepBlockScopeWhenCompletingLine = true

--- a/clients/tabby-agent/src/postprocess/golden/limit_scope/experimental_block_02.toml
+++ b/clients/tabby-agent/src/postprocess/golden/limit_scope/experimental_block_02.toml
@@ -1,4 +1,4 @@
-description = 'Limit scope: limit to block scope: case 0'
+description = 'Limit scope experimental: limit to block when completing a line: case 02'
 
 [config.limitScope.indentation]
 experimentalKeepBlockScopeWhenCompletingLine = true

--- a/clients/tabby-agent/src/postprocess/golden/replace_range/experimental_syntax_mismatched_01.toml
+++ b/clients/tabby-agent/src/postprocess/golden/replace_range/experimental_syntax_mismatched_01.toml
@@ -1,4 +1,4 @@
-description = 'Replace range experimental: syntax mismatched: bad case 01'
+description = 'Replace range experimental: syntax mismatched: case 01'
 
 [config.limitScope]
 experimentalSyntax = true
@@ -29,4 +29,3 @@ def fibonacci(├n):
   else:
     return fibonacci(n - 1) + fibonacci(n - 2)┤)╣
 '''
-notEqual = true # FIXME: fix bad case

--- a/clients/tabby-agent/src/postprocess/index.ts
+++ b/clients/tabby-agent/src/postprocess/index.ts
@@ -1,7 +1,6 @@
 import { CompletionContext, CompletionResponse } from "../CompletionContext";
 import { AgentConfig } from "../AgentConfig";
-import { isBrowser } from "../env";
-import { applyFilter } from "./base";
+import { applyFilter, applyChoiceFilter } from "./base";
 import { removeRepetitiveBlocks } from "./removeRepetitiveBlocks";
 import { removeRepetitiveLines } from "./removeRepetitiveLines";
 import { removeLineEndsWithRepetition } from "./removeLineEndsWithRepetition";
@@ -12,8 +11,7 @@ import { trimSpace } from "./trimSpace";
 import { trimMultiLineInSingleLineMode } from "./trimMultiLineInSingleLineMode";
 import { dropDuplicated } from "./dropDuplicated";
 import { dropBlank } from "./dropBlank";
-import { calculateReplaceRangeByBracketStack } from "./calculateReplaceRangeByBracketStack";
-import { calculateReplaceRangeBySyntax, supportedLanguages } from "./calculateReplaceRangeBySyntax";
+import { calculateReplaceRange } from "./calculateReplaceRange";
 
 export async function preCacheProcess(
   context: CompletionContext,
@@ -41,17 +39,6 @@ export async function postCacheProcess(
     .then(applyFilter(formatIndentation(), context))
     .then(applyFilter(dropDuplicated(), context))
     .then(applyFilter(trimSpace(), context))
-    .then(applyFilter(dropBlank(), context));
-}
-
-export async function calculateReplaceRange(
-  context: CompletionContext,
-  config: AgentConfig["postprocess"],
-  response: CompletionResponse,
-): Promise<CompletionResponse> {
-  return isBrowser || // syntax parser is not supported in browser yet
-    !config["calculateReplaceRange"].experimentalSyntax ||
-    !supportedLanguages.includes(context.language)
-    ? calculateReplaceRangeByBracketStack(response, context)
-    : calculateReplaceRangeBySyntax(response, context);
+    .then(applyFilter(dropBlank(), context))
+    .then(applyChoiceFilter(calculateReplaceRange(config["calculateReplaceRange"]), context));
 }

--- a/clients/tabby-agent/src/postprocess/limitScope.ts
+++ b/clients/tabby-agent/src/postprocess/limitScope.ts
@@ -1,21 +1,23 @@
 import { CompletionContext } from "../CompletionContext";
 import { AgentConfig } from "../AgentConfig";
 import { isBrowser } from "../env";
-import { PostprocessFilter } from "./base";
+import { PostprocessFilter, logger } from "./base";
 import { limitScopeByIndentation } from "./limitScopeByIndentation";
-import { limitScopeBySyntax, supportedLanguages } from "./limitScopeBySyntax";
+import { limitScopeBySyntax } from "./limitScopeBySyntax";
 
 export function limitScope(config: AgentConfig["postprocess"]["limitScope"]): PostprocessFilter {
-  return isBrowser
-    ? (input: string, context: CompletionContext) => {
-        // syntax parser is not supported in browser yet
-        return limitScopeByIndentation(config["indentation"])(input, context);
+  return async (input: string, context: CompletionContext) => {
+    const preferSyntaxParser =
+      !isBrowser && // syntax parser is not supported in browser yet
+      config.experimentalSyntax;
+
+    if (preferSyntaxParser) {
+      try {
+        return await limitScopeBySyntax()(input, context);
+      } catch (error) {
+        logger.debug({ error }, "Failed to limit scope by syntax parser");
       }
-    : (input: string, context: CompletionContext) => {
-        if (config.experimentalSyntax && supportedLanguages.includes(context.language)) {
-          return limitScopeBySyntax()(input, context);
-        } else {
-          return limitScopeByIndentation(config["indentation"])(input, context);
-        }
-      };
+    }
+    return limitScopeByIndentation(config["indentation"])(input, context);
+  };
 }

--- a/clients/tabby-agent/src/postprocess/limitScopeBySyntax.ts
+++ b/clients/tabby-agent/src/postprocess/limitScopeBySyntax.ts
@@ -55,7 +55,7 @@ export function limitScopeBySyntax(): PostprocessFilter {
   return async (input: string, context: CompletionContext) => {
     const { position, text, language, prefix, suffix } = context;
     if (!supportedLanguages.includes(language)) {
-      return input;
+      throw new Error(`Language ${language} is not supported`);
     }
     const languageConfig = languagesConfigs[language]!;
     const parser = await getParser(languageConfig);
@@ -69,7 +69,23 @@ export function limitScopeBySyntax(): PostprocessFilter {
       typeList[languageConfig] ?? [],
     );
 
+    if (scope.type == "ERROR") {
+      throw new Error("Cannot determine syntax scope.");
+    }
+
     if (scope.endIndex < position + input.length) {
+      console.log(
+        {
+          languageConfig,
+          text,
+          updatedText,
+          position,
+          lineBegin,
+          lineEnd,
+          scope: { type: scope.type, start: scope.startIndex, end: scope.endIndex },
+        },
+        "Remove content out of syntax scope",
+      );
       logger.debug(
         {
           languageConfig,

--- a/clients/tabby-agent/src/postprocess/limitScopeBySyntax.ts
+++ b/clients/tabby-agent/src/postprocess/limitScopeBySyntax.ts
@@ -74,18 +74,6 @@ export function limitScopeBySyntax(): PostprocessFilter {
     }
 
     if (scope.endIndex < position + input.length) {
-      console.log(
-        {
-          languageConfig,
-          text,
-          updatedText,
-          position,
-          lineBegin,
-          lineEnd,
-          scope: { type: scope.type, start: scope.startIndex, end: scope.endIndex },
-        },
-        "Remove content out of syntax scope",
-      );
       logger.debug(
         {
           languageConfig,

--- a/clients/tabby-agent/src/postprocess/postprocess.test.ts
+++ b/clients/tabby-agent/src/postprocess/postprocess.test.ts
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import { deepmerge } from "deepmerge-ts";
 import { AgentConfig, defaultAgentConfig } from "../AgentConfig";
 import { CompletionContext, CompletionResponse } from "../CompletionContext";
-import { preCacheProcess, postCacheProcess, calculateReplaceRange } from ".";
+import { preCacheProcess, postCacheProcess } from ".";
 
 type PostprocessConfig = AgentConfig["postprocess"];
 
@@ -76,7 +76,6 @@ describe("postprocess golden test", () => {
   const postprocess = async (context: CompletionContext, config: PostprocessConfig, response: CompletionResponse) => {
     let processed = await preCacheProcess(context, config, response);
     processed = await postCacheProcess(context, config, processed);
-    processed = await calculateReplaceRange(context, config, processed);
     return processed;
   };
 


### PR DESCRIPTION
Changes: 
- Refactor `calculateReplaceRange` as a postprocess filter, will be invoked by `postCacheProcess`.
- Make syntaxBased filter fallback to non-SyntaxBased filter when syntax parser error.

Fix TAB-365