### PR TITLE
feat(agent&vscode): add support for agent log to vscode output.

### DIFF
--- a/clients/tabby-agent/src/Agent.ts
+++ b/clients/tabby-agent/src/Agent.ts
@@ -1,6 +1,7 @@
 import type { components as ApiComponents } from "./types/tabbyApi";
 import type { AgentConfig, PartialAgentConfig } from "./AgentConfig";
 import type { DataStore } from "./dataStore";
+import type { Logger } from "./logger";
 import type { CompletionRequest, CompletionResponse } from "./CompletionContext";
 
 export type { CompletionRequest, CompletionResponse };
@@ -14,6 +15,7 @@ export type AgentInitOptions = Partial<{
   config: PartialAgentConfig;
   clientProperties: ClientProperties;
   dataStore: DataStore;
+  loggers: Logger[];
 }>;
 
 export type ServerHealthState = ApiComponents["schemas"]["HealthState"];

--- a/clients/tabby-agent/src/AnonymousUsageLogger.ts
+++ b/clients/tabby-agent/src/AnonymousUsageLogger.ts
@@ -5,12 +5,12 @@ import { v4 as uuid } from "uuid";
 import type { paths as CloudApi } from "./types/cloudApi";
 import { name as agentName, version as agentVersion } from "../package.json";
 import { isBrowser } from "./env";
