### PR TITLE
feat(webserver): complete `github_auth` method

### DIFF
--- a/ee/tabby-db/src/invitations.rs
+++ b/ee/tabby-db/src/invitations.rs
@@ -69,6 +69,24 @@ impl DbConn {
         Ok(token?)
     }
 
+    pub async fn get_invitation_by_email(&self, email: &str) -> Result<Option<InvitationDAO>> {
+        let email = email.to_owned();
+        let token = self
+            .conn
+            .call(|conn| {
+                Ok(conn
+                    .query_row(
+                        r#"SELECT id, email, code, created_at FROM invitations WHERE email = ?"#,
+                        [email],
+                        InvitationDAO::from_row,
+                    )
+                    .optional())
+            })
+            .await?;
+
+        Ok(token?)
+    }
+
     pub async fn create_invitation(&self, email: String) -> Result<i32> {
         if self.get_user_by_email(&email).await?.is_some() {
             return Err(anyhow!("User already registered"));

--- a/ee/tabby-webserver/src/oauth/mod.rs
+++ b/ee/tabby-webserver/src/oauth/mod.rs
@@ -62,6 +62,7 @@ async fn github_callback(
         }
         Err(GithubAuthError::InvalidVerificationCode) => Err(StatusCode::BAD_REQUEST),
         Err(GithubAuthError::CredentialNotActive) => Err(StatusCode::NOT_FOUND),
+        Err(GithubAuthError::UserNotInvited) => Err(StatusCode::UNAUTHORIZED),
         Err(e) => {
             error!("Failed to authenticate with Github: {:?}", e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)

--- a/ee/tabby-webserver/src/schema/auth.rs
+++ b/ee/tabby-webserver/src/schema/auth.rs
@@ -159,6 +159,9 @@ pub enum GithubAuthError {
     #[error("The Github credential is not active")]
     CredentialNotActive,
 
+    #[error("The user is not invited to access the system")]
+    UserNotInvited,
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -365,6 +365,10 @@ impl AuthenticationService for DbConn {
             let Some(invitation) = self.get_invitation_by_email(&email).await? else {
                 return Err(GithubAuthError::UserNotInvited);
             };
+            // it's ok to set password to empty string here, because
+            // 1. both `register` & `token_auth` mutation will do input validation, so empty password won't be accepted
+            // 2. `password_verify` will always return false for empty password hash read from user table
+            // so user created here is only able to login by github oauth, normal login won't work
             let id = self
                 .create_user_with_invitation(email, "".to_owned(), false, invitation.id)
                 .await?;

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -187,7 +187,7 @@ impl AuthenticationService for DbConn {
                 !is_admin_initialized,
                 invitation.id,
             )
-                .await?
+            .await?
         } else {
             self.create_user(input.email.clone(), pwd_hash, !is_admin_initialized)
                 .await?
@@ -199,9 +199,9 @@ impl AuthenticationService for DbConn {
         self.create_refresh_token(id, &refresh_token).await?;
 
         let Ok(access_token) = generate_jwt(JWTPayload::new(user.email.clone(), user.is_admin))
-            else {
-                return Err(RegisterError::Unknown);
-            };
+        else {
+            return Err(RegisterError::Unknown);
+        };
 
         let resp = RegisterResponse::new(access_token, refresh_token);
         Ok(resp)
@@ -227,9 +227,9 @@ impl AuthenticationService for DbConn {
         self.create_refresh_token(user.id, &refresh_token).await?;
 
         let Ok(access_token) = generate_jwt(JWTPayload::new(user.email.clone(), user.is_admin))
-            else {
-                return Err(TokenAuthError::Unknown);
-            };
+        else {
+            return Err(TokenAuthError::Unknown);
+        };
 
         let resp = TokenAuthResponse::new(access_token, refresh_token);
         Ok(resp)
@@ -254,9 +254,9 @@ impl AuthenticationService for DbConn {
 
         // refresh token update is done, generate new access token based on user info
         let Ok(access_token) = generate_jwt(JWTPayload::new(user.email.clone(), user.is_admin))
-            else {
-                return Err(RefreshTokenError::Unknown);
-            };
+        else {
+            return Err(RefreshTokenError::Unknown);
+        };
 
         let resp = RefreshTokenResponse::new(access_token, new_token, refresh_token.expires_at);
 
@@ -359,16 +359,17 @@ impl AuthenticationService for DbConn {
 
         let email = client.fetch_user_email(code, credential).await?;
 
-        let user =
-            if let Some(user) = self.get_user_by_email(&email).await? {
-                user
-            } else {
-                let Some(invitation) = self.get_invitation_by_email(&email).await? else {
-                    return Err(GithubAuthError::UserNotInvited);
-                };
-                let id = self.create_user_with_invitation(email, "".to_owned(), false, invitation.id).await?;
-                self.get_user(id).await?.unwrap()
+        let user = if let Some(user) = self.get_user_by_email(&email).await? {
+            user
+        } else {
+            let Some(invitation) = self.get_invitation_by_email(&email).await? else {
+                return Err(GithubAuthError::UserNotInvited);
             };
+            let id = self
+                .create_user_with_invitation(email, "".to_owned(), false, invitation.id)
+                .await?;
+            self.get_user(id).await?.unwrap()
+        };
 
         let refresh_token = generate_refresh_token();
         self.create_refresh_token(user.id, &refresh_token).await?;
@@ -435,8 +436,8 @@ mod tests {
             ADMIN_PASSWORD.to_owned(),
             None,
         )
-            .await
-            .unwrap()
+        .await
+        .unwrap()
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow up of PR: https://github.com/TabbyML/tabby/pull/1160

During oauth login by github

- first, check if user exists, if so, skip password verification, generate access/refresh token for the user
- if user not exist, check if user has been invited, if so, register user with empty password, then generate tokens
- if user not exist & not invited, return `401`
