### PR TITLE
docs: update online docs for clients config about timeout limit.

### DIFF
--- a/website/docs/extensions/configurations.md
+++ b/website/docs/extensions/configurations.md
@@ -35,15 +35,6 @@ Header1 = "Value1" # list your custom headers here
 Header2 = "Value2" # values can be strings, numbers or booleans
 ```
 
-## Completion
-
-If you want to allocate more time to Tabby for completion requests, you can adjust the timeout configurations here.
-
-```toml
-[completion]
-timeout = 4000 # By default the timeout is 4 seconds.
-```
-
 ## Logs
 
 If you encounter any issues with the Tabby IDE extensions and need to report a bug, you can enable debug logs to help us investigate the issue.

--- a/website/docs/extensions/troubleshooting.md
+++ b/website/docs/extensions/troubleshooting.md
@@ -121,9 +121,6 @@ on a GPU with CUDA or ROCm support or on Apple M1/M2 with Metal support. When ru
 the server, make sure to specify the device in the arguments using  `--device cuda`, `--device rocm` or
 `--device metal`. You can also try using a smaller model from the available [models](https://tabby.tabbyml.com/docs/models/). 
 
-By default, the timeout for automatically triggered completion requests is set to 4 seconds. 
-You can adjust this timeout value in the [config file](https://tabby.tabbyml.com/docs/extensions/configurations).
-
 ## Want to Deep Dive via Logs?
 
 If you cannot solve the issue using the previous steps, you may want to 


### PR DESCRIPTION
Remove documentation about the client-side timeout limit, as the timeout limit has been removed in clients after version 1.3.0.