### PR TITLE
feat(tabby): Added --chat-device arg for serve subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.10.0 [UNRELEASED]
 
 ## Features
+* Added the --chat-device flag to override a device used to run chat model.
 
 ## Fixes and Improvements
 

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -97,6 +97,10 @@ pub struct ServeArgs {
     #[clap(long, default_value_t=Device::Cpu)]
     device: Device,
 
+    /// Device to run chat model [default equals --device arg]
+    #[clap(long, requires("chat_model"))]
+    chat_device: Option<Device>,
+
     /// Parallelism for model serving - increasing this number will have a significant impact on the
     /// memory requirement e.g., GPU vRAM.
     #[clap(long, default_value_t = 1)]
@@ -187,7 +191,13 @@ async fn api_router(
 
     let chat_state = if let Some(chat_model) = &args.chat_model {
         Some(Arc::new(
-            create_chat_service(logger.clone(), chat_model, &args.device, args.parallelism).await,
+            create_chat_service(
+                logger.clone(),
+                chat_model,
+                args.chat_device.as_ref().unwrap_or(&args.device),
+                args.parallelism,
+            )
+            .await,
         ))
     } else {
         None


### PR DESCRIPTION
# Brief
A implementation of issue #1659 

# Details
The very simple implementation of the --chat-device flag to override device to use for chat model. This implementation, however, rejects arguments if --chat-device specified without the --chat-model flag. The issue suggests giving a warning instead, but I found out a good `clap` macro to achieve the implemented behaviour. I decided to not implement a logging warning message and give the situation handling to the `clap` crate to keep the code clean.

# Testing
Tested with rocm + cpu devices. I cannot test other devices myself.

---
closes  #1659 