### PR TITLE
feat(db): Split prod and dev db, default to dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,17 +35,17 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014
             container: quay.io/pypa/manylinux2014_x86_64
-            build_args: --features static-ssl
+            build_args: --features static-ssl,prod
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014-cuda117
             container: sameli/manylinux2014_x86_64_cuda_11.7
-            build_args: --features static-ssl --features cuda
+            build_args: --features static-ssl --features cuda,prod
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014-cuda122
             container: sameli/manylinux2014_x86_64_cuda_12.2
-            build_args: --features static-ssl --features cuda
+            build_args: --features static-ssl --features cuda,prod
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc
@@ -54,19 +54,19 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc-cuda117
             ext: .exe
-            build_args: --features cuda
+            build_args: --features cuda,prod
             windows_cuda: '11.7.1'
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc-cuda122
             ext: .exe
-            build_args: --features cuda
+            build_args: --features cuda,prod
             windows_cuda: '12.2.0'
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014-rocm57
             container: ghcr.io/cromefire/hipblas-manylinux/2014/5.7:latest
-            build_args: --features static-ssl --features rocm
+            build_args: --features static-ssl,rocm,prod
 
     env:
       SCCACHE_GHA_ENABLED: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,17 +35,17 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014
             container: quay.io/pypa/manylinux2014_x86_64
-            build_args: --features static-ssl,prod
+            build_args: --features static-ssl,prod-db
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014-cuda117
             container: sameli/manylinux2014_x86_64_cuda_11.7
-            build_args: --features static-ssl --features cuda,prod
+            build_args: --features static-ssl --features cuda,prod-db
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014-cuda122
             container: sameli/manylinux2014_x86_64_cuda_12.2
-            build_args: --features static-ssl --features cuda,prod
+            build_args: --features static-ssl --features cuda,prod-db
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc
@@ -54,19 +54,19 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc-cuda117
             ext: .exe
-            build_args: --features cuda,prod
+            build_args: --features cuda,prod-db
             windows_cuda: '11.7.1'
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc-cuda122
             ext: .exe
-            build_args: --features cuda,prod
+            build_args: --features cuda,prod-db
             windows_cuda: '12.2.0'
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux2014-rocm57
             container: ghcr.io/cromefire/hipblas-manylinux/2014/5.7:latest
-            build_args: --features static-ssl,rocm,prod
+            build_args: --features static-ssl,rocm,prod-db
 
     env:
       SCCACHE_GHA_ENABLED: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/root/workspace/target \
-    cargo build --features cuda,prod --release --package tabby && \
+    cargo build --features cuda,prod-db --release --package tabby && \
     cp target/release/tabby /opt/tabby/bin/
 
 FROM ${BASE_CUDA_RUN_CONTAINER} as runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/root/workspace/target \
-    cargo build --features cuda --release --package tabby && \
+    cargo build --features cuda,prod --release --package tabby && \
     cp target/release/tabby /opt/tabby/bin/
 
 FROM ${BASE_CUDA_RUN_CONTAINER} as runtime

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -13,6 +13,7 @@ experimental-http = ["dep:http-api-bindings"]
 # architecture, enable this feature to compile OpenSSL as part of the build.
 # See https://docs.rs/openssl/#vendored for more.
 static-ssl = ['openssl/vendored']
+prod-db = ['tabby-webserver/prod-db']
 
 [dependencies]
 tabby-common = { path = "../tabby-common" }

--- a/ee/tabby-db/Cargo.toml
+++ b/ee/tabby-db/Cargo.toml
@@ -7,6 +7,7 @@ homepage.workspace = true
 
 [features]
 testutils = []
+prod = []
 
 [dependencies]
 anyhow.workspace = true

--- a/ee/tabby-db/Cargo.toml
+++ b/ee/tabby-db/Cargo.toml
@@ -7,7 +7,7 @@ homepage.workspace = true
 
 [features]
 testutils = []
-prod = []
+prod-db = []
 
 [dependencies]
 anyhow.workspace = true

--- a/ee/tabby-db/src/path.rs
+++ b/ee/tabby-db/src/path.rs
@@ -7,11 +7,11 @@ fn tabby_ee_root() -> PathBuf {
 }
 
 pub fn db_file() -> PathBuf {
-    #[cfg(feature = "prod")]
+    #[cfg(feature = "prod-db")]
     {
         tabby_ee_root().join("db.sqlite")
     }
-    #[cfg(not(feature = "prod"))]
+    #[cfg(not(feature = "prod-db"))]
     {
         tabby_ee_root().join("dev-db.sqlite")
     }

--- a/ee/tabby-db/src/path.rs
+++ b/ee/tabby-db/src/path.rs
@@ -7,5 +7,12 @@ fn tabby_ee_root() -> PathBuf {
 }
 
 pub fn db_file() -> PathBuf {
-    tabby_ee_root().join("db.sqlite")
+    #[cfg(feature = "prod")]
+    {
+        tabby_ee_root().join("db.sqlite")
+    }
+    #[cfg(not(feature = "prod"))]
+    {
+        tabby_ee_root().join("dev-db.sqlite")
+    }
 }

--- a/ee/tabby-webserver/Cargo.toml
+++ b/ee/tabby-webserver/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 
+[features]
+prod-db = ['tabby-db/prod-db']
+
 [dependencies]
 anyhow.workspace = true
 argon2 = "0.5.1"


### PR DESCRIPTION
Closes #1272 

NOTE: This will immediately present a breaking change for anyone who currently has a prod db and is expecting it to be used on startup. We might want to document this, but if so, which document(s)?