### PR TITLE
fix: default value for server settings without webserver enabled.

### DIFF
--- a/crates/tabby/src/routes/server_setting.rs
+++ b/crates/tabby/src/routes/server_setting.rs
@@ -15,7 +15,7 @@ use tabby_common::api::server_setting::ServerSetting;
 )]
 pub async fn setting() -> Json<ServerSetting> {
     let config = ServerSetting {
-        disable_client_side_telemetry: true,
+        disable_client_side_telemetry: false,
     };
     Json(config)
 }


### PR DESCRIPTION
Fixed: the default value for `disable_client_side_telemetry` in `server_settings` should be `false`.

BTW I think it should be better to return 404 from `/v1beta/server_setting` when the webserver feature is not enabled. Then the client will know that the current server does not support the `server_setting` feature.