### PR TITLE
feat(agent): add lsp support to agent.

### DIFF
--- a/clients/tabby-agent/README.md
+++ b/clients/tabby-agent/README.md
@@ -1,0 +1,80 @@
+# Tabby agent
+
+The Tabby Agent is an agent used for communication with the Tabby server. It is based on Node.js v18 and implements several common features to enhance code completion, including caching, debouncing, and post-processing.
+
+This package exports both libraries and a CLI tool.
+
+## Language Server (Unreleased)
+
+To run the agent as a language server, you can pass the argument `--lsp` and an additional IO option to the CLI tool. The available IO options are `--stdio`, `--node-ipc` or `--socket=<PORT>`.
+
+```bash
+npx tabby-agent --lsp --stdio
+```
+
+The language server provides the following features:
+
+- Completion
+- Inline Completion (WIP, upcoming LSP v3.18 feature)
+
+Since most text editors have their built-in LSP clients or popular LSP client plugins, you can easily connect to the Tabby agent language server from your editor. Here are some example configurations for popular editors.
+
+### VSCode
+
+A common way to add a new language server to VSCode is by creating a new extension. We provide an example extension for VSCode in [example-vscode-lsp](https://github.com/tabbyml/tabby/blob/master/clients/example-vscode-lsp).
+
+**Note**: Tabby provides an official extension for VSCode, you can install it from [marketplace](https://marketplace.visualstudio.com/items?itemName=tabbyml.vscode-tabby). The example provided here is just for reference on how to use the Tabby agent as a language server.
+
+### Emacs
+
+The package [lsp-mode](https://github.com/emacs-lsp/lsp-mode) provides an LSP client for Emacs. You can add the following code to your Emacs configuration script to use the Tabby agent as a language server.
+
+```emacs-lisp
+(with-eval-after-load 'lsp-mode
+  (lsp-register-client
+    (make-lsp-client  :new-connection (lsp-stdio-connection '("npx" "tabby-agent" "--lsp" "--stdio"))
+                      ;; you can select languages to enable Tabby language server
+                      :activation-fn (lsp-activate-on "typescript" "javascript" "toml")
+                      :priority 1
+                      :add-on? t
+                      :server-id 'tabby-agent)))
+```
+
+### Vim/Neovim
+
+There are several Vim/Neovim plugins that provide LSP support. One of them is [coc.nvim](https://github.com/neoclide/coc.nvim). To use the Tabby agent as a language server, you can add the following code to your :CocConfig.
+
+```json
+{
+  "languageserver": {
+    "tabby-agent": {
+      "command": "npx",
+      "args": ["tabby-agent", "--lsp", "--stdio"],
+      "filetypes": ["*"]
+    }
+  }
+}
+```
+
+### Helix
+
+[Helix](https://helix-editor.com/) has built-in LSP support. To use the Tabby agent as a language server, you can add the following code to your `languages.toml`.
+
+```toml
+[language-server.tabby]
+command = "npx"
+args = ["tabby-agent", "--lsp", "--stdio"]
+
+# Add Tabby as the second language server for your specific languages
+[[languages]]
+name = "typescript"
+language-servers = ["typescript-language-server", "tabby"]
+
+[[languages]]
+name = "toml"
+language-servers = ["taplo", "tabby"]
+```
+
+### More Editors
+
+You are welcome to contribute by adding example configurations for your favorite editor. Please submit a PR with your additions.

--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -58,6 +58,8 @@
     "stats-logscale": "^1.0.7",
     "toml": "^3.0.0",
     "uuid": "^9.0.0",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.11",
     "web-tree-sitter": "^0.20.8"
   }
 }

--- a/clients/tabby-agent/src/LspServer.ts
+++ b/clients/tabby-agent/src/LspServer.ts
@@ -1,0 +1,202 @@
+import {
+  createConnection,
+  TextDocuments,
+  TextDocumentSyncKind,
+  InitializeParams,
+  InitializeResult,
+  ShowMessageParams,
+  MessageType,
+  CompletionParams,
+  CompletionList,
+  CompletionItem,
+  CompletionItemKind,
+  TextDocumentPositionParams,
+} from "vscode-languageserver/node";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { name as agentName, version as agentVersion } from "../package.json";
+import { Agent, StatusChangedEvent, CompletionRequest, CompletionResponse } from "./Agent";
+import { rootLogger } from "./logger";
+import { splitLines, isCanceledError } from "./utils";
+
+export class LspServer {
+  private readonly connection = createConnection();
+  private readonly documents = new TextDocuments(TextDocument);
+
+  private readonly logger = rootLogger.child({ component: "LspServer" });
+
+  private agent?: Agent;
+
+  constructor() {
+    this.connection.onInitialize(async (params) => {
+      return await this.initialize(params);
+    });
+    this.connection.onShutdown(async () => {
+      return await this.shutdown();
+    });
+    this.connection.onExit(async () => {
+      return await this.exit();
+    });
+    this.connection.onCompletion(async (params) => {
+      return await this.completion(params);
+    });
+  }
+
+  bind(agent: Agent): void {
+    this.agent = agent;
+
+    this.agent.on("statusChanged", (event: StatusChangedEvent) => {
+      if (event.status === "disconnected" || event.status === "unauthorized") {
+        this.showMessage({
+          type: MessageType.Warning,
+          message: `Tabby agent status: ${event.status}`,
+        });
+      }
+    });
+  }
+
+  listen() {
+    this.documents.listen(this.connection);
+    this.connection.listen();
+  }
+
+  // LSP interface methods
+
+  async initialize(params: InitializeParams): Promise<InitializeResult> {
+    this.logger.debug({ params }, "LSP: initialize: request");
+    if (!this.agent) {
+      throw new Error(`Agent not bound.\n`);
+    }
+
+    const { clientInfo, capabilities } = params;
+    if (capabilities.textDocument?.inlineCompletion) {
+      // TODO: use inlineCompletion prefer to completion
+    }
+
+    await this.agent.initialize({
+      clientProperties: {
+        session: {
+          client: `${clientInfo?.name} ${clientInfo?.version ?? ""}`,
+        },
+      },
+    });
+
+    const result: InitializeResult = {
+      capabilities: {
+        textDocumentSync: {
+          openClose: true,
+          change: TextDocumentSyncKind.Incremental,
+        },
+        completionProvider: {},
+        // inlineCompletionProvider: {},
+      },
+      serverInfo: {
+        name: agentName,
+        version: agentVersion,
+      },
+    };
+    return result;
+  }
+
+  async shutdown() {
+    this.logger.debug("LSP: shutdown: request");
+    if (!this.agent) {
+      throw new Error(`Agent not bound.\n`);
+    }
+
+    await this.agent.finalize();
+  }
+
+  async exit() {
+    this.logger.debug("LSP: exit: request");
+    return process.exit(0);
+  }
+
+  async showMessage(params: ShowMessageParams) {
+    this.logger.debug({ params }, "LSP server notification: window/showMessage");
+    this.connection.sendNotification("window/showMessage", params);
+  }
+
+  async completion(params: CompletionParams): Promise<CompletionList> {
+    this.logger.debug({ params }, "LSP: textDocument/completion: request");
+    if (!this.agent) {
+      throw new Error(`Agent not bound.\n`);
+    }
+
+    try {
+      const request = await this.buildCompletionRequest(params);
+      this.logger.trace({ request }, "LSP: textDocument/completion: internalState: buildCompletionRequest");
+      const response = await this.agent.provideCompletions(request);
+      this.logger.trace({ response }, "LSP: textDocument/completion: internalState: provideCompletions");
+      const completionList = this.toCompletionList(response, params);
+      this.logger.debug({ completionList }, "LSP: textDocument/completion: response");
+      return completionList;
+    } catch (error) {
+      if (isCanceledError(error)) {
+        this.logger.debug({ error }, "LSP: textDocument/completion: canceled");
+      } else {
+        this.logger.error({ error }, "LSP: textDocument/completion: error");
+      }
+    }
+
+    return {
+      isIncomplete: true,
+      items: [],
+    };
+  }
+
+  private async buildCompletionRequest(
+    documentPosition: TextDocumentPositionParams,
+    manually: boolean = false,
+  ): Promise<CompletionRequest> {
+    const { textDocument, position } = documentPosition;
+    const document = this.documents.get(textDocument.uri)!;
+
+    const request: CompletionRequest = {
+      filepath: document.uri,
+      language: document.languageId,
+      text: document.getText(),
+      position: document.offsetAt(position),
+      manually,
+    };
+    return request;
+  }
+
+  private async toCompletionList(
+    response: CompletionResponse,
+    documentPosition: TextDocumentPositionParams,
+  ): Promise<CompletionList> {
+    const { textDocument } = documentPosition;
+    const document = this.documents.get(textDocument.uri)!;
+
+    return {
+      isIncomplete: false,
+      items: response.choices.map((choice): CompletionItem => {
+        const lines = splitLines(choice.text);
+        const firstLine = lines[0] || "";
+        const secondLine = lines[1] || "";
+        return {
+          label: firstLine,
+          labelDetails: {
+            detail: secondLine,
+            description: "Tabby",
+          },
+          kind: CompletionItemKind.Text,
+          detail: choice.text,
+          sortText: " ", // let suggestion by tabby sorted to te top
+          filterText: "\t", // filter text
+          textEdit: {
+            newText: choice.text,
+            range: {
+              start: document.positionAt(choice.replaceRange.start),
+              end: document.positionAt(choice.replaceRange.end),
+            },
+          },
+          data: {
+            completionId: response.id,
+            choiceIndex: choice.index,
+          },
+        };
+      }),
+    };
+  }
+}

--- a/clients/tabby-agent/src/cli.ts
+++ b/clients/tabby-agent/src/cli.ts
@@ -2,8 +2,16 @@
 
 import { TabbyAgent } from "./TabbyAgent";
 import { StdIO } from "./StdIO";
+import { LspServer } from "./LspServer";
 
-const stdio = new StdIO();
+const args = process.argv.slice(2);
+
+let server;
+if (args.indexOf("--lsp") >= 0) {
+  server = new LspServer();
+} else {
+  server = new StdIO();
+}
 const agent = new TabbyAgent();
-stdio.bind(agent);
-stdio.listen();
+server.bind(agent);
+server.listen();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,6 +4209,36 @@ vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vscode-jsonrpc@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
+  integrity sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==
+
+vscode-languageserver-protocol@3.17.5:
+  version "3.17.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz#864a8b8f390835572f4e13bd9f8313d0e3ac4bea"
+  integrity sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==
+  dependencies:
+    vscode-jsonrpc "8.2.0"
+    vscode-languageserver-types "3.17.5"
+
+vscode-languageserver-textdocument@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz#0822a000e7d4dc083312580d7575fe9e3ba2e2bf"
+  integrity sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==
+
+vscode-languageserver-types@3.17.5:
+  version "3.17.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
+  integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
+
+vscode-languageserver@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz#500aef82097eb94df90d008678b0b6b5f474015b"
+  integrity sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==
+  dependencies:
+    vscode-languageserver-protocol "3.17.5"
+
 vscode-uri@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"


### PR DESCRIPTION
Add basic lsp support.
Complete TAB-388

Add command line arg `--lsp` will run agent as a lsp server.

Supported client -> server method:

- initialize
- shutdown
- exit
- textDocument/completion

Used server -> client method:
- window/showMessage
  - show warning when disconnected