### PR TITLE
feat(scheduler, docs): Added repository context support for C#

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "tree-sitter-c",
+ "tree-sitter-c-sharp",
  "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -4715,6 +4716,16 @@ dependencies = [
 name = "tree-sitter-c"
 version = "0.20.6"
 source = "git+https://github.com/tree-sitter/tree-sitter-c/?rev=212a80f#212a80f86452bb1316324fa0db730cf52f29e05a"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ab3dc608f34924fa9e10533a95f62dbc14b6de0ddd7107722eba66fe19ae31"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/tabby-scheduler/Cargo.toml
+++ b/crates/tabby-scheduler/Cargo.toml
@@ -22,6 +22,7 @@ tree-sitter-go = "0.20.0"
 tree-sitter-ruby = "0.20.0"
 tree-sitter-c = { git = "https://github.com/tree-sitter/tree-sitter-c/", rev = "212a80f" }
 tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "a714740" }
+tree-sitter-c-sharp = "0.20.0"
 ignore = "0.4.20"
 kdam = { version = "0.5.0" }
 requirements = "0.3.0"

--- a/crates/tabby-scheduler/queries/csharp.scm
+++ b/crates/tabby-scheduler/queries/csharp.scm
@@ -1,0 +1,19 @@
+(
+  (class_declaration (identifier) @name) @definition.class
+)
+
+(
+  (struct_declaration (identifier) @name) @definition.struct
+)
+
+(
+  (method_declaration (identifier) @name) @definition.method
+)
+
+(
+  (interface_declaration (identifier) @name) @definition.interface
+)
+
+(
+  (local_function_statement (identifier) @name) @definition.function
+)

--- a/crates/tabby-scheduler/src/dataset/tags.rs
+++ b/crates/tabby-scheduler/src/dataset/tags.rs
@@ -142,6 +142,17 @@ lazy_static! {
                     .unwrap(),
                 ),
             ),
+            (
+                "csharp",
+                TagsConfigurationSync(
+                    TagsConfiguration::new(
+                        tree_sitter_c_sharp::language(),
+                        include_str!("../../queries/csharp.scm"),
+                        "",
+                    )
+                    .unwrap(),
+                ),
+            ),
         ])
     };
 }

--- a/website/docs/programming-languages.md
+++ b/website/docs/programming-languages.md
@@ -31,12 +31,12 @@ For an actual example of an issue or pull request adding the above support, plea
 * [Kotlin](https://www.kotlinlang.org/)
 * [C/C++](https://cplusplus.com/), since v0.8.0
 * [PHP](https://www.php.net/): Since v0.8.0
+* [C#](https://learn.microsoft.com/en-us/dotnet/csharp/): Since v0.9.0
 
 ## Languages Missing Certain Support
 
 | Language | Stop Words (time to contribute: <5 min) | Repository Context (time to contribute: <1 hr) |
 | :------: | :-------------------------------------: | :--------------------------------------------: |
-|    C#    |                    🚫                    |                       🚫                        |
 |   CSS    |                    🚫                    |                       🚫                        |
 | Haskell  |                    🚫                    |                       🚫                        |
 |  Julia   |                    🚫                    |                       🚫                        |


### PR DESCRIPTION
This should close #239, I noticed that #1030 had done most of the job but didn't update docs so, I've taken the liberty of doing that. Not sure if this will slip into RC or not but I've made an assumption it will for docs.

**Commits**
- feat(scheduler, docs): Add repo context support for C#, added language to supported list in docs