### PR TITLE
fix(vscode): remove the clipboard accessing in getting inline completion.

### DIFF
--- a/clients/vscode/src/TabbyCompletionProvider.ts
+++ b/clients/vscode/src/TabbyCompletionProvider.ts
@@ -9,7 +9,6 @@ import {
   TextDocument,
   NotebookDocument,
   NotebookRange,
-  env,
   window,
   workspace,
 } from "vscode";
@@ -73,7 +72,6 @@ export class TabbyCompletionProvider extends EventEmitter implements InlineCompl
       text: additionalContext.prefix + document.getText() + additionalContext.suffix,
       position: additionalContext.prefix.length + document.offsetAt(position),
       indentation: this.getEditorIndentation(),
-      clipboard: await env.clipboard.readText(),
       manually: context.triggerKind === InlineCompletionTriggerKind.Invoke,
     };
 


### PR DESCRIPTION
Follow up #885 

Remove the clipboard reading in every code completion request for now, considering: 
- The clipboard content have not been used as prompt for now.
- In the browser enviroment, reading clipboard causes the browser prompts the user for clipboard permission once user editing a file.