### PR TITLE
ci: support Vulkan build on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           - x86_64-manylinux2014-cuda122
           - x86_64-manylinux2014-vulkan
           - x86_64-windows-msvc
+          - x86_64-windows-msvc-vulkan
           - x86_64-windows-msvc-cuda117
           - x86_64-windows-msvc-cuda122
         include:
@@ -66,6 +67,12 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc
             ext: .exe
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: x86_64-windows-msvc-vulkan
+            ext: .exe
+            build_args: --features vulkan,prod-db
+            vulkan_sdk: '1.3.280.0'
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc-cuda117

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,12 @@ To run Tabby locally with ROCm (AMD):
 cargo run --features rocm serve --model TabbyML/StarCoder-1B --device rocm
 ```
 
+To run Tabby locally with Vulkan:
+
+```
+cargo run --features vulkan serve --model TabbyML/StarCoder-1B --device vulkan
+```
+
 To run Tabby locally with Metal (Apple M1/M2):
 
 ```

--- a/crates/llama-cpp-bindings/build.rs
+++ b/crates/llama-cpp-bindings/build.rs
@@ -94,7 +94,11 @@ fn build_llama_cpp() {
             println!("cargo:rustc-link-search={}/lib", vulkan_sdk_path);
         }
         config.define("LLAMA_VULKAN", "ON");
-        println!("cargo:rustc-link-lib=vulkan");
+        if cfg!(target_os = "windows") {
+            println!("cargo:rustc-link-lib=vulkan-1");
+        } else {
+            println!("cargo:rustc-link-lib=vulkan");
+        }
     }
 
     // By default, this value is automatically inferred from Rust’s compilation profile.

--- a/crates/llama-cpp-bindings/build.rs
+++ b/crates/llama-cpp-bindings/build.rs
@@ -91,7 +91,7 @@ fn build_llama_cpp() {
     }
     if cfg!(feature = "vulkan") {
         if let Ok(vulkan_sdk_path) = env::var("VULKAN_SDK") {
-            println!("cargo:rustc-link-search=native={}/lib", vulkan_sdk_path);
+            println!("cargo:rustc-link-search={}/lib", vulkan_sdk_path);
         }
         config.define("LLAMA_VULKAN", "ON");
         println!("cargo:rustc-link-lib=vulkan");

--- a/website/docs/installation/windows/index.mdx
+++ b/website/docs/installation/windows/index.mdx
@@ -12,7 +12,8 @@ Running Tabby on Windows using Tabby's exe distribution.
 
 ## 2. Download the release
 * If you are using a CPU-only system, download the **tabby_x86_64-windows-msvc.exe file**.
-* If you are using a GPU-enabled system, download the **tabby_x86_64-windows-msvc-cuda117.exe** file, In this example, we assume you are using CUDA 11.7.
+* If you are using an Nvidia GPU, download the **tabby_x86_64-windows-msvc-cuda117.exe** file, In this example, we assume you are using CUDA 11.7.
+* If you are using a different GPU with Vulkan support, download the **tabby_x86_64-windows-msvc-vulkan.exe** file.
 
 **Tips:**
 * Download the CUDA Toolkit from Nvidia: https://developer.nvidia.com/cuda-toolkit
@@ -26,6 +27,10 @@ nvcc --version
 Open a command prompt or PowerShell window in the directory where you downloaded the Tabby executable. Run the following command:
 ```
 .\tabby_x86_64-windows-msvc-cuda117.exe serve --model StarCoder-1B --device cuda
+```
+or
+```
+.\tabby_x86_64-windows-msvc-vulkan.exe serve --model StarCoder-1B --device vulkan
 ```
 You should see the following output if the command runs successfully:
 ![Windows running output](./status.png)

--- a/website/docs/installation/windows/index.mdx
+++ b/website/docs/installation/windows/index.mdx
@@ -12,8 +12,7 @@ Running Tabby on Windows using Tabby's exe distribution.
 
 ## 2. Download the release
 * If you are using a CPU-only system, download the **tabby_x86_64-windows-msvc.exe file**.
-* If you are using an Nvidia GPU, download the **tabby_x86_64-windows-msvc-cuda117.exe** file, In this example, we assume you are using CUDA 11.7.
-* If you are using a different GPU with Vulkan support, download the **tabby_x86_64-windows-msvc-vulkan.exe** file.
+* If you are using a GPU-enabled system, download the **tabby_x86_64-windows-msvc-cuda117.exe** file, In this example, we assume you are using CUDA 11.7.
 
 **Tips:**
 * Download the CUDA Toolkit from Nvidia: https://developer.nvidia.com/cuda-toolkit
@@ -27,10 +26,6 @@ nvcc --version
 Open a command prompt or PowerShell window in the directory where you downloaded the Tabby executable. Run the following command:
 ```
 .\tabby_x86_64-windows-msvc-cuda117.exe serve --model StarCoder-1B --device cuda
-```
-or
-```
-.\tabby_x86_64-windows-msvc-vulkan.exe serve --model StarCoder-1B --device vulkan
 ```
 You should see the following output if the command runs successfully:
 ![Windows running output](./status.png)


### PR DESCRIPTION
I tried compiling the Vulkan feature on Windows, but was running into the vulkan library not being found by the build script. This is the fix. Now I can run tabby on my AMD 5700XT on Windows. It's seems quite fast too!

Changes:
* Remove `=native` in vulkan feature in build.rs so that all library kinds are part of the search. This *shouldn't* break the Linux builds, but if it does CI should catch it.
* Add a CI step to create a Windows Vulkan build automatically. If I'm lucky it'll work first try? 🤞
* User-facing documentation changes to reflect Vulkan support.