### PR TITLE
fix(agent): fix tree-shaking file-stream-rotator in building browser scripts.

### DIFF
--- a/clients/tabby-agent/tsup.config.ts
+++ b/clients/tabby-agent/tsup.config.ts
@@ -56,7 +56,7 @@ export default async () => [
         polyfills: { fs: true },
       }),
       // Mark sideEffects false for tree-shaking unused libraries in browser.
-      markSideEffects(false, ["chokidar", "rotating-file-stream"]),
+      markSideEffects(false, ["chokidar", "file-stream-rotator"]),
     ],
     esbuildOptions(options) {
       defineEnvs(options, { browser: true });


### PR DESCRIPTION
follow #1077 