### PR TITLE
fix(agent): make health checking compatible with older server version only support POST.

### DIFF
--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -204,19 +204,24 @@ export class TabbyAgent extends EventEmitter implements Agent {
     return abortSignalFromAnyOf([AbortSignal.timeout(timeout), options?.signal]);
   }
 
-  private async healthCheck(options?: AbortSignalOption): Promise<void> {
+  private async healthCheck(options?: { signal?: AbortSignal; method?: "GET" | "POST" }): Promise<void> {
     const requestId = uuid();
     const requestPath = "/v1/health";
     const requestUrl = this.config.server.endpoint + requestPath;
     const requestOptions = {
-      signal: this.createAbortSignal(options),
+      signal: this.createAbortSignal({ signal: options?.signal }),
     };
     try {
       if (!this.api) {
         throw new Error("http client not initialized");
       }
       this.logger.debug({ requestId, requestOptions, url: requestUrl }, "Health check request");
-      const response = await this.api.GET(requestPath, requestOptions);
+      let response;
+      if (options?.method === "POST") {
+        response = await this.api.POST(requestPath, requestOptions);
+      } else {
+        response = await this.api.GET(requestPath, requestOptions);
+      }
       if (response.error || !response.response.ok) {
         throw new HttpError(response.response);
       }
@@ -235,7 +240,9 @@ export class TabbyAgent extends EventEmitter implements Agent {
       }
     } catch (error) {
       this.serverHealthState = undefined;
-      if (error instanceof HttpError && [401, 403, 405].includes(error.status)) {
+      if (error instanceof HttpError && error.status == 405 && options?.method !== "POST") {
+        return await this.healthCheck({ method: "POST" });
+      } else if (error instanceof HttpError && [401, 403].includes(error.status)) {
         this.logger.debug({ requestId, error }, "Health check error: unauthorized");
         this.changeStatus("unauthorized");
       } else {

--- a/clients/tabby-agent/src/types/tabbyApi.d.ts
+++ b/clients/tabby-agent/src/types/tabbyApi.d.ts
@@ -12,6 +12,8 @@ export interface paths {
   };
   "/v1/health": {
     get: operations["health"];
+    // back compatible for Tabby server 0.2.x and earlier
+    post: operations["health"];
   };
   "/v1beta/chat/completions": {
     post: operations["chat_completions"];


### PR DESCRIPTION
Related to #1159

Changes:
- Fixed the error handling of code 405
- Fallback to POST if GET is not allowed when health checking (compatible with older server version)