### PR TITLE
feat: Remove 'active' field from OAuth credentials

### DIFF
--- a/ee/tabby-db/migrations/06-github-oauth-credential/up.sql
+++ b/ee/tabby-db/migrations/06-github-oauth-credential/up.sql
@@ -2,7 +2,6 @@ CREATE TABLE github_oauth_credential (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     client_id     VARCHAR(32) NOT NULL,
     client_secret VARCHAR(64) NOT NULL,
-    active        BOOLEAN DEFAULT (1),
     created_at    TIMESTAMP DEFAULT (DATETIME('now')),
     updated_at    TIMESTAMP DEFAULT (DATETIME('now'))
 );

--- a/ee/tabby-db/src/github_oauth_credential.rs
+++ b/ee/tabby-db/src/github_oauth_credential.rs
@@ -133,6 +133,10 @@ mod tests {
         assert_eq!(res.client_id, "client_id");
         assert_eq!(res.client_secret, "client_secret_2");
 
+        // test delete
+        conn.delete_github_oauth_credential().await.unwrap();
+        assert!(conn.read_github_oauth_credential().await.unwrap().is_none());
+
         // test update without client_secret
         conn.update_github_oauth_credential("client_id_2", None)
             .await

--- a/ee/tabby-webserver/src/schema/auth.rs
+++ b/ee/tabby-webserver/src/schema/auth.rs
@@ -408,7 +408,7 @@ pub trait AuthenticationService: Send + Sync {
         &self,
         provider: OAuthProvider,
         client_id: String,
-        client_secret: Option<String>,
+        client_secret: String,
     ) -> Result<()>;
 
     async fn delete_oauth_credential(&self, provider: OAuthProvider) -> Result<()>;

--- a/ee/tabby-webserver/src/schema/auth.rs
+++ b/ee/tabby-webserver/src/schema/auth.rs
@@ -344,7 +344,6 @@ pub enum OAuthProvider {
 pub struct OAuthCredential {
     pub provider: OAuthProvider,
     pub client_id: String,
-    pub active: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -410,8 +409,9 @@ pub trait AuthenticationService: Send + Sync {
         provider: OAuthProvider,
         client_id: String,
         client_secret: Option<String>,
-        active: bool,
     ) -> Result<()>;
+
+    async fn delete_oauth_credential(&self, provider: OAuthProvider) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/ee/tabby-webserver/src/schema/dao.rs
+++ b/ee/tabby-webserver/src/schema/dao.rs
@@ -48,7 +48,6 @@ impl From<GithubOAuthCredentialDAO> for OAuthCredential {
         OAuthCredential {
             provider: OAuthProvider::Github,
             client_id: val.client_id,
-            active: val.active,
             created_at: val.created_at,
             updated_at: val.updated_at,
         }

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -363,7 +363,6 @@ impl Mutation {
         provider: OAuthProvider,
         client_id: String,
         client_secret: Option<String>,
-        _active: bool,
     ) -> Result<bool> {
         if let Some(claims) = &ctx.claims {
             if claims.is_admin {

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -369,7 +369,7 @@ impl Mutation {
             if claims.is_admin {
                 ctx.locator
                     .auth()
-                    .update_oauth_credential(provider, client_id, client_secret, active)
+                    .update_oauth_credential(provider, client_id, client_secret)
                     .await?;
                 return Ok(true);
             }

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -363,7 +363,7 @@ impl Mutation {
         provider: OAuthProvider,
         client_id: String,
         client_secret: Option<String>,
-        active: bool,
+        _active: bool,
     ) -> Result<bool> {
         if let Some(claims) = &ctx.claims {
             if claims.is_admin {

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -362,7 +362,7 @@ impl Mutation {
         ctx: &Context,
         provider: OAuthProvider,
         client_id: String,
-        client_secret: Option<String>,
+        client_secret: String,
     ) -> Result<bool> {
         if let Some(claims) = &ctx.claims {
             if claims.is_admin {

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -353,9 +353,6 @@ impl AuthenticationService for DbConn {
             .read_github_oauth_credential()
             .await?
             .ok_or(GithubAuthError::CredentialNotActive)?;
-        if !credential.active {
-            return Err(GithubAuthError::CredentialNotActive);
-        }
 
         let email = client.fetch_user_email(code, credential).await?;
 
@@ -404,12 +401,17 @@ impl AuthenticationService for DbConn {
         provider: OAuthProvider,
         client_id: String,
         client_secret: Option<String>,
-        active: bool,
     ) -> Result<()> {
         match provider {
             OAuthProvider::Github => Ok(self
-                .update_github_oauth_credential(&client_id, client_secret.as_deref(), active)
+                .update_github_oauth_credential(&client_id, client_secret.as_deref())
                 .await?),
+        }
+    }
+
+    async fn delete_oauth_credential(&self, provider: OAuthProvider) -> Result<()> {
+        match provider {
+            OAuthProvider::Github => self.delete_github_oauth_credential().await,
         }
     }
 }

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -400,11 +400,11 @@ impl AuthenticationService for DbConn {
         &self,
         provider: OAuthProvider,
         client_id: String,
-        client_secret: Option<String>,
+        client_secret: String,
     ) -> Result<()> {
         match provider {
             OAuthProvider::Github => Ok(self
-                .update_github_oauth_credential(&client_id, client_secret.as_deref())
+                .update_github_oauth_credential(&client_id, &client_secret)
                 .await?),
         }
     }


### PR DESCRIPTION
Removes the active field and determines active status based on whether the credential is present or not