### PR TITLE
fix(core): add Clone trait to the Declaration

### DIFF
--- a/crates/tabby-common/src/api/event.rs
+++ b/crates/tabby-common/src/api/event.rs
@@ -98,7 +98,7 @@ pub struct Segments {
     pub declarations: Option<Vec<Declaration>>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Declaration {
     pub filepath: String,
     pub body: String,


### PR DESCRIPTION
To fix the error
```rust
error[E0277]: the trait bound `Declaration: Clone` is not satisfied
  --> crates/tabby-common/src/api/event.rs:98:5
   |
86 | #[derive(Serialize, Deserialize, Debug, Clone)]
   |                                         ----- in this derive macro expansion
...
98 |     pub declarations: Option<Vec<Declaration>>,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `Declaration`, which is required by `std::option::Option<std::vec::Vec<Declaration>>: Clone`
   |
```