-import { rootLogger } from "./logger";
+import { logger } from "./logger";
 import { DataStore } from "./dataStore";
 
 export class AnonymousUsageLogger {
   private anonymousUsageTrackingApi = createClient<CloudApi>({ baseUrl: "https://app.tabbyml.com/api" });
-  private logger = rootLogger.child({ component: "AnonymousUsage" });
+  private logger = logger("AnonymousUsage");
   private systemData = {
     agent: `${agentName}, ${agentVersion}`,
     browser: isBrowser ? navigator?.userAgent || "browser" : undefined,

--- a/clients/tabby-agent/src/Auth.ts
+++ b/clients/tabby-agent/src/Auth.ts
@@ -6,7 +6,7 @@ import type { paths as CloudApi } from "./types/cloudApi";
 import type { AbortSignalOption } from "./Agent";
 import { HttpError, abortSignalFromAnyOf } from "./utils";
 import { DataStore, FileDataStore } from "./dataStore";
-import { rootLogger } from "./logger";
+import { logger } from "./logger";
 
 export type StorageData = {
   auth: { [endpoint: string]: { jwt: string } };
@@ -46,7 +46,7 @@ export class Auth extends EventEmitter {
     },
   };
 
-  private readonly logger = rootLogger.child({ component: "Auth" });
+  private readonly logger = logger("Auth");
   private dataStore?: DataStore;
   private authApi = createClient<CloudApi>({ baseUrl: "https://app.tabbyml.com/api" });
   private jwt?: JWT;

--- a/clients/tabby-agent/src/CompletionCache.ts
+++ b/clients/tabby-agent/src/CompletionCache.ts
@@ -1,13 +1,13 @@
 import { LRUCache } from "lru-cache";
 import { CompletionContext, CompletionResponse } from "./CompletionContext";
-import { rootLogger } from "./logger";
+import { logger } from "./logger";
 import { splitLines, autoClosingPairs, findUnpairedAutoClosingChars } from "./utils";
 
 type CompletionCacheKey = CompletionContext;
 type CompletionCacheValue = CompletionResponse;
 
 export class CompletionCache {
-  private readonly logger = rootLogger.child({ component: "CompletionCache" });
+  private readonly logger = logger("CompletionCache");
   private options = {
     maxCount: 10000,
     prebuildCache: {

--- a/clients/tabby-agent/src/JsonLineServer.ts
+++ b/clients/tabby-agent/src/JsonLineServer.ts
@@ -1,6 +1,6 @@
 import readline from "readline";
 import { AgentFunction, AgentEvent, Agent, agentEventNames } from "./Agent";
-import { rootLogger } from "./logger";
+import { logger } from "./logger";
 import { isCanceledError } from "./utils";
 
 type AgentFunctionRequest<T extends keyof AgentFunction> = [
@@ -45,7 +45,7 @@ export class JsonLineServer {
   private readonly process: NodeJS.Process = process;
   private readonly inStream: NodeJS.ReadStream = process.stdin;
   private readonly outStream: NodeJS.WriteStream = process.stdout;
-  private readonly logger = rootLogger.child({ component: "JsonLineServer" });
+  private readonly logger = logger("JsonLineServer");
 
   private abortControllers: { [id: string]: AbortController } = {};
 

--- a/clients/tabby-agent/src/LspServer.ts
+++ b/clients/tabby-agent/src/LspServer.ts
@@ -15,14 +15,14 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { name as agentName, version as agentVersion } from "../package.json";
 import { Agent, StatusChangedEvent, CompletionRequest, CompletionResponse } from "./Agent";
-import { rootLogger } from "./logger";
+import { logger } from "./logger";
 import { splitLines, isCanceledError } from "./utils";
 
 export class LspServer {
   private readonly connection = createConnection();
   private readonly documents = new TextDocuments(TextDocument);
 
-  private readonly logger = rootLogger.child({ component: "LspServer" });
+  private readonly logger = logger("LspServer");
 
   private agent?: Agent;
 

--- a/clients/tabby-agent/src/configFile.ts
+++ b/clients/tabby-agent/src/configFile.ts
@@ -8,7 +8,7 @@ import deepEqual from "deep-equal";
 import { getProperty, deleteProperty } from "dot-prop";
 import type { PartialAgentConfig } from "./AgentConfig";
 import { isBrowser } from "./env";
-import { rootLogger } from "./logger";
+import { logger } from "./logger";
 
 const configTomlTemplate = `## Tabby agent configuration file
 
@@ -82,7 +82,7 @@ function validateConfig(config: PartialAgentConfig): PartialAgentConfig {
 class ConfigFile extends EventEmitter {
   private data: PartialAgentConfig = {};
   private watcher?: chokidar.FSWatcher;
-  private logger = rootLogger.child({ component: "ConfigFile" });
+  private logger = logger("ConfigFile");
 
   constructor(private readonly filepath: string) {
     super();

--- a/clients/tabby-agent/src/loadCaCerts.ts
+++ b/clients/tabby-agent/src/loadCaCerts.ts
@@ -6,11 +6,11 @@ import * as macCa from "mac-ca";
 import type { AgentConfig } from "./AgentConfig";
 import { isBrowser } from "./env";
 import "./ArrayExt";
-import { rootLogger } from "./logger";
+import { logger as getLogger } from "./logger";
 
 type Cert = string | winCa.Certificate;
 
-const logger = rootLogger.child({ component: "CaCert" });
+const logger = getLogger("CaCert");
 let extraCaCerts: Cert[] = [];
 let originalCreateSecureContext: typeof tls.createSecureContext | undefined = undefined;
 

--- a/clients/tabby-agent/src/logger.ts
+++ b/clients/tabby-agent/src/logger.ts
@@ -4,6 +4,32 @@ import pino from "pino";
 import * as FileStreamRotator from "file-stream-rotator";
 import { isBrowser, isTest, testLogDebug } from "./env";
 
+export interface LogFn {
+  (msg: string, ...args: any[]): void;
+}
+
+export interface Logger {
+  error: LogFn;
+  warn: LogFn;
+  info: LogFn;
+  debug: LogFn;
+  trace: LogFn;
+}
+
+export type ObjLogFn = {
+  <T extends object>(obj: T, msg?: string, ...args: any[]): void;
+  (obj: unknown, msg?: string, ...args: any[]): void;
+  (msg: string, ...args: any[]): void;
+};
+
+export interface ObjLogger {
+  error: ObjLogFn;
+  warn: ObjLogFn;
+  info: ObjLogFn;
+  debug: ObjLogFn;
+  trace: ObjLogFn;
+}
+
 class LogFileStream implements pino.DestinationStream {
   private streamOptions = {
     // Rotating file locate at `~/.tabby-client/agent/logs/`.
@@ -25,17 +51,76 @@ class LogFileStream implements pino.DestinationStream {
 }
 
 // LogFileStream not available in browser, will use default browser console output instead.
-const stream = isBrowser || isTest ? undefined : new LogFileStream();
-
-const options = { serializers: { error: pino.stdSerializers.err } };
-export const rootLogger = stream ? pino(options, stream) : pino(options);
+const logFileStream = isBrowser || isTest ? undefined : new LogFileStream();
+const pinoOptions = { serializers: { error: pino.stdSerializers.err } };
+const rootBasicLogger = logFileStream ? pino(pinoOptions, logFileStream) : pino(pinoOptions);
 if (isTest && testLogDebug) {
-  rootLogger.level = "debug";
+  rootBasicLogger.level = "debug";
 } else {
-  rootLogger.level = "silent";
+  rootBasicLogger.level = "silent";
+}
+export const allBasicLoggers = [rootBasicLogger];
+rootBasicLogger.onChild = (child: pino.Logger) => {
+  allBasicLoggers.push(child);
+};
+
+function toObjLogFn(logFn: LogFn): ObjLogFn {
+  return (...args: any[]) => {
+    const arg0 = args.shift();
+    if (typeof arg0 === "string") {
+      logFn(arg0, ...args);
+    } else {
+      const arg1 = args.shift();
+      if (typeof arg1 === "string") {
+        logFn(arg1, ...args, arg0);
+      } else {
+        logFn(arg0, arg1, ...args);
+      }
+    }
+  };
 }
 
-export const allLoggers = [rootLogger];
-rootLogger.onChild = (child: pino.Logger) => {
-  allLoggers.push(child);
+function withComponent(logFn: LogFn, component: string): LogFn {
+  return (msg: string, ...args: any[]) => {
+    logFn(`[${component}] ${msg ?? ""}`, ...args);
+  };
+}
+
+export const extraLogger = {
+  loggers: [] as Logger[],
+  child(component: string): ObjLogger {
+    const buildLogFn = (level: keyof Logger) => {
+      const logFn = (...args: any[]) => {
+        const arg0 = args.shift();
+        this.loggers.forEach((logger) => logger[level](arg0, ...args));
+      };
+      return toObjLogFn(withComponent(logFn, component));
+    };
+    return {
+      error: buildLogFn("error"),
+      warn: buildLogFn("warn"),
+      info: buildLogFn("info"),
+      debug: buildLogFn("debug"),
+      trace: buildLogFn("trace"),
+    };
+  },
 };
+
+export function logger(component: string): ObjLogger {
+  const basic = rootBasicLogger.child({ component });
+  const extra = extraLogger.child(component);
+  const all = [basic, extra];
+  const buildLogFn = (level: keyof ObjLogger) => {
+    return (...args: any[]) => {
+      const arg0 = args.shift();
+      all.forEach((logger) => logger[level](arg0, ...args));
+    };
+  };
+  return {
+    error: buildLogFn("error"),
+    warn: buildLogFn("warn"),
+    info: buildLogFn("info"),
+    debug: buildLogFn("debug"),
+    trace: buildLogFn("trace"),
+  };
+}

--- a/clients/tabby-agent/src/postprocess/base.ts
+++ b/clients/tabby-agent/src/postprocess/base.ts
@@ -1,5 +1,5 @@
 import { CompletionResponse, CompletionResponseChoice, CompletionContext } from "../CompletionContext";
-import { rootLogger } from "../logger";
+import { logger as getLogger } from "../logger";
 import "../ArrayExt";
 
 type PostprocessFilterBase<T extends string | CompletionResponseChoice> = (
@@ -10,7 +10,7 @@ type PostprocessFilterBase<T extends string | CompletionResponseChoice> = (
 export type PostprocessFilter = PostprocessFilterBase<string>;
 export type PostprocessChoiceFilter = PostprocessFilterBase<CompletionResponseChoice>;
 
-export const logger = rootLogger.child({ component: "Postprocess" });
+export const logger = getLogger("Postprocess");
 
 export function applyFilter(
   filter: PostprocessFilter,

--- a/clients/vscode/src/TabbyStatusBarItem.ts
+++ b/clients/vscode/src/TabbyStatusBarItem.ts
@@ -1,6 +1,7 @@
 import { StatusBarAlignment, ThemeColor, ExtensionContext, window } from "vscode";
 import { createMachine, interpret } from "@xstate/fsm";
 import type { StatusChangedEvent, AuthRequiredEvent, IssuesUpdatedEvent } from "tabby-agent";
+import { logger } from "./logger";
 import { agent } from "./agent";
 import { notifications } from "./notifications";
 import { TabbyCompletionProvider } from "./TabbyCompletionProvider";
@@ -19,6 +20,7 @@ const backgroundColorNormal = new ThemeColor("statusBar.background");
 const backgroundColorWarning = new ThemeColor("statusBarItem.warningBackground");
 
 export class TabbyStatusBarItem {
+  private readonly logger = logger();
   private item = window.createStatusBarItem(StatusBarAlignment.Right);
   private extensionContext: ExtensionContext;
   private completionProvider: TabbyCompletionProvider;
@@ -144,17 +146,17 @@ export class TabbyStatusBarItem {
     });
 
     agent().on("statusChanged", (event: StatusChangedEvent) => {
-      console.debug("Tabby agent statusChanged", { event });
+      this.logger.info("Tabby agent statusChanged", { event });
       this.fsmService.send(event.status);
     });
 
     agent().on("authRequired", (event: AuthRequiredEvent) => {
-      console.debug("Tabby agent authRequired", { event });
+      this.logger.info("Tabby agent authRequired", { event });
       notifications.showInformationWhenUnauthorized();
     });
 
     agent().on("issuesUpdated", (event: IssuesUpdatedEvent) => {
-      console.debug("Tabby agent issuesUpdated", { event });
+      this.logger.info("Tabby agent issuesUpdated", { event });
       const status = agent().getStatus();
       this.fsmService.send(status);
     });
@@ -227,7 +229,7 @@ export class TabbyStatusBarItem {
       arguments: [() => notifications.showInformationWhenInlineSuggestDisabled()],
     };
 
-    console.debug("Tabby code completion is enabled but inline suggest is disabled.");
+    this.logger.info("Tabby code completion is enabled but inline suggest is disabled.");
     notifications.showInformationWhenInlineSuggestDisabled();
   }
 

--- a/clients/vscode/src/agent.ts
+++ b/clients/vscode/src/agent.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, workspace, env, version } from "vscode";
+import { ExtensionContext, workspace, window, env, version } from "vscode";
 import { TabbyAgent, AgentInitOptions, PartialAgentConfig, ClientProperties, DataStore } from "tabby-agent";
 
 function buildInitOptions(context: ExtensionContext): AgentInitOptions {
@@ -55,7 +55,8 @@ function buildInitOptions(context: ExtensionContext): AgentInitOptions {
     },
   };
   const dataStore = env.appHost === "desktop" ? undefined : extensionDataStore;
-  return { config, clientProperties, dataStore };
+  const loggers = [window.createOutputChannel("Tabby Agent", { log: true })];
+  return { config, clientProperties, dataStore, loggers };
 }
 
 let instance: TabbyAgent | undefined = undefined;

--- a/clients/vscode/src/commands.ts
+++ b/clients/vscode/src/commands.ts
@@ -12,6 +12,7 @@ import {
 } from "vscode";
 import os from "os";
 import { strict as assert } from "assert";
+import { logger } from "./logger";
 import { agent } from "./agent";
 import { notifications } from "./notifications";
 import { TabbyCompletionProvider } from "./TabbyCompletionProvider";
@@ -65,7 +66,7 @@ const setApiEndpoint: Command = {
       })
       .then((url) => {
         if (url) {
-          console.debug("Set Tabby Server URL: ", url);
+          logger().debug("Set Tabby Server URL: ", url);
           configuration.update("api.endpoint", url, configTarget, false);
         }
       });
@@ -88,11 +89,11 @@ const setApiToken = (context: ExtensionContext): Command => {
             return; // User canceled
           }
           if (token.length > 0) {
-            console.debug("Set token: ", token);
+            logger().debug("Set token: ", token);
             context.globalState.update("server.token", token);
             agent().updateConfig("server.token", token);
           } else {
-            console.debug("Clear token.");
+            logger().debug("Clear token.");
             context.globalState.update("server.token", undefined);
             agent().clearConfig("server.token");
           }
@@ -178,7 +179,7 @@ const openAuthPage: Command = {
           if (error.name === "AbortError") {
             return;
           }
-          console.debug("Error auth", { error });
+          logger().error("Error auth", { error });
           notifications.showInformationWhenAuthFailed();
         } finally {
           callbacks?.onAuthEnd?.();

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import { ExtensionContext, languages } from "vscode";
+import { logger } from "./logger";
 import { createAgentInstance, disposeAgentInstance } from "./agent";
 import { tabbyCommands } from "./commands";
 import { TabbyCompletionProvider } from "./TabbyCompletionProvider";
@@ -9,7 +10,7 @@ import { TabbyStatusBarItem } from "./TabbyStatusBarItem";
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export async function activate(context: ExtensionContext) {
-  console.debug("Activating Tabby extension", new Date());
+  logger().info("Activating Tabby extension");
   await createAgentInstance(context);
   const completionProvider = new TabbyCompletionProvider();
   const statusBarItem = new TabbyStatusBarItem(context, completionProvider);
@@ -22,6 +23,6 @@ export async function activate(context: ExtensionContext) {
 
 // this method is called when your extension is deactivated
 export async function deactivate() {
-  console.debug("Deactivating Tabby extension", new Date());
+  logger().info("Deactivating Tabby extension");
   await disposeAgentInstance();
 }

--- a/clients/vscode/src/logger.ts
+++ b/clients/vscode/src/logger.ts
@@ -1,0 +1,10 @@
+import { window, LogOutputChannel } from "vscode";
+
+let instance: LogOutputChannel | undefined = undefined;
+
+export function logger(): LogOutputChannel {
+  if (!instance) {
+    instance = window.createOutputChannel("Tabby", { log: true });
+  }
+  return instance;
+}

--- a/clients/vscode/src/notifications.ts
+++ b/clients/vscode/src/notifications.ts
@@ -4,6 +4,7 @@ import type {
   SlowCompletionResponseTimeIssue,
   ConnectionFailedIssue,
 } from "tabby-agent";
+import { logger } from "./logger";
 import { agent } from "./agent";
 
 function showInformationWhenInitializing() {
@@ -78,7 +79,7 @@ function showInformationWhenInlineSuggestDisabled() {
     .then((selection) => {
       switch (selection) {
         case "Enable":
-          console.debug(`Set editor.inlineSuggest.enabled: true.`);
+          logger().debug(`Set editor.inlineSuggest.enabled: true.`);
           workspace.getConfiguration("editor").update("inlineSuggest.enabled", true, ConfigurationTarget.Global, false);
           break;
         case "Settings":


### PR DESCRIPTION
Complete TAB-486

Added support for logging to the VSCode output channel.

Preview:
![Screenshot from 2024-02-29 12-52-27](https://github.com/TabbyML/tabby/assets/13573879/ea58271d-41e5-4717-82cb-afe2a7517438)

VSCode output log level could be set by `Developer: Set Log Level...` in the command palette.
