### PR TITLE
feat(agent): support fetching server-provided client-side config.

### DIFF
--- a/clients/tabby-agent/openapi/tabby.json
+++ b/clients/tabby-agent/openapi/tabby.json
@@ -4,7 +4,7 @@
     "title": "Tabby Server",
     "description": "\n[![tabby stars](https://img.shields.io/github/stars/TabbyML/tabby)](https://github.com/TabbyML/tabby)\n[![Join Slack](https://shields.io/badge/Join-Tabby%20Slack-red?logo=slack)](https://links.tabbyml.com/join-slack)\n\nInstall following IDE / Editor extensions to get started with [Tabby](https://github.com/TabbyML/tabby).\n* [VSCode Extension](https://github.com/TabbyML/tabby/tree/main/clients/vscode) – Install from the [marketplace](https://marketplace.visualstudio.com/items?itemName=TabbyML.vscode-tabby), or [open-vsx.org](https://open-vsx.org/extension/TabbyML/vscode-tabby)\n* [VIM Extension](https://github.com/TabbyML/tabby/tree/main/clients/vim)\n* [IntelliJ Platform Plugin](https://github.com/TabbyML/tabby/tree/main/clients/intellij) – Install from the [marketplace](https://plugins.jetbrains.com/plugin/22379-tabby)\n",
     "license": { "name": "Apache 2.0", "url": "https://github.com/TabbyML/tabby/blob/main/LICENSE" },
-    "version": "0.7.0"
+    "version": "0.9.0-dev"
   },
   "servers": [{ "url": "/", "description": "Server" }],
   "paths": {
@@ -95,6 +95,19 @@
             "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SearchResponse" } } }
           },
           "501": { "description": "When code search is not enabled, the endpoint will returns 501 Not Implemented" }
+        },
+        "security": [{ "token": [] }]
+      }
+    },
+    "/v1beta/server_setting": {
+      "get": {
+        "tags": ["v1beta"],
+        "operationId": "config",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ServerSetting" } } }
+          }
         },
         "security": [{ "token": [] }]
       }
@@ -300,6 +313,11 @@
             "nullable": true
           }
         }
