### PR TITLE
fix(vscode): fix keybinding next word (cmd+right) for macOS.

### DIFF
--- a/clients/vscode/assets/walkthroughs/codeCompletion.md
+++ b/clients/vscode/assets/walkthroughs/codeCompletion.md
@@ -14,7 +14,7 @@ If you select manual trigger in the [settings](command:tabby.openSettings), you 
 
 You can select a keybinding profile in the [settings](command:tabby.openSettings), or customize your own [keybindings](command:tabby.openKeybindings).
 
-|                                    | Next Line | Full Completion | Next Word         |
-| :--------------------------------- | :-------- | :-------------- | :---------------- |
-| _vscode-style_                     | -         | Tab             | Ctrl + RightArrow |
-| _tabby-style_<br/>_(experimental)_ | Tab       | Ctrl + Tab      | Ctrl + RightArrow |
+|                                   | Next Line | Full Completion | Next Word                                       |
+| :-------------------------------- | :-------- | :-------------- | :---------------------------------------------- |
+| _vscode-style_                    | -         | Tab             | Ctrl + RightArrow <br> Cmd + RightArrow (macOS) |
+| _tabby-style_<br>_(experimental)_ | Tab       | Ctrl + Tab      | Ctrl + RightArrow <br> Cmd + RightArrow (macOS) |

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -154,7 +154,7 @@
             "tabby-style"
           ],
           "default": "vscode-style",
-          "markdownDescription": "Select the keybinding profile to accept shown inline completion. \n | | Next Line | Full Completion | Next Word | \n |:---:|:---:|:---:|:---:| \n | _vscode-style_ | - | Tab | Ctrl + RightArrow | \n | _tabby-style_ <br/> _(experimental)_ | Tab | Ctrl + Tab | Ctrl + RightArrow | \n"
+          "markdownDescription": "Select the keybinding profile to accept inline completion. You can also customize it in [Keyboard Shortcuts](command:tabby.openKeybindings). \n | | Next Line | Full Completion | Next Word | \n |:---|:---|:---|:---| \n | _vscode-style_ | - | `Tab` | `Ctrl + RightArrow` (macOS: `Cmd + RightArrow`) | \n | _tabby-style_  _(experimental)_ | `Tab` | `Ctrl + Tab` | `Ctrl + RightArrow` (macOS: `Cmd + RightArrow`) | \n"
         },
         "tabby.usage.anonymousUsageTracking": {
           "type": "boolean",
@@ -177,16 +177,19 @@
       {
         "command": "tabby.inlineCompletion.acceptNextWord",
         "key": "ctrl+right",
+        "mac": "cmd+right",
         "when": "config.tabby.keybindings === 'vscode-style' && inlineSuggestionVisible && !editorReadonly && !suggestWidgetVisible"
       },
       {
         "command": "tabby.inlineCompletion.accept",
         "key": "ctrl+tab",
+        "mac": "ctrl+tab",
         "when": "config.tabby.keybindings === 'tabby-style' && inlineSuggestionVisible && !editorReadonly && !suggestWidgetVisible"
       },
       {
         "command": "tabby.inlineCompletion.acceptNextWord",
         "key": "ctrl+right",
+        "mac": "cmd+right",
         "when": "config.tabby.keybindings === 'tabby-style' && inlineSuggestionVisible && !editorReadonly && !suggestWidgetVisible"
       },
       {


### PR DESCRIPTION
#1557 