### PR TITLE
feat(webserver): Add Google oauth support

### DIFF
--- a/ee/tabby-db/migrations/09-google-oauth-credential/down.sql
+++ b/ee/tabby-db/migrations/09-google-oauth-credential/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE google_oauth_credential;

--- a/ee/tabby-db/migrations/09-google-oauth-credential/up.sql
+++ b/ee/tabby-db/migrations/09-google-oauth-credential/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE google_oauth_credential (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    client_id     VARCHAR(256) NOT NULL,
+    client_secret VARCHAR(64) NOT NULL,
+    redirect_uri  VARCHAR(256) NOT NULL,
+    created_at    TIMESTAMP DEFAULT (DATETIME('now')),
+    updated_at    TIMESTAMP DEFAULT (DATETIME('now'))
+);

--- a/ee/tabby-db/src/google_oauth_credential.rs
+++ b/ee/tabby-db/src/google_oauth_credential.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use rusqlite::{named_params, OptionalExtension};
+
+use super::DbConn;
+
+const GOOGLE_OAUTH_CREDENTIAL_ROW_ID: i32 = 1;
+
+pub struct GoogleOAuthCredentialDAO {
+    pub client_id: String,
+    pub client_secret: String,
+    pub redirect_uri: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl GoogleOAuthCredentialDAO {
+    fn from_row(row: &rusqlite::Row<'_>) -> std::result::Result<Self, rusqlite::Error> {
+        Ok(Self {
+            client_id: row.get(0)?,
+            client_secret: row.get(1)?,
+            redirect_uri: row.get(2)?,
+            created_at: row.get(3)?,
+            updated_at: row.get(4)?,
+        })
+    }
+}
+
+/// db read/write operations for `google_oauth_credential` table
+impl DbConn {
+    pub async fn update_google_oauth_credential(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+        redirect_uri: Option<&str>,
+    ) -> Result<()> {
+        let redirect_uri = redirect_uri.unwrap_or_default().to_string();
+        if !client_secret.is_empty() {
+            let client_id = client_id.to_string();
+            let client_secret = client_secret.to_string();
+            let sql = r#"INSERT INTO google_oauth_credential (id, client_id, client_secret, redirect_uri)
+                                VALUES (:id, :cid, :secret, :redirect) ON CONFLICT(id) DO UPDATE
+                                SET client_id = :cid, client_secret = :secret, redirect_uri = :redirect, updated_at = datetime('now')
+                                WHERE id = :id"#;
+            self.conn
+                .call(move |c| {
+                    let mut stmt = c.prepare(sql)?;
+                    stmt.insert(named_params! {
+                    ":id": GOOGLE_OAUTH_CREDENTIAL_ROW_ID,
+                    ":cid": client_id,
+                    ":secret": client_secret,
+                    ":redirect": redirect_uri,
+                    })?;
+                    Ok(())
+                })
+                .await?;
+            Ok(())
+        } else {
+            let sql = r#"
+            UPDATE google_oauth_credential SET redirect_uri = :redirect, updated_at = datetime('now')
+            WHERE id = :id"#;
+            let rows = self
+                .conn
+                .call(move |c| {
+                    let mut stmt = c.prepare(sql)?;
+                    let rows = stmt.execute(named_params! {
+                    ":id": GOOGLE_OAUTH_CREDENTIAL_ROW_ID,
+                    ":redirect": redirect_uri,
+                    })?;
+                    Ok(rows)
+                })
+                .await?;
+            if rows != 1 {
+                return Err(anyhow::anyhow!(
+                    "failed to update: google credential not found"
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    pub async fn read_google_oauth_credential(&self) -> Result<Option<GoogleOAuthCredentialDAO>> {
+        let token = self
+            .conn
+            .call(|conn| {
+                Ok(conn
+                    .query_row(
+                        r#"SELECT client_id, client_secret, redirect_uri, created_at, updated_at FROM google_oauth_credential WHERE id = ?"#,
+                        [GOOGLE_OAUTH_CREDENTIAL_ROW_ID],
+                        GoogleOAuthCredentialDAO::from_row,
+                    )
+                    .optional())
+            })
+            .await?;
+
+        Ok(token?)
+    }
+
+    pub async fn delete_google_oauth_credential(&self) -> Result<()> {
+        Ok(self
+            .conn
+            .call(move |c| {
+                c.execute(
+                    "DELETE FROM google_oauth_credential WHERE id = ?",
+                    [GOOGLE_OAUTH_CREDENTIAL_ROW_ID],
+                )?;
+                Ok(())
+            })
+            .await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_update_google_oauth_credential() {
+        let conn = DbConn::new_in_memory().await.unwrap();
+
+        // test update failure when no record exists
+        let res = conn
+            .update_google_oauth_credential("", "", Some("http://localhost"))
+            .await;
+        assert!(res.is_err());
+
+        // test insert
+        conn.update_google_oauth_credential("client_id", "client_secret", None)
+            .await
+            .unwrap();
+        let res = conn.read_google_oauth_credential().await.unwrap().unwrap();
+        assert_eq!(res.client_id, "client_id");
+        assert_eq!(res.client_secret, "client_secret");
+        assert_eq!(res.redirect_uri, "");
+
+        // test delete
+        conn.delete_google_oauth_credential().await.unwrap();
+        let res = conn.read_google_oauth_credential().await.unwrap();
+        assert!(res.is_none());
+
+        // test insert with redirect_uri
+        conn.update_google_oauth_credential("client_id", "client_secret", Some("http://localhost"))
+            .await
+            .unwrap();
+        let res = conn.read_google_oauth_credential().await.unwrap().unwrap();
+        assert_eq!(res.client_id, "client_id");
+        assert_eq!(res.client_secret, "client_secret");
+        assert_eq!(res.redirect_uri, "http://localhost");
+
+        // test update
+        conn.update_google_oauth_credential(
+            "client_id_2",
+            "client_secret_2",
+            Some("http://127.0.0.1"),
+        )
+        .await
+        .unwrap();
+        let res = conn.read_google_oauth_credential().await.unwrap().unwrap();
+        assert_eq!(res.client_id, "client_id_2");
+        assert_eq!(res.client_secret, "client_secret_2");
+        assert_eq!(res.redirect_uri, "http://127.0.0.1");
+
+        // test update redirect_uri
+        conn.update_google_oauth_credential("", "", Some("http://localhost"))
+            .await
+            .unwrap();
+        let res = conn.read_google_oauth_credential().await.unwrap().unwrap();
+        assert_eq!(res.client_id, "client_id_2");
+        assert_eq!(res.client_secret, "client_secret_2");
+        assert_eq!(res.redirect_uri, "http://localhost");
+    }
+}

--- a/ee/tabby-db/src/lib.rs
+++ b/ee/tabby-db/src/lib.rs
@@ -1,11 +1,13 @@
 pub use email_service_credential::EmailServiceCredentialDAO;
 pub use github_oauth_credential::GithubOAuthCredentialDAO;
+pub use google_oauth_credential::GoogleOAuthCredentialDAO;
 pub use invitations::InvitationDAO;
 pub use job_runs::JobRunDAO;
 pub use users::UserDAO;
 
 mod email_service_credential;
 mod github_oauth_credential;
+mod google_oauth_credential;
 mod invitations;
 mod job_runs;
 mod path;

--- a/ee/tabby-webserver/src/oauth/github.rs
+++ b/ee/tabby-webserver/src/oauth/github.rs
@@ -27,23 +27,12 @@ struct GithubUserEmail {
     visibility: String,
 }
 
+#[derive(Default)]
 pub struct GithubClient {
     client: reqwest::Client,
 }
 
-impl Default for GithubClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl GithubClient {
-    pub fn new() -> Self {
-        Self {
-            client: reqwest::Client::new(),
-        }
-    }
-
     pub async fn fetch_user_email(
         &self,
         code: String,

--- a/ee/tabby-webserver/src/oauth/google.rs
+++ b/ee/tabby-webserver/src/oauth/google.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use serde::Deserialize;
+use tabby_db::GoogleOAuthCredentialDAO;
+
+#[derive(Debug, Deserialize)]
+struct GoogleOAuthResponse {
+    #[serde(default)]
+    access_token: String,
+    #[serde(default)]
+    expires_in: i32,
+    #[serde(default)]
+    token_type: String,
+    #[serde(default)]
+    scope: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleOAuthError {
+    code: i32,
+    message: String,
+    status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleUserEmail {
+    #[serde(default)]
+    email: String,
+    error: Option<GoogleOAuthError>,
+}
+
+#[derive(Default)]
+pub struct GoogleClient {
+    client: reqwest::Client,
+}
+
+impl GoogleClient {
+    pub async fn fetch_user_email(
+        &self,
+        code: String,
+        credential: GoogleOAuthCredentialDAO,
+    ) -> Result<String> {
+        let token_resp = self.exchange_access_token(code, credential).await?;
+        if token_resp.access_token.is_empty() {
+            return Err(anyhow::anyhow!("Empty access token from Google OAuth"));
+        }
+
+        let resp = self
+            .client
+            .get("https://www.googleapis.com/oauth2/v2/userinfo?alt=json&fields=email")
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {}", token_resp.access_token),
+            )
+            .send()
+            .await?
+            .json::<GoogleUserEmail>()
+            .await?;
+
+        if let Some(err) = resp.error {
+            return Err(anyhow::anyhow!(err.message));
+        }
+        Ok(resp.email)
+    }
+
+    async fn exchange_access_token(
+        &self,
+        code: String,
+        credential: GoogleOAuthCredentialDAO,
+    ) -> Result<GoogleOAuthResponse> {
+        let params = [
+            ("client_id", credential.client_id.as_str()),
+            ("client_secret", credential.client_secret.as_str()),
+            ("code", code.as_str()),
+            ("grant_type", "authorization_code"),
+            ("redirect_uri", credential.redirect_uri.as_str()),
+        ];
+        let resp = self
+            .client
+            .post("https://oauth2.googleapis.com/token")
+            .form(&params)
+            .send()
+            .await?
+            .json::<GoogleOAuthResponse>()
+            .await?;
+
+        Ok(resp)
+    }
+}

--- a/ee/tabby-webserver/src/oauth/mod.rs
+++ b/ee/tabby-webserver/src/oauth/mod.rs
@@ -10,31 +10,41 @@ use serde::Deserialize;
 use tracing::error;
 
 use crate::{
-    oauth::github::GithubClient,
+    oauth::{github::GithubClient, google::GoogleClient},
     schema::{
-        auth::{AuthenticationService, GithubAuthError},
+        auth::{AuthenticationService, OAuthError, OAuthResponse},
         ServiceLocator,
     },
 };
 
 pub mod github;
+pub mod google;
+
+pub enum OAuthClient {
+    Github(Arc<GithubClient>),
+    Google(Arc<GoogleClient>),
+}
 
 #[derive(Clone)]
 #[non_exhaustive]
 struct OAuthState {
     auth: Arc<dyn AuthenticationService>,
     github_client: Arc<GithubClient>,
+    google_client: Arc<GoogleClient>,
 }
 
 pub fn routes(auth: Arc<dyn AuthenticationService>) -> Router {
     let state = OAuthState {
         auth,
-        github_client: Arc::new(GithubClient::new()),
+        github_client: Arc::new(GithubClient::default()),
+        google_client: Arc::new(GoogleClient::default()),
     };
 
     Router::new()
         .route("/github", routing::get(github_callback))
-        .with_state(state)
+        .with_state(state.clone())
+        .route("/google", routing::get(google_callback))
+        .with_state(state.clone())
 }
 
 #[derive(Deserialize)]
@@ -48,11 +58,42 @@ async fn github_callback(
     State(state): State<OAuthState>,
     Query(param): Query<GithubCallbackParam>,
 ) -> Result<Redirect, StatusCode> {
-    match state
-        .auth
-        .github_auth(param.code, state.github_client.clone())
-        .await
-    {
+    match_auth_result(
+        state
+            .auth
+            .oauth(param.code, OAuthClient::Github(state.github_client.clone()))
+            .await,
+    )
+}
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+struct GoogleCallbackParam {
+    #[serde(default)]
+    code: String,
+    #[serde(default)]
+    scope: String,
+    #[serde(default)]
+    error: String,
+}
+
+async fn google_callback(
+    State(state): State<OAuthState>,
+    Query(param): Query<GoogleCallbackParam>,
+) -> Result<Redirect, StatusCode> {
+    if !param.error.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    match_auth_result(
+        state
+            .auth
+            .oauth(param.code, OAuthClient::Google(state.google_client.clone()))
+            .await,
+    )
+}
+
+fn match_auth_result(result: Result<OAuthResponse, OAuthError>) -> Result<Redirect, StatusCode> {
+    match result {
         Ok(resp) => {
             let uri = format!(
                 "/auth/signin?refresh_token={}&access_token={}",
@@ -60,11 +101,11 @@ async fn github_callback(
             );
             Ok(Redirect::temporary(&uri))
         }
-        Err(GithubAuthError::InvalidVerificationCode) => Err(StatusCode::BAD_REQUEST),
-        Err(GithubAuthError::CredentialNotActive) => Err(StatusCode::NOT_FOUND),
-        Err(GithubAuthError::UserNotInvited) => Err(StatusCode::UNAUTHORIZED),
+        Err(OAuthError::InvalidVerificationCode) => Err(StatusCode::BAD_REQUEST),
+        Err(OAuthError::CredentialNotActive) => Err(StatusCode::NOT_FOUND),
+        Err(OAuthError::UserNotInvited) => Err(StatusCode::UNAUTHORIZED),
         Err(e) => {
-            error!("Failed to authenticate with Github: {:?}", e);
+            error!("Failed to authenticate with Google: {:?}", e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }

--- a/ee/tabby-webserver/src/oauth/mod.rs
+++ b/ee/tabby-webserver/src/oauth/mod.rs
@@ -41,22 +41,22 @@ pub fn routes(auth: Arc<dyn AuthenticationService>) -> Router {
     };
 
     Router::new()
-        .route("/github", routing::get(github_callback))
+        .route("/github", routing::get(github_oauth_handler))
         .with_state(state.clone())
-        .route("/google", routing::get(google_callback))
+        .route("/google", routing::get(google_oauth_handler))
         .with_state(state.clone())
 }
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
-struct GithubCallbackParam {
+struct GithubOAuthQueryParam {
     code: String,
     state: Option<String>,
 }
 
-async fn github_callback(
+async fn github_oauth_handler(
     State(state): State<OAuthState>,
-    Query(param): Query<GithubCallbackParam>,
+    Query(param): Query<GithubOAuthQueryParam>,
 ) -> Result<Redirect, StatusCode> {
     match_auth_result(
         state
@@ -68,7 +68,7 @@ async fn github_callback(
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
-struct GoogleCallbackParam {
+struct GoogleOAuthQueryParam {
     #[serde(default)]
     code: String,
     #[serde(default)]
@@ -77,9 +77,9 @@ struct GoogleCallbackParam {
     error: String,
 }
 
-async fn google_callback(
+async fn google_oauth_handler(
     State(state): State<OAuthState>,
-    Query(param): Query<GoogleCallbackParam>,
+    Query(param): Query<GoogleOAuthQueryParam>,
 ) -> Result<Redirect, StatusCode> {
     if !param.error.is_empty() {
         return Err(StatusCode::BAD_REQUEST);

--- a/ee/tabby-webserver/src/schema/dao.rs
+++ b/ee/tabby-webserver/src/schema/dao.rs
@@ -1,4 +1,6 @@
-use tabby_db::{GithubOAuthCredentialDAO, InvitationDAO, JobRunDAO, UserDAO};
+use tabby_db::{
+    GithubOAuthCredentialDAO, GoogleOAuthCredentialDAO, InvitationDAO, JobRunDAO, UserDAO,
+};
 
 use crate::schema::{
     auth,
@@ -48,6 +50,19 @@ impl From<GithubOAuthCredentialDAO> for OAuthCredential {
         OAuthCredential {
             provider: OAuthProvider::Github,
             client_id: val.client_id,
+            redirect_uri: None,
+            created_at: val.created_at,
+            updated_at: val.updated_at,
+        }
+    }
+}
+
+impl From<GoogleOAuthCredentialDAO> for OAuthCredential {
+    fn from(val: GoogleOAuthCredentialDAO) -> Self {
+        OAuthCredential {
+            provider: OAuthProvider::Google,
+            client_id: val.client_id,
+            redirect_uri: Some(val.redirect_uri),
             created_at: val.created_at,
             updated_at: val.updated_at,
         }

--- a/ee/tabby-webserver/src/schema/mod.rs
+++ b/ee/tabby-webserver/src/schema/mod.rs
@@ -363,12 +363,13 @@ impl Mutation {
         provider: OAuthProvider,
         client_id: String,
         client_secret: String,
+        redirect_uri: Option<String>,
     ) -> Result<bool> {
         if let Some(claims) = &ctx.claims {
             if claims.is_admin {
                 ctx.locator
                     .auth()
-                    .update_oauth_credential(provider, client_id, client_secret)
+                    .update_oauth_credential(provider, client_id, client_secret, redirect_uri)
                     .await?;
                 return Ok(true);
             }


### PR DESCRIPTION
For closing issue: https://github.com/TabbyML/tabby/issues/1039

Similar to Github oauth, add following changes

- Add `google_oauth_credential` db table, and read/write operations
  - it's slightly different from `github_oauth_credential`, we need to keep `redirect_uri` because it's a `required` parameter when exchange access token (unlike github which is optional)
- Add `google` client, implement token exhange and user email fetching
- Add `/oauth_callback/google` route, extract common response handling logic into `match_auth_result` method
- google oauth is very simliar to github oauth, so refactor `github_auth` method to take care of both providers
- update graphql api to update/return `redirect_uri` field, this field is defined as optional, so should break nothing

