### PR TITLE
feat(core): added recent snippets in completion request segments.

### DIFF
--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -56,7 +56,6 @@ Install following IDE / Editor extensions to get started with [Tabby](https://gi
         completion::CompletionResponse,
         completion::Segments,
         completion::Declaration,
-        completion::RecentSnippet,
         completion::Choice,
         completion::Snippet,
         completion::DebugOptions,

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -56,6 +56,7 @@ Install following IDE / Editor extensions to get started with [Tabby](https://gi
         completion::CompletionResponse,
         completion::Segments,
         completion::Declaration,
+        completion::RecentSnippet,
         completion::Choice,
         completion::Snippet,
         completion::DebugOptions,

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -122,8 +122,8 @@ pub struct Segments {
     declarations: Option<Vec<Declaration>>,
 
     /// The relevant code snippets extracted from recently edited files.
-    /// These snippets are selected from candidates found within a 
-    /// code chunk based on the edited location.
+    /// These snippets are selected from candidates found within code chunks
+    /// based on the edited location.
     /// The current editing file is excluded from the search candidates.
     ///
     /// When provided alongside [Segments::declarations], the snippets have

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -121,14 +121,15 @@ pub struct Segments {
     /// contain declarations of symbols extracted from [Segments::prefix].
     declarations: Option<Vec<Declaration>>,
 
-    /// The relevant code snippets extracted from recently accessed files.
+    /// The relevant code snippets extracted from recently changed files.
     /// The current editing file is excluded from the search candidates.
     ///
-    /// When provided alongside [Segments::declarations], the snippets should
-    /// be deduplicated to avoid duplication with entries in `declarations`.
+    /// When provided alongside [Segments::declarations], the snippets have
+    /// already been deduplicated to ensure no duplication with entries
+    /// in [Segments::declarations].
     ///
-    /// Sorted in descending order of [RecentSnippet::score].
-    recent_snippets: Option<Vec<RecentSnippet>>,
+    /// Sorted in descending order of [Snippet::score].
+    relevant_snippets_from_changed_files: Option<Vec<Snippet>>,
 
     /// Clipboard content when requesting code completion.
     clipboard: Option<String>,
@@ -169,21 +170,6 @@ impl From<Declaration> for api::event::Declaration {
             body: val.body,
         }
     }
-}
-
-/// A snippet of code that is relevant to the current completion request.
-#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
-pub struct RecentSnippet {
-    /// Filepath of the file where the snippet is from.
-    /// Use the same rule as [Segments::filepath].
-    pub filepath: String,
-
-    /// Body of the snippet.
-    pub body: String,
-
-    /// A higher score means that the snippet is more relevant.
-    /// The value is in [0, 1].
-    pub score: f32,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
@@ -400,7 +386,7 @@ mod tests {
             filepath: None,
             git_url: None,
             declarations: None,
-            recent_snippets: None,
+            relevant_snippets_from_changed_files: None,
             clipboard: None,
         };
 
@@ -416,7 +402,7 @@ mod tests {
                 body: "def fib(n):\n    return n if n <= 1 else fib(n - 1) + fib(n - 2)"
                     .to_string(),
             }]),
-            recent_snippets: None,
+            relevant_snippets_from_changed_files: None,
             clipboard: None,
         };
 

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -121,7 +121,9 @@ pub struct Segments {
     /// contain declarations of symbols extracted from [Segments::prefix].
     declarations: Option<Vec<Declaration>>,
 
-    /// The relevant code snippets extracted from recently changed files.
+    /// The relevant code snippets extracted from recently edited files.
+    /// These snippets are selected from candidates found within a 
+    /// code chunk based on the edited location.
     /// The current editing file is excluded from the search candidates.
     ///
     /// When provided alongside [Segments::declarations], the snippets have

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -108,8 +108,8 @@ pub struct Segments {
     suffix: Option<String>,
 
     /// The relative path of the file that is being edited.
-    /// - When `git_url` is set, this is the path of the file in the git repository.
-    /// - When `git_url` is empty, this is the path of the file in the workspace.
+    /// - When [Segments::git_url] is set, this is the path of the file in the git repository.
+    /// - When [Segments::git_url] is empty, this is the path of the file in the workspace.
     filepath: Option<String>,
 
     /// The remote URL of the current git repository.
@@ -117,9 +117,18 @@ pub struct Segments {
     /// or the git repository does not have a remote URL.
     git_url: Option<String>,
 
-    /// The relevant declaration code snippets provided by editor.
-    /// It'll contains declarations extracted from `prefix` segments using LSP.
+    /// The relevant declaration code snippets provided by the editor's LSP,
+    /// contain declarations of symbols extracted from [Segments::prefix].
     declarations: Option<Vec<Declaration>>,
+
+    /// The relevant code snippets extracted from recently accessed files.
+    /// The current editing file is excluded from the search candidates.
+    ///
+    /// When provided alongside [Segments::declarations], the snippets should
+    /// be deduplicated to avoid duplication with entries in `declarations`.
+    ///
+    /// Sorted in descending order of [RecentSnippet::score].
+    recent_snippets: Option<Vec<RecentSnippet>>,
 
     /// Clipboard content when requesting code completion.
     clipboard: Option<String>,
@@ -144,7 +153,7 @@ impl From<Segments> for api::event::Segments {
 pub struct Declaration {
     /// Filepath of the file where the snippet is from.
     /// - When the file belongs to the same workspace as the current file,
-    ///   this is a relative filepath, that has the same root as the current file.
+    ///   this is a relative filepath, use the same rule as [Segments::filepath].
     /// - When the file located outside the workspace, such as in a dependency package,
     ///   this is a file URI with an absolute filepath.
     pub filepath: String,
@@ -160,6 +169,21 @@ impl From<Declaration> for api::event::Declaration {
             body: val.body,
         }
     }
+}
+
+/// A snippet of code that is relevant to the current completion request.
+#[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
+pub struct RecentSnippet {
+    /// Filepath of the file where the snippet is from.
+    /// Use the same rule as [Segments::filepath].
+    pub filepath: String,
+
+    /// Body of the snippet.
+    pub body: String,
+
+    /// A higher score means that the snippet is more relevant.
+    /// The value is in [0, 1].
+    pub score: f32,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
@@ -376,6 +400,7 @@ mod tests {
             filepath: None,
             git_url: None,
             declarations: None,
+            recent_snippets: None,
             clipboard: None,
         };
 
@@ -391,6 +416,7 @@ mod tests {
                 body: "def fib(n):\n    return n if n <= 1 else fib(n - 1) + fib(n - 2)"
                     .to_string(),
             }]),
+            recent_snippets: None,
             clipboard: None,
         };
 

--- a/crates/tabby/src/services/completion/completion_prompt.rs
+++ b/crates/tabby/src/services/completion/completion_prompt.rs
@@ -196,6 +196,7 @@ mod tests {
             filepath: None,
             git_url: None,
             declarations: None,
+            recent_snippets: None,
             clipboard: None,
         }
     }

--- a/crates/tabby/src/services/completion/completion_prompt.rs
+++ b/crates/tabby/src/services/completion/completion_prompt.rs
@@ -196,7 +196,7 @@ mod tests {
             filepath: None,
             git_url: None,
             declarations: None,
-            recent_snippets: None,
+            relevant_snippets_from_changed_files: None,
             clipboard: None,
         }
     }


### PR DESCRIPTION
TAB-512

Changes:
- Added `recent_snippets` in completion request segments.
- Updated comments using rustdoc links. (But it does not seem to be compiled to openapi doc links)