### PR TITLE
fix: fix caddy redirect for api page

### DIFF
--- a/ee/tabby-webserver/development/Caddyfile
+++ b/ee/tabby-webserver/development/Caddyfile
@@ -8,6 +8,10 @@
 		path /hub
 		path /repositories/*
 		path /oauth/*
+
+		path /swagger-ui
+		path /swagger-ui/*
+		path /api-docs/*
 	}
 
 	handle @backend {


### PR DESCRIPTION
fix TAB-536