### PR TITLE
fix(agent): add removeDuplicatedLineSuffix postprocess filter

### DIFF
--- a/clients/tabby-agent/src/postprocess/golden/remove_duplication/duplicated_line_suffix.toml
+++ b/clients/tabby-agent/src/postprocess/golden/remove_duplication/duplicated_line_suffix.toml
@@ -8,7 +8,7 @@ filepath = 'checks.ts'
 language = 'typescript'
 # indentation = '  ' # not specified
 text = '''
-const log = ({ ok }: { ok:├ boolean }) => { ┤ }) => {
+const log = ({ ok }: { ok:├ boolean }) => {┤ }) => {
   console.log(ok);
 }
 '''
@@ -19,4 +19,3 @@ const log = ({ ok }: { ok:├ boolean┤ }) => {
   console.log(ok);
 }
 '''
-notEqual = true  # FIXME: fix bad case

--- a/clients/tabby-agent/src/postprocess/index.ts
+++ b/clients/tabby-agent/src/postprocess/index.ts
@@ -12,6 +12,7 @@ import { trimMultiLineInSingleLineMode } from "./trimMultiLineInSingleLineMode";
 import { dropDuplicated } from "./dropDuplicated";
 import { dropBlank } from "./dropBlank";
 import { calculateReplaceRange } from "./calculateReplaceRange";
+import { removeDuplicatedLineSuffix } from "./removeDuplicatedLineSuffix";
 
 export async function preCacheProcess(
   context: CompletionContext,
@@ -23,7 +24,8 @@ export async function preCacheProcess(
     .then(applyFilter(removeLineEndsWithRepetition(), context))
     .then(applyFilter(dropDuplicated(), context))
     .then(applyFilter(trimSpace(), context))
-    .then(applyFilter(dropBlank(), context));
+    .then(applyFilter(dropBlank(), context))
+    .then(applyFilter(removeDuplicatedLineSuffix(), context));
 }
 
 export async function postCacheProcess(
@@ -40,5 +42,6 @@ export async function postCacheProcess(
     .then(applyFilter(dropDuplicated(), context))
     .then(applyFilter(trimSpace(), context))
     .then(applyFilter(dropBlank(), context))
+    .then(applyFilter(removeDuplicatedLineSuffix(), context))
     .then(applyChoiceFilter(calculateReplaceRange(config["calculateReplaceRange"]), context));
 }

--- a/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.test.ts
+++ b/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.test.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+import { documentContext, inline } from "./testUtils";
+import { removeDuplicatedLineSuffix } from "./removeDuplicatedLineSuffix";
+
+describe("postprocess", () => {
+  describe("removeDuplicatedLineSuffix", () => {
+    it("should remove duplicated line suffix", () => {
+      const context = {
+        ...documentContext`
+        const log = ({ ok }: { ok:║ }) => {
+          console.log(ok);
+        } 
+        `,
+        language: "javascript",
+      };
+      const completion = inline`├ boolean }) => {┤`;
+
+      const expected = inline`├ boolean┤`;
+      expect(removeDuplicatedLineSuffix()(completion, context)).to.be.equal(expected);
+    });
+  });
+});

--- a/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.test.ts
+++ b/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.test.ts
@@ -11,7 +11,7 @@ describe("postprocess", () => {
           console.log(ok);
         } 
         `,
-        language: "javascript",
+        language: "typescript",
       };
       const completion = inline`├ boolean }) => {┤`;
 

--- a/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.ts
+++ b/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.ts
@@ -1,0 +1,35 @@
+import { CompletionContext } from "../CompletionContext";
+import { PostprocessFilter } from "./base";
+
+// remove the newline suffix if last char is \n
+function trimSuffixNewline(input: string): string {
+  return input.endsWith("\n") ? input.slice(0, -1) : input;
+}
+
+function trimSimilarEndingChar(a: string, b: string): string {
+  let i = a.length - 1;
+  let j = b.length - 1;
+
+  // Start from the end of both strings and move backwards
+  while (i >= 0 && j >= 0) {
+    if (a[i] === b[j]) {
+      i--;
+      j--;
+    } else {
+      break; // Stop when characters don't match
+    }
+  }
+
+  // Trim the similar part, +1 because slice stops before the end index
+  // and we decreased j one too many times in the last iteration of the loop
+  return b.slice(0, j + 1);
+}
+
+export function removeDuplicatedLineSuffix(): PostprocessFilter {
+  return (input: string, context: CompletionContext) => {
+    // this filter is only for single line completions
+    if (input.includes("\n")) return input;
+    const currentLineSuffix = trimSuffixNewline(context.currentLineSuffix);
+    return trimSimilarEndingChar(currentLineSuffix, input);
+  };
+}

--- a/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.ts
+++ b/clients/tabby-agent/src/postprocess/removeDuplicatedLineSuffix.ts
@@ -2,7 +2,7 @@ import { CompletionContext } from "../CompletionContext";
 import { PostprocessFilter } from "./base";
 
 // remove the newline suffix if last char is \n
-function trimSuffixNewline(input: string): string {
+function trimEndingNewline(input: string): string {
   return input.endsWith("\n") ? input.slice(0, -1) : input;
 }
 
@@ -29,7 +29,7 @@ export function removeDuplicatedLineSuffix(): PostprocessFilter {
   return (input: string, context: CompletionContext) => {
     // this filter is only for single line completions
     if (input.includes("\n")) return input;
-    const currentLineSuffix = trimSuffixNewline(context.currentLineSuffix);
+    const currentLineSuffix = trimEndingNewline(context.currentLineSuffix);
     return trimSimilarEndingChar(currentLineSuffix, input);
   };
 }


### PR DESCRIPTION
here is my attempt to fix `clients/tabby-agent/src/postprocess/golden/remove_duplication/duplicated_line_suffix.toml` test.
I also tested this on a daily usage. the fix just works fine.

but currently not all the tests are passing, because of a logical interference in `removeDuplicatedLineSuffix` and `calculateReplaceRange` filters. `removeDuplicatedLineSuffix` approach is to trim the input. but `calculateReplaceRange` approach is to keep the current input and modify the replaceRange.

should i refactor this filter and move it under replaceRange filter categories?
