### PR TITLE
feat(ui): adjust the dark theme for card and popup

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/sso/components/oauth-credential-list.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/sso/components/oauth-credential-list.tsx
@@ -91,7 +91,7 @@ const OAuthCredentialList = () => {
   }
 
   return (
-    <div className="mx-auto max-w-2xl">
+    <div>
       <SSOHeader />
       <div className="flex flex-col gap-8">
         {credentialList.map(credential => {
@@ -117,7 +117,7 @@ const OauthCredentialCard = ({
   }, [data])
   return (
     <Card>
-      <CardHeader className="border-b border-secondary p-4">
+      <CardHeader className="border-b p-4">
         <div className="flex items-center justify-between">
           <CardTitle className="text-xl">
             {meta?.displayName || data?.provider}
@@ -131,7 +131,7 @@ const OauthCredentialCard = ({
         </div>
       </CardHeader>
       <CardContent className="p-4 text-sm">
-        <div className="flex border-b border-secondary py-2">
+        <div className="flex border-b py-2">
           <span className="w-[100px]">Type</span>
           <span>OAuth 2.0</span>
         </div>

--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/sso/components/oauth-credential-list.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/sso/components/oauth-credential-list.tsx
@@ -91,7 +91,7 @@ const OAuthCredentialList = () => {
   }
 
   return (
-    <div>
+    <div className="mx-auto max-w-2xl">
       <SSOHeader />
       <div className="flex flex-col gap-8">
         {credentialList.map(credential => {
@@ -117,21 +117,21 @@ const OauthCredentialCard = ({
   }, [data])
   return (
     <Card>
-      <CardHeader className="border-b p-4">
+      <CardHeader className="border-b border-secondary p-4">
         <div className="flex items-center justify-between">
           <CardTitle className="text-xl">
             {meta?.displayName || data?.provider}
           </CardTitle>
           <Link
             href={`/settings/sso/detail/${data?.provider.toLowerCase()}`}
-            className={buttonVariants({ variant: 'secondary' })}
+            className={buttonVariants({ variant: 'default' })}
           >
             View
           </Link>
         </div>
       </CardHeader>
       <CardContent className="p-4 text-sm">
-        <div className="flex border-b py-2">
+        <div className="flex border-b border-secondary py-2">
           <span className="w-[100px]">Type</span>
           <span>OAuth 2.0</span>
         </div>

--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/sso/components/oauth-credential-list.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/sso/components/oauth-credential-list.tsx
@@ -124,7 +124,7 @@ const OauthCredentialCard = ({
           </CardTitle>
           <Link
             href={`/settings/sso/detail/${data?.provider.toLowerCase()}`}
-            className={buttonVariants({ variant: 'default' })}
+            className={buttonVariants({ variant: 'secondary' })}
           >
             View
           </Link>

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -51,7 +51,7 @@
     --popover: 39 15% 29%;
     --popover-foreground: 39 3.2% 99.35%;
 
-    --card: 39 15% 27%;
+    --card: 39 15% 29%;
     --card-foreground: 39 3.2% 99.35%;
 
     --border: 39 16% 26.1%;

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -45,7 +45,7 @@
     --background: 0 0 12%;
     --foreground: 39 3.2% 99.35%;
 
-    --muted: 39 16% 26.1%;
+    --muted: 39 13% 21%;
     --muted-foreground: 39 3.2% 58.7%;
 
     --popover: 39 15% 27%;
@@ -54,7 +54,7 @@
     --card: 39 15% 27%;
     --card-foreground: 39 3.2% 99.35%;
 
-    --border: 39 16% 26.1%;
+    --border: 39 13% 21%;
     --input: 39 16% 26.1%;
 
     --primary: 39 32% 87%;
@@ -63,7 +63,7 @@
     --secondary: 39 13% 21%;
     --secondary-foreground: 39 3.2% 99.35%;
 
-    --accent: 39 16% 26.1%;
+    --accent: 39 13% 21%;
     --accent-foreground: 39 3.2% 99.35%;
 
     --destructive: 3.2 36.95% 60.2%;

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -48,10 +48,10 @@
     --muted: 39 16% 26.1%;
     --muted-foreground: 39 3.2% 58.7%;
 
-    --popover: 0 0 12%;
+    --popover: 39 15% 29%;
     --popover-foreground: 39 3.2% 99.35%;
 
-    --card: 0 0 12%;
+    --card: 39 15% 29%;
     --card-foreground: 39 3.2% 99.35%;
 
     --border: 39 16% 26.1%;

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -51,7 +51,7 @@
     --popover: 39 15% 29%;
     --popover-foreground: 39 3.2% 99.35%;
 
-    --card: 39 15% 29%;
+    --card: 39 15% 27%;
     --card-foreground: 39 3.2% 99.35%;
 
     --border: 39 16% 26.1%;

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -48,10 +48,10 @@
     --muted: 39 16% 26.1%;
     --muted-foreground: 39 3.2% 58.7%;
 
-    --popover: 39 58.6% 11.31%;
+    --popover: 0 0 12%;
     --popover-foreground: 39 3.2% 99.35%;
 
-    --card: 39 58.6% 11.31%;
+    --card: 0 0 12%;
     --card-foreground: 39 3.2% 99.35%;
 
     --border: 39 16% 26.1%;

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -48,10 +48,10 @@
     --muted: 39 16% 26.1%;
     --muted-foreground: 39 3.2% 58.7%;
 
-    --popover: 39 15% 29%;
+    --popover: 39 15% 27%;
     --popover-foreground: 39 3.2% 99.35%;
 
-    --card: 39 15% 29%;
+    --card: 39 15% 27%;
     --card-foreground: 39 3.2% 99.35%;
 
     --border: 39 16% 26.1%;


### PR DESCRIPTION
fix TAB-568

### Previous:

![屏幕截图 2024-03-26 154544](https://github.com/TabbyML/tabby/assets/5305874/e6366f21-d0dd-460e-92ef-48b74ab50035)
![屏幕截图 2024-03-26 154552](https://github.com/TabbyML/tabby/assets/5305874/64b05005-717a-4174-9132-49178bf736e0)

### Current:
#### Card
![cluster](https://github.com/TabbyML/tabby/assets/5305874/7d1bf867-2da0-475f-990b-a6a304133aa1)

![sso](https://github.com/TabbyML/tabby/assets/5305874/70a0cda2-ba56-490d-be6f-2e3daf44e6d2)


#### Popup
![popup](https://github.com/TabbyML/tabby/assets/5305874/2b06834f-81f7-4760-a3b6-c40bd435d532)


