### PR TITLE
feat(webserver): Prevent disabling owner user

### DIFF
--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -430,6 +430,9 @@ impl AuthenticationService for DbConn {
     }
 
     async fn update_user_active(&self, id: &ID, active: bool) -> Result<()> {
+        if id.as_rowid()? == 1 {
+            return Err(anyhow!("Cannot toggle the active status of the owner user"));
+        }
         self.update_user_active(id.as_rowid()?, active).await
     }
 }

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -431,7 +431,7 @@ impl AuthenticationService for DbConn {
 
     async fn update_user_active(&self, id: &ID, active: bool) -> Result<()> {
         if id.as_rowid()? == 1 {
-            return Err(anyhow!("Cannot toggle the active status of the owner user"));
+            return Err(anyhow!("Cannot toggle the active status of the owner"));
         }
         self.update_user_active(id.as_rowid()?, active).await
     }


### PR DESCRIPTION
There is currently no way to update `is_admin` for a user, we will have to remember to apply this same check when we get to that.