### PR TITLE
fix(agent): Do not export FileDataStore to a wide scope

### DIFF
--- a/clients/tabby-agent/src/Auth.ts
+++ b/clients/tabby-agent/src/Auth.ts
@@ -5,7 +5,7 @@ import createClient from "openapi-fetch";
 import type { paths as CloudApi } from "./types/cloudApi";
 import type { AbortSignalOption } from "./Agent";
 import { HttpError, abortSignalFromAnyOf } from "./utils";
-import { DataStore, FileDataStore } from "./dataStore";
+import { DataStore } from "./dataStore";
 import { logger } from "./logger";
 
 export type StorageData = {
@@ -57,7 +57,7 @@ export class Auth extends EventEmitter {
 
   async init(options?: { dataStore?: DataStore }) {
     this.dataStore = options?.dataStore;
-    if (this.dataStore instanceof FileDataStore) {
+    if (this.dataStore instanceof EventEmitter) {
       this.dataStore.on("updated", async () => {
         const oldJwt = this.jwt;
         await this.load();

--- a/clients/tabby-agent/src/dataStore.ts
+++ b/clients/tabby-agent/src/dataStore.ts
@@ -19,7 +19,7 @@ export interface DataStore {
   save(): PromiseLike<void>;
 }
 
-export class FileDataStore extends EventEmitter implements FileDataStore {
+class FileDataStore extends EventEmitter implements DataStore {
   private watcher?: ReturnType<typeof chokidar.watch>;
   public data: Partial<StoredData> = {};
 


### PR DESCRIPTION
Fix #1568 
Do not export FileDataStore to a wide scope, so that it can be treeshaked in browser build.