### PR TITLE
fix(webserver): ignore .git for /repositories resolve api

### DIFF
--- a/ee/tabby-webserver/src/repositories/mod.rs
+++ b/ee/tabby-webserver/src/repositories/mod.rs
@@ -23,10 +23,13 @@ use crate::{
 
 pub fn routes(locator: Arc<dyn ServiceLocator>) -> Router {
     Router::new()
+        .route("/:name/resolve/.git/", routing::get(not_found))
+        .route("/:name/resolve/.git/*path", routing::get(not_found))
         .route("/:name/resolve/", routing::get(repositories::resolve))
         .route("/:name/resolve/*path", routing::get(repositories::resolve))
         .route("/:name/meta/", routing::get(repositories::meta))
         .route("/:name/meta/*path", routing::get(repositories::meta))
+        .fallback(not_found)
         .layer(from_fn_with_state(locator, require_login_middleware))
 }
 
@@ -51,6 +54,10 @@ async fn require_login_middleware(
     };
 
     next.run(request).await
+}
+
+async fn not_found() -> StatusCode {
+    StatusCode::NOT_FOUND
 }
 
 #[instrument(skip(repo))]


### PR DESCRIPTION
Follow up of issue: https://github.com/TabbyML/tabby/issues/815#issuecomment-1870146269

- ignore `.git` directory from resolve api, return `404` directly
- add fallback handling