### PR TITLE
fix(agent): Use /usr/bin/env instead of /bin/env

### DIFF
--- a/clients/intellij/node_scripts/tabby-agent.js
+++ b/clients/intellij/node_scripts/tabby-agent.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 'use strict';
 
 var events = require('events');

--- a/clients/tabby-agent/src/cli.ts
+++ b/clients/tabby-agent/src/cli.ts
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 import { TabbyAgent } from "./TabbyAgent";
 import { JsonLineServer } from "./JsonLineServer";

--- a/clients/vim/node_scripts/tabby-agent.js
+++ b/clients/vim/node_scripts/tabby-agent.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 'use strict';
 
 var events = require('events');


### PR DESCRIPTION
macOS does not have `/bin/env`, so let's point to `/usr/bin/env` like the other instances.