### PR TITLE
fix(ui): The date-range-picker can only select dates before the current date

### DIFF
--- a/ee/tabby-ui/components/ui/date-range-picker.tsx
+++ b/ee/tabby-ui/components/ui/date-range-picker.tsx
@@ -13,6 +13,7 @@ import {
   PopoverContent,
   PopoverTrigger
 } from '@/components/ui/popover'
+import moment from 'moment'
 
 export default function DatePickerWithRange({
   dateRange,
@@ -68,10 +69,11 @@ export default function DatePickerWithRange({
           <Calendar
             initialFocus
             mode="range"
-            defaultMonth={date?.from}
+            defaultMonth={moment(date?.from).subtract(1, 'month').toDate()}
             selected={date}
             onSelect={setDate}
             numberOfMonths={2}
+            disabled={(date: Date) => date > new Date()}
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
https://jam.dev/c/f13a4f55-0ada-454e-a44c-fb41ae445c89