### PR TITLE
fix(juniper_axum): Fix how has_previous_page and has_next_page are computed

### DIFF
--- a/crates/juniper-axum/src/relay/connection.rs
+++ b/crates/juniper-axum/src/relay/connection.rs
@@ -33,7 +33,8 @@ where
         first: Option<usize>,
         last: Option<usize>,
     ) -> Self {
-        let has_next_page = first.or(last).is_some_and(|count| nodes.len() > count);
+        let selected_count = first.or(last).unwrap_or(nodes.len());
+        let has_next_page = selected_count < nodes.len();
         let has_previous_page = after || before;
         let len = nodes.len();
 

--- a/crates/juniper-axum/src/relay/connection.rs
+++ b/crates/juniper-axum/src/relay/connection.rs
@@ -27,8 +27,8 @@ where
     }
 
     pub fn build_connection(nodes: Vec<Node>, first: Option<usize>, last: Option<usize>) -> Self {
-        let has_next_page = first.map_or(false, |first| nodes.len() > first);
-        let has_previous_page = last.map_or(false, |last| nodes.len() > last);
+        let has_next_page = first.is_some_and(|first| nodes.len() > first);
+        let has_previous_page = first.is_some_and(|first| first > 0);
         let len = nodes.len();
 
         let edges: Vec<_> = if let Some(last) = last {

--- a/crates/juniper-axum/src/relay/connection.rs
+++ b/crates/juniper-axum/src/relay/connection.rs
@@ -34,9 +34,17 @@ where
         last: Option<usize>,
     ) -> Self {
         let selected_count = first.or(last).unwrap_or(nodes.len());
-        let has_next_page = selected_count < nodes.len();
-        let has_previous_page = after || before;
         let len = nodes.len();
+        let has_next_page = if last.is_some() {
+            before
+        } else {
+            selected_count < len
+        };
+        let has_previous_page = if last.is_some() {
+            selected_count < len
+        } else {
+            after
+        };
 
         let edges: Vec<_> = if let Some(last) = last {
             nodes

--- a/crates/juniper-axum/src/relay/connection.rs
+++ b/crates/juniper-axum/src/relay/connection.rs
@@ -26,9 +26,15 @@ where
         }
     }
 
-    pub fn build_connection(nodes: Vec<Node>, first: Option<usize>, last: Option<usize>) -> Self {
-        let has_next_page = first.is_some_and(|first| nodes.len() > first);
-        let has_previous_page = first.is_some_and(|first| first > 0);
+    pub fn build_connection(
+        nodes: Vec<Node>,
+        after: bool,
+        before: bool,
+        first: Option<usize>,
+        last: Option<usize>,
+    ) -> Self {
+        let has_next_page = first.or(last).is_some_and(|count| nodes.len() > count);
+        let has_previous_page = after || before;
         let len = nodes.len();
 
         let edges: Vec<_> = if let Some(last) = last {

--- a/crates/juniper-axum/src/relay/mod.rs
+++ b/crates/juniper-axum/src/relay/mod.rs
@@ -50,16 +50,40 @@ where
 
     match (first, last) {
         (None, None) => {
+            let after_some = after.is_some();
+            let before_some = before.is_some();
             let nodes = f(after, before, None, None)?;
-            Ok(Connection::build_connection(nodes, None, None))
+            Ok(Connection::build_connection(
+                nodes,
+                after_some,
+                before_some,
+                None,
+                None,
+            ))
         }
         (Some(first), None) => {
+            let after_some = after.is_some();
+            let before_some = before.is_some();
             let nodes = f(after, before, Some(first + 1), None)?;
-            Ok(Connection::build_connection(nodes, Some(first), None))
+            Ok(Connection::build_connection(
+                nodes,
+                after_some,
+                before_some,
+                Some(first),
+                None,
+            ))
         }
         (None, Some(last)) => {
+            let after_some = after.is_some();
+            let before_some = before.is_some();
             let nodes = f(after, before, None, Some(last + 1))?;
-            Ok(Connection::build_connection(nodes, None, Some(last)))
+            Ok(Connection::build_connection(
+                nodes,
+                after_some,
+                before_some,
+                None,
+                Some(last),
+            ))
         }
         _ => Err("The \"first\" and \"last\" parameters cannot exist at the same time".into()),
     }
@@ -99,16 +123,40 @@ where
 
     match (first, last) {
         (None, None) => {
+            let after_some = after.is_some();
+            let before_some = before.is_some();
             let nodes = f(after, before, None, None).await?;
-            Ok(Connection::build_connection(nodes, None, None))
+            Ok(Connection::build_connection(
+                nodes,
+                after_some,
+                before_some,
+                None,
+                None,
+            ))
         }
         (Some(first), None) => {
+            let after_some = after.is_some();
+            let before_some = before.is_some();
             let nodes = f(after, before, Some(first + 1), None).await?;
-            Ok(Connection::build_connection(nodes, Some(first), None))
+            Ok(Connection::build_connection(
+                nodes,
+                after_some,
+                before_some,
+                Some(first),
+                None,
+            ))
         }
         (None, Some(last)) => {
+            let after_some = after.is_some();
+            let before_some = before.is_some();
             let nodes = f(after, before, None, Some(last + 1)).await?;
-            Ok(Connection::build_connection(nodes, None, Some(last)))
+            Ok(Connection::build_connection(
+                nodes,
+                after_some,
+                before_some,
+                None,
+                Some(last),
+            ))
         }
         _ => Err("The \"first\" and \"last\" parameters cannot exist at the same time".into()),
     }

--- a/crates/juniper-axum/src/relay/mod.rs
+++ b/crates/juniper-axum/src/relay/mod.rs
@@ -12,6 +12,32 @@ pub use edge::Edge;
 pub use node_type::NodeType;
 pub use page_info::PageInfo;
 
+fn validate_first_last(
+    first: Option<i32>,
+    last: Option<i32>,
+) -> FieldResult<(Option<usize>, Option<usize>)> {
+    if first.is_some() && last.is_some() {
+        return Err("The \"first\" and \"last\" parameters cannot exist at the same time".into());
+    }
+
+    let first = match first {
+        Some(first) if first < 0 => {
+            return Err("The \"first\" parameter must be a non-negative number".into());
+        }
+        Some(first) => Some(first as usize),
+        None => None,
+    };
+
+    let last = match last {
+        Some(last) if last < 0 => {
+            return Err("The \"last\" parameter must be a non-negative number".into());
+        }
+        Some(last) => Some(last as usize),
+        None => None,
+    };
+    Ok((first, last))
+}
+
 pub fn query<Node, F>(
     after: Option<String>,
     before: Option<String>,
@@ -28,65 +54,20 @@ where
         Option<usize>,
     ) -> FieldResult<Vec<Node>>,
 {
-    if first.is_some() && last.is_some() {
-        return Err("The \"first\" and \"last\" parameters cannot exist at the same time".into());
-    }
+    let (first, last) = validate_first_last(first, last)?;
 
-    let first = match first {
-        Some(first) if first < 0 => {
-            return Err("The \"first\" parameter must be a non-negative number".into());
-        }
-        Some(first) => Some(first as usize),
-        None => None,
-    };
-
-    let last = match last {
-        Some(last) if last < 0 => {
-            return Err("The \"last\" parameter must be a non-negative number".into());
-        }
-        Some(last) => Some(last as usize),
-        None => None,
-    };
-
-    match (first, last) {
-        (None, None) => {
-            let after_some = after.is_some();
-            let before_some = before.is_some();
-            let nodes = f(after, before, None, None)?;
-            Ok(Connection::build_connection(
-                nodes,
-                after_some,
-                before_some,
-                None,
-                None,
-            ))
-        }
-        (Some(first), None) => {
-            let after_some = after.is_some();
-            let before_some = before.is_some();
-            let nodes = f(after, before, Some(first + 1), None)?;
-            Ok(Connection::build_connection(
-                nodes,
-                after_some,
-                before_some,
-                Some(first),
-                None,
-            ))
-        }
-        (None, Some(last)) => {
-            let after_some = after.is_some();
-            let before_some = before.is_some();
-            let nodes = f(after, before, None, Some(last + 1))?;
-            Ok(Connection::build_connection(
-                nodes,
-                after_some,
-                before_some,
-                None,
-                Some(last),
-            ))
-        }
-        _ => Err("The \"first\" and \"last\" parameters cannot exist at the same time".into()),
-    }
+    let first_plus_one = first.map(|i| i + 1);
+    let last_plus_one = last.map(|i| i + 1);
+    let after_some = after.is_some();
+    let before_some = before.is_some();
+    let nodes = f(after, before, first_plus_one, last_plus_one)?;
+    Ok(Connection::build_connection(
+        nodes,
+        after_some,
+        before_some,
+        first,
+        last,
+    ))
 }
 
 pub async fn query_async<Node, F, R>(
@@ -101,63 +82,18 @@ where
     F: FnOnce(Option<String>, Option<String>, Option<usize>, Option<usize>) -> R,
     R: Future<Output = FieldResult<Vec<Node>>>,
 {
-    if first.is_some() && last.is_some() {
-        return Err("The \"first\" and \"last\" parameters cannot exist at the same time".into());
-    }
+    let (first, last) = validate_first_last(first, last)?;
 
-    let first = match first {
-        Some(first) if first < 0 => {
-            return Err("The \"first\" parameter must be a non-negative number".into());
-        }
-        Some(first) => Some(first as usize),
-        None => None,
-    };
-
-    let last = match last {
-        Some(last) if last < 0 => {
-            return Err("The \"last\" parameter must be a non-negative number".into());
-        }
-        Some(last) => Some(last as usize),
-        None => None,
-    };
-
-    match (first, last) {
-        (None, None) => {
-            let after_some = after.is_some();
-            let before_some = before.is_some();
-            let nodes = f(after, before, None, None).await?;
-            Ok(Connection::build_connection(
-                nodes,
-                after_some,
-                before_some,
-                None,
-                None,
-            ))
-        }
-        (Some(first), None) => {
-            let after_some = after.is_some();
-            let before_some = before.is_some();
-            let nodes = f(after, before, Some(first + 1), None).await?;
-            Ok(Connection::build_connection(
-                nodes,
-                after_some,
-                before_some,
-                Some(first),
-                None,
-            ))
-        }
-        (None, Some(last)) => {
-            let after_some = after.is_some();
-            let before_some = before.is_some();
-            let nodes = f(after, before, None, Some(last + 1)).await?;
-            Ok(Connection::build_connection(
-                nodes,
-                after_some,
-                before_some,
-                None,
-                Some(last),
-            ))
-        }
-        _ => Err("The \"first\" and \"last\" parameters cannot exist at the same time".into()),
-    }
+    let first_plus_one = first.map(|i| i + 1);
+    let last_plus_one = last.map(|i| i + 1);
+    let after_some = after.is_some();
+    let before_some = before.is_some();
+    let nodes = f(after, before, first_plus_one, last_plus_one).await?;
+    Ok(Connection::build_connection(
+        nodes,
+        after_some,
+        before_some,
+        first,
+        last,
+    ))
 }

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -454,7 +454,6 @@ fn password_verify(raw: &str, hash: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    
 
     use assert_matches::assert_matches;
     use juniper_axum::relay::{self, Connection};

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -678,6 +678,18 @@ mod tests {
 
         let users = list_users(&conn, None, Some("2".into()), None, Some(1)).await;
 
+        assert!(users.page_info.has_next_page);
+        assert!(!users.page_info.has_previous_page);
+
+        let users = list_users(&conn, Some("3".into()), None, None, None).await;
+        assert!(!users.page_info.has_next_page);
+        assert!(users.page_info.has_previous_page);
+
+        let users = list_users(&conn, None, None, Some(3), None).await;
+        assert!(!users.page_info.has_next_page);
+        assert!(!users.page_info.has_previous_page);
+
+        let users = list_users(&conn, Some("1".into()), None, Some(2), None).await;
         assert!(!users.page_info.has_next_page);
         assert!(users.page_info.has_previous_page);
     }

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -454,7 +454,7 @@ fn password_verify(raw: &str, hash: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    
 
     use assert_matches::assert_matches;
     use juniper_axum::relay::{self, Connection};


### PR DESCRIPTION
Remaining flaw: `has_previous_page` will always be true if `before` or `after` are specified, even if all possible values are returned. This cannot be resolved with the current setup of functions.