### PR TITLE
Delete Kotlin from the missing support list in programming-languages.md

### DIFF
--- a/website/docs/programming-languages.md
+++ b/website/docs/programming-languages.md
@@ -43,4 +43,3 @@ For an actual example of an issue or pull request adding the above support, plea
 |   Lua    |                    🚫                    |                       🚫                        |
 |   Perl   |                    🚫                    |                       🚫                        |
 |  Scala   |                    🚫                    |                       🚫                        |
-|  Kotlin  |                    🚫                    |                       🚫                        |


### PR DESCRIPTION
I assume Kotlin is supported as stated above. The documentation seems outdated.