### PR TITLE
fix(webserver): incorrect node limit check on worker register

### DIFF
--- a/ee/tabby-webserver/src/service/mod.rs
+++ b/ee/tabby-webserver/src/service/mod.rs
@@ -164,7 +164,7 @@ impl WorkerService for ServerContext {
             .await
             .map_err(|_| RegisterWorkerError::RequiresEnterpriseLicense)?;
 
-        if license.check_node_limit(count_workers + 1) {
+        if !license.check_node_limit(count_workers + 1) {
             return Err(RegisterWorkerError::RequiresEnterpriseLicense);
         }
 


### PR DESCRIPTION
# Brief
There is a problem with missing NOT when checking current node limit.

# Description
The current version of [check_node_limit](https://github.com/TabbyML/tabby/blob/a80935f4637187ddea0b8c5dfb4f3d0161f796c2/ee/tabby-webserver/src/schema/license.rs#L45) returns true if the node limit has not been reached and, therefore, a worker should be registered but [here](https://github.com/TabbyML/tabby/blob/a80935f4637187ddea0b8c5dfb4f3d0161f796c2/ee/tabby-webserver/src/service/mod.rs#L167) function fails resulting in Requires Enterprise License error. The PR adds missing NOT operation.

