### PR TITLE
fix(ui): restrict image type of avatar

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/profile/components/avatar.tsx
+++ b/ee/tabby-ui/app/(dashboard)/profile/components/avatar.tsx
@@ -84,7 +84,7 @@ export const Avatar = () => {
         <input
           id="avatar-file"
           type="file"
-          accept="image/*"
+          accept="image/png, image/jpeg"
           className="hidden"
           onChange={onPreviewAvatar}
         />


### PR DESCRIPTION
Test:
* .png, .jpg, .jpeg are supported to upload, updated and display
* other files are not selectable, e.g.:
<img width="218" alt="2024-04-17 09 26 21" src="https://github.com/TabbyML/tabby/assets/5305874/54cf5321-7a37-4184-9708-b6c52ee0f715">
