### PR TITLE
feat: Support AMD GPU in docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,15 +3,15 @@ name: Create and publish docker image
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 */1 * *'
+    - cron: "0 20 */1 * *"
   push:
     tags:
-      - 'v*'
-      - '!*-dev'
+      - "v*"
+      - "!*-dev"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }} 
-  
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+
   # If this is enabled it will cancel current running and start latest
   cancel-in-progress: true
 
@@ -27,6 +27,10 @@ jobs:
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
+
+    strategy:
+      matrix:
+        device-type: [cpu, cuda, rocm]
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -88,9 +92,9 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=raw,value={{branch}}-{{sha}},enable=${{ startsWith(github.ref, 'refs/heads') }}
-            type=schedule,pattern=nightly
-            type=schedule,pattern={{date 'YYYYMMDD'}}
-            type=semver,pattern={{version}}
+            type=schedule,pattern=nightly-${{ matrix.device-type }}
+            type=schedule,pattern={{date 'YYYYMMDD'}}-${{ matrix.device-type }}
+            type=semver,pattern={{version}}-${{ matrix.device-type }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -113,4 +117,3 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: tabbyml/tabby
-

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,0 +1,67 @@
+ARG UBUNTU_VERSION=22.04
+# Target the build image
+ARG BASE_DEV_CONTAINER=rust:bookworm
+# Target the runtime image
+ARG BASE_RUN_CONTAINER=ubuntu:${UBUNTU_VERSION}
+
+FROM ${BASE_DEV_CONTAINER} AS build
+
+# Rust toolchain version
+ARG RUST_TOOLCHAIN=stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    git \
+    cmake \
+    ca-certificates \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# setup rust.
+RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain ${RUST_TOOLCHAIN} -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /root/workspace
+
+RUN mkdir -p /opt/tabby/bin
+RUN mkdir -p /opt/tabby/lib
+RUN mkdir -p target
+
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/root/workspace/target \
+    cargo build --features prod-db --release --package tabby && \
+    cp target/release/tabby /opt/tabby/bin/
+
+FROM ${BASE_RUN_CONTAINER} AS runtime
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git \
+    openssh-client \
+    ca-certificates \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Disable safe directory in docker
+# Context: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
+RUN git config --system --add safe.directory "*"
+
+# Automatic platform ARGs in the global scope
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
+
+COPY --from=build /opt/tabby /opt/tabby
+
+ENV PATH="$PATH:/opt/tabby/bin"
+ENV TABBY_ROOT=/data
+
+ENTRYPOINT ["/opt/tabby/bin/tabby"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -71,6 +71,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then  \
 COPY --from=build /opt/tabby /opt/tabby
 
 ENV PATH="$PATH:/opt/tabby/bin"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/compat"
 ENV TABBY_ROOT=/data
 
 ENTRYPOINT ["/opt/tabby/bin/tabby"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,0 +1,76 @@
+ARG UBUNTU_VERSION=22.04
+# This needs to generally match the container host's environment.
+ARG CUDA_VERSION=11.7.1
+# Target the CUDA build image
+ARG BASE_CUDA_DEV_CONTAINER=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+# Target the CUDA runtime image
+ARG BASE_CUDA_RUN_CONTAINER=nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+
+FROM ${BASE_CUDA_DEV_CONTAINER} AS build
+
+# Rust toolchain version
+ARG RUST_TOOLCHAIN=stable
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    git \
+    cmake \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# setup rust.
+RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain ${RUST_TOOLCHAIN} -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /root/workspace
+
+RUN mkdir -p /opt/tabby/bin
+RUN mkdir -p /opt/tabby/lib
+RUN mkdir -p target
+
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/root/workspace/target \
+    cargo build --features cuda,prod-db --release --package tabby && \
+    cp target/release/tabby /opt/tabby/bin/
+
+FROM ${BASE_CUDA_RUN_CONTAINER} AS runtime
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git \
+    openssh-client \
+    ca-certificates \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Disable safe directory in docker
+# Context: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
+RUN git config --system --add safe.directory "*"
+
+# Automatic platform ARGs in the global scope
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
+
+# AMD64 only:
+# Make link to libnvidia-ml.so (NVML) library
+# so that we could get GPU stats.
+RUN if [ "$TARGETARCH" = "amd64" ]; then  \
+    ln -s /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1 \
+    /usr/lib/x86_64-linux-gnu/libnvidia-ml.so; \
+    fi
+
+COPY --from=build /opt/tabby /opt/tabby
+
+ENV PATH="$PATH:/opt/tabby/bin"
+ENV TABBY_ROOT=/data
+
+ENTRYPOINT ["/opt/tabby/bin/tabby"]

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,12 +1,12 @@
 ARG UBUNTU_VERSION=22.04
 # This needs to generally match the container host's environment.
-ARG CUDA_VERSION=11.7.1
-# Target the CUDA build image
-ARG BASE_CUDA_DEV_CONTAINER=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
-# Target the CUDA runtime image
-ARG BASE_CUDA_RUN_CONTAINER=nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+ARG ROCM_VERSION=5.7.1
+# Target the ROCM build image
+ARG BASE_ROCM_DEV_CONTAINER=rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete
+# Target the ROCM runtime image
+ARG BASE_ROCM_RUN_CONTAINER=rocm/rocm-terminal:${ROCM_VERSION}
 
-FROM ${BASE_CUDA_DEV_CONTAINER} as build
+FROM ${BASE_ROCM_DEV_CONTAINER} AS build
 
 # Rust toolchain version
 ARG RUST_TOOLCHAIN=stable
@@ -14,13 +14,13 @@ ARG RUST_TOOLCHAIN=stable
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        curl \
-        pkg-config \
-        libssl-dev \
-        protobuf-compiler \
-        git \
-        cmake \
-        && \
+    curl \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    git \
+    cmake \
+    && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -38,22 +38,19 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/root/workspace/target \
-    cargo build --features cuda,prod-db --release --package tabby && \
+    cargo build --features rocm,prod-db --release --package tabby && \
     cp target/release/tabby /opt/tabby/bin/
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/root/workspace/target \
-    cargo build --features prod-db --release --package tabby && \
-    cp target/release/tabby /opt/tabby/bin/tabby-cpu
+FROM ${BASE_ROCM_RUN_CONTAINER} AS runtime
 
-FROM ${BASE_CUDA_RUN_CONTAINER} as runtime
+USER root
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        git \
-        openssh-client \
-        ca-certificates \
-        && \
+    git \
+    openssh-client \
+    ca-certificates \
+    && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -65,17 +62,11 @@ RUN git config --system --add safe.directory "*"
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH
 
-# AMD64 only:
-# Make link to libnvidia-ml.so (NVML) library
-# so that we could get GPU stats.
-RUN if [ "$TARGETARCH" = "amd64" ]; then  \
-    ln -s /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1 \
-        /usr/lib/x86_64-linux-gnu/libnvidia-ml.so; \
-    fi
-
 COPY --from=build /opt/tabby /opt/tabby
 
 ENV PATH="$PATH:/opt/tabby/bin"
 ENV TABBY_ROOT=/data
+
+USER rocm-user
 
 ENTRYPOINT ["/opt/tabby/bin/tabby"]

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -4,7 +4,7 @@ ARG ROCM_VERSION=5.7.1
 # Target the ROCM build image
 ARG BASE_ROCM_DEV_CONTAINER=rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete
 # Target the ROCM runtime image
-ARG BASE_ROCM_RUN_CONTAINER=rocm/rocm-terminal:${ROCM_VERSION}
+ARG BASE_ROCM_RUN_CONTAINER=rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}
 
 FROM ${BASE_ROCM_DEV_CONTAINER} AS build
 
@@ -43,13 +43,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM ${BASE_ROCM_RUN_CONTAINER} AS runtime
 
-USER root
-
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git \
     openssh-client \
     ca-certificates \
+    libssl3 \
+    rocblas \
+    hipblas \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -66,7 +67,5 @@ COPY --from=build /opt/tabby /opt/tabby
 
 ENV PATH="$PATH:/opt/tabby/bin"
 ENV TABBY_ROOT=/data
-
-USER rocm-user
 
 ENTRYPOINT ["/opt/tabby/bin/tabby"]


### PR DESCRIPTION
ROCm and CUDA are not suitable for building in the same docker image, so I separated 3 different device types.
Because I don't have a macos device to build and test locally so I didn't add the `metal` type.