### PR TITLE
fix(ui): report page title format & language selection order

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -66,7 +66,7 @@ function StatsSummary({
       <Card className="flex flex-1 flex-col justify-between self-stretch bg-primary-foreground/30 md:block">
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">
-            Total completions
+            Total Completions
           </CardTitle>
           <IconCode className="text-muted-foreground" />
         </CardHeader>
@@ -80,7 +80,7 @@ function StatsSummary({
       <Card className="flex flex-1 flex-col justify-between self-stretch bg-primary-foreground/30 md:block">
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">
-            Total acceptances
+            Total Acceptances
           </CardTitle>
           <IconCheck className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
@@ -275,7 +275,7 @@ export function Report() {
                 <SelectContent>
                   <SelectGroup>
                     <SelectItem value={'all'}>All</SelectItem>
-                    {Object.entries(Language).map(([key, value]) => (
+                    {Object.entries(Language).sort((_, b) => b[1] === Language.Other ? -1 : 0).map(([key, value]) => (
                       <SelectItem key={value} value={value}>
                         {key}
                       </SelectItem>

--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -275,11 +275,13 @@ export function Report() {
                 <SelectContent>
                   <SelectGroup>
                     <SelectItem value={'all'}>All</SelectItem>
-                    {Object.entries(Language).sort((_, b) => b[1] === Language.Other ? -1 : 0).map(([key, value]) => (
-                      <SelectItem key={value} value={value}>
-                        {key}
-                      </SelectItem>
-                    ))}
+                    {Object.entries(Language)
+                      .sort((_, b) => (b[1] === Language.Other ? -1 : 0))
+                      .map(([key, value]) => (
+                        <SelectItem key={value} value={value}>
+                          {key}
+                        </SelectItem>
+                      ))}
                   </SelectGroup>
                 </SelectContent>
               </Select>


### PR DESCRIPTION
### Align the format of the title
<img width="1084" alt="2" src="https://github.com/TabbyML/tabby/assets/5305874/0a770c89-4d73-45ef-b640-b01b5c512168">

### Language Other always at the end of option list
<img width="691" alt="1" src="https://github.com/TabbyML/tabby/assets/5305874/dc0ce645-79bd-40e7-a7e8-429e4f4aad44">
