### PR TITLE
chore(vscode): bump VSCode Extension version to 1.3.0.

### DIFF
--- a/clients/vscode/CHANGELOG.md
+++ b/clients/vscode/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.3.0
+
+### Features:
+
+- Removed the completion request timeout limit. Now, a warning status bar icon will be displayed when the completion requests take too long.
+- Enabled experimental feature of stripping auto-closing characters in prompt suffix by default.
+- Enabled experimental feature of syntax-based post-processing by default.
+- Added support for logging completion dismiss events.
+
+### Fixes:
+
+- Fixed an issue where completion was triggered when the text selection was not empty.
+- Fixed a bug that caused the completion not to show in non-last cells of a notebook.
+- Fixed health checking to be compatibility with Tabby server version 0.2.0 or earlier.
+
 ## 1.2.0
 
 ### Features:

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/TabbyML/tabby",
   "bugs": "https://github.com/TabbyML/tabby/issues",
   "license": "Apache-2.0",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "keywords": [
     "ai",
     "autocomplete",


### PR DESCRIPTION
Complete TAB-467