### PR TITLE
fix(ui): block form submission upon loading of response in playground

### DIFF
--- a/ee/tabby-ui/components/prompt-form.tsx
+++ b/ee/tabby-ui/components/prompt-form.tsx
@@ -147,6 +147,10 @@ function PromptFormRenderer(
       return
     }
 
+    if (isLoading) {
+      return
+    }
+
     let finalInput = input
     // replace queryname to doc.body of selected completions
     Object.keys(selectedCompletionsMap).forEach(key => {


### PR DESCRIPTION
Prevent form submission on pressing Enter when the response is still loading in the playground