### PR TITLE
chore(vscode): bump vsce version to 1.5.2.

### DIFF
--- a/clients/vscode/CHANGELOG.md
+++ b/clients/vscode/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.2
+
+### Fixes
+
+- Fixed an issue where the indexing worker for recently edited code may cause a stuck.
+
 ## 1.5.0
 
 ### Features

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/TabbyML/tabby",
   "bugs": "https://github.com/TabbyML/tabby/issues",
   "license": "Apache-2.0",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "keywords": [
     "ai",
     "autocomplete",


### PR DESCRIPTION
V1.5.2 is a pre-release version.