### PR TITLE
fix(ui): format of accept rate in report page

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -47,7 +47,7 @@ function StatsSummary({
   const acceptRate =
     totalAcceptances === 0
       ? 0
-      : Math.round((totalAcceptances / totalCompletions) * 100)
+      : ((totalAcceptances / totalCompletions) * 100).toFixed(2)
   return (
     <div className="flex w-full items-center justify-center space-x-6 xl:justify-start">
       <Card className="flex flex-1 flex-col justify-between self-stretch bg-primary-foreground/30 md:block">


### PR DESCRIPTION
<img width="1147" alt="2024-04-10 09 02 14" src="https://github.com/TabbyML/tabby/assets/5305874/64a5d9ef-768e-4617-b081-f9e51d7cc0b4">
