### PR TITLE
fix(ui): display root error in `form` after integrating `urql`

### DIFF
--- a/ee/tabby-ui/lib/tabby/gql.ts
+++ b/ee/tabby-ui/lib/tabby/gql.ts
@@ -75,8 +75,8 @@ function makeFormErrorHandler<T extends FieldValues>(form: UseFormReturn<T>) {
         for (const error of validationErrors.errors) {
           form.setError(error.path as any, error)
         }
-      } else {
-        form.setError('root', error)
+      } else if (error?.originalError) {
+        form.setError('root', error.originalError)
       }
     }
   }


### PR DESCRIPTION
`urql` wraps the original error