### PR TITLE
fix(agent): skip fetching server config when server version < 0.9.0.

### DIFF
--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -81,6 +81,7 @@
     "object-hash": "^3.0.0",
     "openapi-fetch": "^0.7.6",
     "pino": "^8.14.1",
+    "semver": "^7.6.0",
     "stats-logscale": "^1.0.7",
     "toml": "^3.0.0",
     "uuid": "^9.0.0",

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -5,6 +5,7 @@ import { deepmerge } from "deepmerge-ts";
 import { getProperty, setProperty, deleteProperty } from "dot-prop";
 import createClient from "openapi-fetch";
 import type { ParseAs } from "openapi-fetch";
+import * as semver from "semver";
 import type { paths as TabbyApi } from "./types/tabbyApi";
 import type {
   Agent,
@@ -281,6 +282,14 @@ export class TabbyAgent extends EventEmitter implements Agent {
   }
 
   private async fetchServerConfig(): Promise<void> {
+    const serverVersion = semver.coerce(this.serverHealthState?.version.git_describe);
+    if (serverVersion && semver.lt(serverVersion, "0.9.0")) {
+      this.logger.debug(
+        { version: this.serverHealthState?.version },
+        "Skip fetching server config due to server version",
+      );
+      return;
+    }
     const requestId = uuid();
     try {
       if (!this.api) {
@@ -317,7 +326,13 @@ export class TabbyAgent extends EventEmitter implements Agent {
         }
       }
     } catch (error) {
-      this.logger.error({ requestId, error }, "Fetch server config error");
+      if (error instanceof HttpError && error.status == 404) {
+        this.logger.debug({ requestId, error }, "Fetch server config failed due to server not supported");
+      } else if (error instanceof HttpError && [401, 403].includes(error.status)) {
+        this.logger.debug({ requestId, error }, "Fetch server config failed due to unauthorized");
+      } else {
+        this.logger.error({ requestId, error }, "Fetch server config error");
+      }
     }
   }
 

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -112,9 +112,6 @@ export class TabbyAgent extends EventEmitter implements Agent {
 
     if (!this.api || !deepEqual(oldConfig.server, this.config.server)) {
       await this.setupApi();
-
-      // schedule fetch server config later, no await
-      this.fetchServerConfig();
     }
 
     if (!deepEqual(oldConfig.server, this.config.server)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,6 +3696,13 @@ semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"


### PR DESCRIPTION
Changes:
- Skip fetching server config when server version < 0.9.0.
- Only schedule fetching server config after the health check returns 200. ( Now it will require auth, which is ignored before)
- Set log level to `debug` when fetching server config returns 401 403 or 404.