+      },
+      "ServerSetting": {
+        "type": "object",
+        "required": ["disable_client_side_telemetry"],
+        "properties": { "disable_client_side_telemetry": { "type": "boolean" } }
       },
       "Snippet": {
         "type": "object",

--- a/clients/tabby-agent/src/Agent.ts
+++ b/clients/tabby-agent/src/Agent.ts
@@ -72,6 +72,7 @@ export interface AgentFunction {
    * 1. Default config
    * 2. User config file `~/.tabby-client/agent/config.toml` (not available in browser)
    * 3. Agent `initialize` and `updateConfig` methods
+   * 4. Fetched server-provided config
    *
    * This method will update the 3rd level config.
    * @param key the key of the config to update, can be nested with dot, e.g. `server.endpoint`

--- a/clients/tabby-agent/src/AnonymousUsageLogger.ts
+++ b/clients/tabby-agent/src/AnonymousUsageLogger.ts
@@ -6,7 +6,7 @@ import type { paths as CloudApi } from "./types/cloudApi";
 import { name as agentName, version as agentVersion } from "../package.json";
 import { isBrowser } from "./env";
 import { rootLogger } from "./logger";
-import { dataStore, DataStore } from "./dataStore";
+import { DataStore } from "./dataStore";
 
 export class AnonymousUsageLogger {
   private anonymousUsageTrackingApi = createClient<CloudApi>({ baseUrl: "https://app.tabbyml.com/api" });
@@ -25,13 +25,8 @@ export class AnonymousUsageLogger {
   disabled: boolean = false;
 
   async init(options?: { dataStore?: DataStore }) {
-    this.dataStore = options?.dataStore || dataStore;
+    this.dataStore = options?.dataStore;
     if (this.dataStore) {
-      try {
-        await this.dataStore.load();
-      } catch (error) {
-        this.logger.debug({ error }, "Error when loading anonymousId");
-      }
       if (typeof this.dataStore.data["anonymousId"] === "string") {
         this.anonymousId = this.dataStore.data["anonymousId"];
       } else {

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -296,7 +296,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
       const fetchedConfig = response.data;
       const serverProvidedConfig: PartialAgentConfig = {};
       if (fetchedConfig.disable_client_side_telemetry) {
-        serverProvidedConfig["anonymousUsageTracking"] = {
+        serverProvidedConfig.anonymousUsageTracking = {
           disable: true,
         };
       }

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -294,11 +294,12 @@ export class TabbyAgent extends EventEmitter implements Agent {
       }
       this.logger.debug({ requestId, response }, "Fetch server config response");
       const fetchedConfig = response.data;
-      const serverProvidedConfig = {
-        anonymousUsageTracking: {
-          disable: fetchedConfig.disable_client_side_telemetry,
-        },
-      };
+      const serverProvidedConfig: PartialAgentConfig = {};
+      if (fetchedConfig.disable_client_side_telemetry) {
+        serverProvidedConfig["anonymousUsageTracking"] = {
+          disable: true,
+        };
+      }
 
       if (!deepEqual(serverProvidedConfig, this.serverProvidedConfig)) {
         this.serverProvidedConfig = serverProvidedConfig;

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -19,7 +19,7 @@ import type {
   CompletionResponse,
   LogEventRequest,
 } from "./Agent";
-import type { DataStore } from "./dataStore";
+import { dataStore as defaultDataStore, DataStore, FileDataStore } from "./dataStore";
 import { isBlank, abortSignalFromAnyOf, HttpError, isTimeoutError, isCanceledError, errorToString } from "./utils";
 import { Auth } from "./Auth";
 import { AgentConfig, PartialAgentConfig, defaultAgentConfig } from "./AgentConfig";
@@ -39,6 +39,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
   private config: AgentConfig = defaultAgentConfig;
   private userConfig: PartialAgentConfig = {}; // config from `~/.tabby-client/agent/config.toml`
   private clientConfig: PartialAgentConfig = {}; // config from `initialize` and `updateConfig` method
+  private serverProvidedConfig: PartialAgentConfig = {}; // config fetched from server and saved in dataStore
   private status: AgentStatus = "notInitialized";
   private issues: AgentIssue["name"][] = [];
   private serverHealthState?: ServerHealthState;
@@ -74,7 +75,12 @@ export class TabbyAgent extends EventEmitter implements Agent {
     const oldConfig = this.config;
     const oldStatus = this.status;
 
-    this.config = deepmerge(defaultAgentConfig, this.userConfig, this.clientConfig) as AgentConfig;
+    this.config = deepmerge(
+      defaultAgentConfig,
+      this.userConfig,
+      this.clientConfig,
+      this.serverProvidedConfig,
+    ) as AgentConfig;
     allLoggers.forEach((logger) => (logger.level = this.config.logs.level));
     this.anonymousUsageLogger.disabled = this.config.anonymousUsageTracking.disable;
 
@@ -103,7 +109,12 @@ export class TabbyAgent extends EventEmitter implements Agent {
       this.connectionErrorMessage = undefined;
     }
 
-    await this.setupApi();
+    if (!this.api || !deepEqual(oldConfig.server, this.config.server)) {
+      await this.setupApi();
+
+      // schedule fetch server config later, no await
+      this.fetchServerConfig();
+    }
 
     if (!deepEqual(oldConfig.server, this.config.server)) {
       // If server config changed and status remain `unauthorized`, we want to emit `authRequired` again.
@@ -240,6 +251,9 @@ export class TabbyAgent extends EventEmitter implements Agent {
       ) {
         this.serverHealthState = healthState;
         this.anonymousUsageLogger.uniqueEvent("AgentConnected", healthState);
+
+        // schedule fetch server config later, no await
+        this.fetchServerConfig();
       }
     } catch (error) {
       this.serverHealthState = undefined;
@@ -266,6 +280,46 @@ export class TabbyAgent extends EventEmitter implements Agent {
     }
   }
 
+  private async fetchServerConfig(): Promise<void> {
+    const requestId = uuid();
+    try {
+      if (!this.api) {
+        throw new Error("http client not initialized");
+      }
+      const requestPath = "/v1beta/server_setting";
+      this.logger.debug({ requestId, url: this.config.server.endpoint + requestPath }, "Fetch server config request");
+      const response = await this.api.GET(requestPath);
+      if (response.error || !response.response.ok) {
+        throw new HttpError(response.response);
+      }
+      this.logger.debug({ requestId, response }, "Fetch server config response");
+      const fetchedConfig = response.data;
+      const serverProvidedConfig = {
+        anonymousUsageTracking: {
+          disable: fetchedConfig.disable_client_side_telemetry,
+        },
+      };
+
+      if (!deepEqual(serverProvidedConfig, this.serverProvidedConfig)) {
+        this.serverProvidedConfig = serverProvidedConfig;
+        await this.applyConfig();
+        if (this.dataStore) {
+          if (!this.dataStore.data.serverConfig) {
+            this.dataStore.data.serverConfig = {};
+          }
+          this.dataStore.data.serverConfig[this.config.server.endpoint] = this.serverProvidedConfig;
+          try {
+            await this.dataStore.save();
+          } catch (error) {
+            this.logger.error({ error }, "Error when saving serverConfig");
+          }
+        }
+      }
+    } catch (error) {
+      this.logger.error({ requestId, error }, "Fetch server config error");
+    }
+  }
+
   private createSegments(context: CompletionContext): { prefix: string; suffix: string; clipboard?: string } {
     // max lines in prefix and suffix configurable
     const maxPrefixLines = this.config.completion.prompt.maxPrefixLines;
@@ -288,7 +342,15 @@ export class TabbyAgent extends EventEmitter implements Agent {
   }
 
   public async initialize(options: AgentInitOptions): Promise<boolean> {
-    this.dataStore = options?.dataStore;
+    this.dataStore = options.dataStore ?? defaultDataStore;
+    if (this.dataStore instanceof FileDataStore) {
+      try {
+        await this.dataStore.load();
+      } catch (error) {
+        this.logger.debug({ error }, "No stored data loaded.");
+      }
+      this.dataStore.watch();
+    }
     await this.anonymousUsageLogger.init({ dataStore: this.dataStore });
     if (options.clientProperties) {
       const { user: userProp, session: sessionProp } = options.clientProperties;
@@ -315,6 +377,20 @@ export class TabbyAgent extends EventEmitter implements Agent {
     }
     if (options.config) {
       this.clientConfig = options.config;
+    }
+    if (this.dataStore) {
+      const localConfig = deepmerge(defaultAgentConfig, this.userConfig, this.clientConfig) as AgentConfig;
+      this.serverProvidedConfig = this.dataStore?.data.serverConfig?.[localConfig.server.endpoint] ?? {};
+      if (this.dataStore instanceof FileDataStore) {
+        this.dataStore.on("updated", async () => {
+          const localConfig = deepmerge(defaultAgentConfig, this.userConfig, this.clientConfig) as AgentConfig;
+          const storedServerConfig = defaultDataStore?.data.serverConfig?.[localConfig.server.endpoint];
+          if (!deepEqual(storedServerConfig, this.serverProvidedConfig)) {
+            this.serverProvidedConfig = storedServerConfig ?? {};
+            await this.applyConfig();
+          }
+        });
+      }
     }
     await this.applyConfig();
     await this.anonymousUsageLogger.uniqueEvent("AgentInitialized");

--- a/clients/tabby-agent/src/dataStore.ts
+++ b/clients/tabby-agent/src/dataStore.ts
@@ -5,10 +5,12 @@ import fs from "fs-extra";
 import deepEqual from "deep-equal";
 import chokidar from "chokidar";
 import { isBrowser } from "./env";
+import type { PartialAgentConfig } from "./AgentConfig";
 
 export type StoredData = {
   anonymousId: string;
   auth: { [endpoint: string]: { jwt: string } };
+  serverConfig: { [endpoint: string]: PartialAgentConfig };
 };
 
 export interface DataStore {
@@ -17,7 +19,7 @@ export interface DataStore {
   save(): PromiseLike<void>;
 }
 
-class FileDataStore extends EventEmitter implements FileDataStore {
+export class FileDataStore extends EventEmitter implements FileDataStore {
   private watcher?: ReturnType<typeof chokidar.watch>;
   public data: Partial<StoredData> = {};
 

--- a/clients/tabby-agent/src/types/tabbyApi.d.ts
+++ b/clients/tabby-agent/src/types/tabbyApi.d.ts
@@ -21,6 +21,9 @@ export interface paths {
   "/v1beta/search": {
     get: operations["search"];
   };
+  "/v1beta/server_setting": {
+    get: operations["config"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -197,6 +200,9 @@ export interface components {
       /** @description Clipboard content when requesting code completion. */
       clipboard?: string | null;
     };
+    ServerSetting: {
+      disable_client_side_telemetry: boolean;
+    };
     Snippet: {
       filepath: string;
       body: string;
@@ -314,6 +320,16 @@ export interface operations {
       /** @description When code search is not enabled, the endpoint will returns 501 Not Implemented */
       501: {
         content: never;
+      };
+    };
+  };
+  config: {
+    responses: {
+      /** @description Success */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ServerSetting"];
+        };
       };
     };
   };

--- a/clients/vscode/src/agent.ts
+++ b/clients/vscode/src/agent.ts
@@ -21,9 +21,11 @@ function buildInitOptions(context: ExtensionContext): AgentInitOptions {
     }
   }
   const anonymousUsageTrackingDisabled = configuration.get<boolean>("usage.anonymousUsageTracking", false);
-  config.anonymousUsageTracking = {
-    disable: anonymousUsageTrackingDisabled,
-  };
+  if (anonymousUsageTrackingDisabled) {
+    config.anonymousUsageTracking = {
+      disable: true,
+    };
+  }
   const clientProperties: ClientProperties = {
     user: {
       vscode: {
@@ -82,7 +84,11 @@ export async function createAgentInstance(context: ExtensionContext): Promise<Ta
       }
       if (event.affectsConfiguration("tabby.usage.anonymousUsageTracking")) {
         const anonymousUsageTrackingDisabled = configuration.get<boolean>("usage.anonymousUsageTracking", false);
-        agent.updateConfig("anonymousUsageTracking.disable", anonymousUsageTrackingDisabled);
+        if (anonymousUsageTrackingDisabled) {
+          agent.updateConfig("anonymousUsageTracking.disable", true);
+        } else {
+          agent.clearConfig("anonymousUsageTracking.disable");
+        }
       }
       if (event.affectsConfiguration("tabby.inlineCompletion.triggerMode")) {
         const triggerMode = configuration.get<string>("inlineCompletion.triggerMode", "automatic");


### PR DESCRIPTION
Complete TAB-528

Added support for fetching the server config `disable_client_side_telemetry`:
- When set to true, no tracking data will be sent, regardless of the client-side configuration `anonymousUsageTracking`.
- When set to false, the client-side configuration `anonymousUsageTracking` will be used.