### PR TITLE
fix(scheduler): Log and skip instead of panicking on invalid tag range

### DIFF
--- a/crates/tabby-scheduler/src/index.rs
+++ b/crates/tabby-scheduler/src/index.rs
@@ -73,17 +73,18 @@ struct IndexedDocument {
     kind: String,
 }
 
-fn read_range_or_panic(filename: &str, content: &str, range: Range<usize>) -> String {
-    content
-        .get(range.clone())
-        .unwrap_or_else(|| panic!("Failed to read content '{range:?}' from '{filename}'"))
-        .to_owned()
+fn read_range(filename: &str, content: &str, range: Range<usize>) -> Option<String> {
+    let Some(content) = content.get(range.clone()) else {
+        eprintln!("Failed to read content '{range:?}' from '{filename}'");
+        return None;
+    };
+    Some(content.to_string())
 }
 
 fn from_source_file(file: SourceFile) -> impl Iterator<Item = IndexedDocument> {
     file.tags.into_iter().filter_map(move |tag| {
-        let name = read_range_or_panic(&file.filepath, &file.content, tag.name_range);
-        let body = read_range_or_panic(&file.filepath, &file.content, tag.range);
+        let name = read_range(&file.filepath, &file.content, tag.name_range)?;
+        let body = read_range(&file.filepath, &file.content, tag.range)?;
 
         if body.lines().collect::<Vec<_>>().len() > MAX_BODY_LINES_THRESHOLD {
             return None;


### PR DESCRIPTION
Fixes TAB-570, closes https://github.com/TabbyML/tabby/issues/1697