### PR TITLE
fix(ui): time zone inconsistency in charts

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/reports/components/annual-activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/annual-activity.tsx
@@ -45,7 +45,7 @@ export function AnnualActivity({
   let lastYearActivities = 0
   const dailyCompletionMap: Record<string, number> =
     yearlyStats?.reduce((acc, cur) => {
-      const date = moment(cur.start).format('YYYY-MM-DD')
+      const date = moment.utc(cur.start).format('YYYY-MM-DD')
       lastYearActivities += cur.completions
       lastYearActivities += cur.selects
       return { ...acc, [date]: cur.completions }

--- a/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
@@ -70,7 +70,7 @@ export function DailyActivity({
   const dailySelectMap: Record<string, number> = {}
 
   dailyStats?.forEach(stats => {
-    const date = moment(stats.start).format('YYYY-MM-DD')
+    const date = moment.utc(stats.start).format('YYYY-MM-DD')
     dailyCompletionMap[date] = stats.completions
     dailySelectMap[date] = stats.selects
   }, {})
@@ -78,15 +78,15 @@ export function DailyActivity({
   const daysBetweenRange = eachDayOfInterval({
     start: from,
     end: to
-  })
+  }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
 
   const chartData = daysBetweenRange.map(date => {
-    const dateKey = moment(date).format('YYYY-MM-DD')
+    const dateKey = moment.utc(date).format('YYYY-MM-DD')
     const completion = dailyCompletionMap[dateKey] || 0
     const select = dailySelectMap[dateKey] || 0
     const pending = completion - select
     return {
-      name: moment(date).format('D MMM'),
+      name: moment.utc(date).format('D MMM'),
       completion,
       select,
       pending

--- a/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
@@ -78,15 +78,15 @@ export function DailyActivity({
   const daysBetweenRange = eachDayOfInterval({
     start: from,
     end: to
-  }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
+  })
 
   const chartData = daysBetweenRange.map(date => {
-    const dateKey = moment.utc(date).format('YYYY-MM-DD')
+    const dateKey = moment(date).format('YYYY-MM-DD')
     const completion = dailyCompletionMap[dateKey] || 0
     const select = dailySelectMap[dateKey] || 0
     const pending = completion - select
     return {
-      name: moment.utc(date).format('D MMM'),
+      name: moment(date).format('D MMM'),
       completion,
       select,
       pending

--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -157,7 +157,9 @@ export function Report() {
   const [{ data: dailyStatsData, fetching: fetchingDailyState }] = useQuery({
     query: queryDailyStats,
     variables: {
-      start: moment(dateRange.from).startOf('day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+      start: moment(dateRange.from)
+        .startOf('day')
+        .format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
       end: moment(dateRange.to).endOf('day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
       users: selectedMember === KEY_SELECT_ALL ? undefined : [selectedMember],
       languages: selectedLanguage.length === 0 ? undefined : selectedLanguage

--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -157,8 +157,8 @@ export function Report() {
   const [{ data: dailyStatsData, fetching: fetchingDailyState }] = useQuery({
     query: queryDailyStats,
     variables: {
-      start: moment(dateRange.from).startOf('day').utc().format(),
-      end: moment(dateRange.to).endOf('day').utc().format(),
+      start: moment(dateRange.from).startOf('day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+      end: moment(dateRange.to).endOf('day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
       users: selectedMember === KEY_SELECT_ALL ? undefined : [selectedMember],
       languages: selectedLanguage.length === 0 ? undefined : selectedLanguage
     }
@@ -176,8 +176,8 @@ export function Report() {
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 10)
       return {
-        start: moment(date).startOf('day').toDate(),
-        end: moment(date).endOf('day').toDate(),
+        start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+        end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         completions,
         selects
       }
@@ -211,8 +211,8 @@ export function Report() {
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 10)
       return {
-        start: moment(date).startOf('day').toDate(),
-        end: moment(date).endOf('day').toDate(),
+        start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+        end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         completions,
         selects
       }

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -107,13 +107,11 @@ function BarTooltip({
 export function CompletionCharts({
   from,
   to,
-  dailyStats,
-  dateRange
+  dailyStats
 }: {
   from: Date
   to: Date
   dailyStats?: DailyStatsQuery['dailyStats']
-  dateRange: number
 }) {
   const { theme } = useTheme()
   const totalCompletions = sum(dailyStats?.map(stats => stats.completions))
@@ -121,7 +119,7 @@ export function CompletionCharts({
   const daysBetweenRange = eachDayOfInterval({
     start: from,
     end: to
-  }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
+  })
 
   // Mapping data of { date: amount }
   const dailyCompletionMap: Record<string, number> = {}
@@ -138,11 +136,11 @@ export function CompletionCharts({
       ? 0
       : ((totalAccepts / totalCompletions) * 100).toFixed(2)
   const acceptRateData = daysBetweenRange.map(date => {
-    const dateKey = moment.utc(date).format('YYYY-MM-DD')
+    const dateKey = moment(date).format('YYYY-MM-DD')
     const completion = dailyCompletionMap[dateKey] || 0
     const select = dailySelectMap[dateKey] || 0
     return {
-      name: moment.utc(date).format('D MMM'),
+      name: moment(date).format('D MMM'),
       value:
         completion === 0
           ? 0
@@ -152,12 +150,12 @@ export function CompletionCharts({
     }
   })
   const completionData = daysBetweenRange.map(date => {
-    const dateKey = moment.utc(date).format('YYYY-MM-DD')
+    const dateKey = moment(date).format('YYYY-MM-DD')
     const completion = dailyCompletionMap[dateKey] || 0
     const select = dailySelectMap[dateKey] || 0
     const pending = completion - select
     return {
-      name: moment.utc(date).format('D MMM'),
+      name: moment(date).format('D MMM'),
       completion,
       select,
       pending: completion === 0 ? 0.5 : pending,

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -121,13 +121,13 @@ export function CompletionCharts({
   const daysBetweenRange = eachDayOfInterval({
     start: from,
     end: to
-  })
+  }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
 
   // Mapping data of { date: amount }
   const dailyCompletionMap: Record<string, number> = {}
   const dailySelectMap: Record<string, number> = {}
   dailyStats?.forEach(stats => {
-    const date = moment(stats.start).format('YYYY-MM-DD')
+    const date = moment.utc(stats.start).format('YYYY-MM-DD')
     dailyCompletionMap[date] = stats.completions
     dailySelectMap[date] = stats.selects
   }, {})
@@ -138,11 +138,11 @@ export function CompletionCharts({
       ? 0
       : ((totalAccepts / totalCompletions) * 100).toFixed(2)
   const acceptRateData = daysBetweenRange.map(date => {
-    const dateKey = moment(date).format('YYYY-MM-DD')
+    const dateKey = moment.utc(date).format('YYYY-MM-DD')
     const completion = dailyCompletionMap[dateKey] || 0
     const select = dailySelectMap[dateKey] || 0
     return {
-      name: moment(date).format('D MMM'),
+      name: moment.utc(date).format('D MMM'),
       value:
         completion === 0
           ? 0
@@ -152,12 +152,12 @@ export function CompletionCharts({
     }
   })
   const completionData = daysBetweenRange.map(date => {
-    const dateKey = moment(date).format('YYYY-MM-DD')
+    const dateKey = moment.utc(date).format('YYYY-MM-DD')
     const completion = dailyCompletionMap[dateKey] || 0
     const select = dailySelectMap[dateKey] || 0
     const pending = completion - select
     return {
-      name: moment(date).format('D MMM'),
+      name: moment.utc(date).format('D MMM'),
       completion,
       select,
       pending: completion === 0 ? 0.5 : pending,

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -220,7 +220,7 @@ export default function Stats() {
     .utc()
     .format()
   const endDate = moment().endOf('day').utc().format()
-
+  
   // Query stats of selected date range
   const [{ data: dailyStatsData, fetching: fetchingDailyState }] = useQuery({
     query: queryDailyStats,
@@ -231,18 +231,19 @@ export default function Stats() {
     }
   })
   let dailyStats: DailyStatsQuery['dailyStats'] | undefined
+
   if (sample) {
     const daysBetweenRange = eachDayOfInterval({
       start: startDate,
       end: endDate
-    })
+    }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
     dailyStats = daysBetweenRange.map(date => {
       const rng = seedrandom(moment(date).format('YYYY-MM-DD') + data?.me.id)
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 25)
       return {
-        start: moment(date).startOf('day').toDate(),
-        end: moment(date).endOf('day').toDate(),
+        start: date,
+        end: moment(date).add(1, 'day').utc().format(),
         completions,
         selects
       }
@@ -269,14 +270,14 @@ export default function Stats() {
     const daysBetweenRange = eachDayOfInterval({
       start: moment().toDate(),
       end: moment().subtract(365, 'days').toDate()
-    })
+    }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
     yearlyStats = daysBetweenRange.map(date => {
       const rng = seedrandom(moment(date).format('YYYY-MM-DD') + data?.me.id)
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 10)
       return {
-        start: moment(date).startOf('day').toDate(),
-        end: moment(date).endOf('day').toDate(),
+        start: date,
+        end: moment(date).add(1, 'day').utc().format(),
         completions,
         selects
       }
@@ -291,7 +292,7 @@ export default function Stats() {
   }
   const dailyCompletionMap: Record<string, number> =
     yearlyStats?.reduce((acc, cur) => {
-      const date = moment(cur.start).format('YYYY-MM-DD')
+      const date = moment.utc(cur.start).format('YYYY-MM-DD')
       lastYearActivities += cur.completions
       lastYearActivities += cur.selects
       return { ...acc, [date]: cur.completions }

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -217,10 +217,9 @@ export default function Stats() {
   const startDate = moment()
     .subtract(DATE_RANGE, 'day')
     .startOf('day')
-    .utc()
-    .format()
-  const endDate = moment().endOf('day').utc().format()
-  
+    .format('YYYY-MM-DD[T]HH:mm:ss[Z]')
+  const endDate = moment().endOf('day').format('YYYY-MM-DD[T]HH:mm:ss[Z]')
+
   // Query stats of selected date range
   const [{ data: dailyStatsData, fetching: fetchingDailyState }] = useQuery({
     query: queryDailyStats,
@@ -234,16 +233,16 @@ export default function Stats() {
 
   if (sample) {
     const daysBetweenRange = eachDayOfInterval({
-      start: startDate,
-      end: endDate
-    }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
+      start: moment().subtract(DATE_RANGE, 'day').toDate(),
+      end: moment().toDate()
+    })
     dailyStats = daysBetweenRange.map(date => {
       const rng = seedrandom(moment(date).format('YYYY-MM-DD') + data?.me.id)
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 25)
       return {
-        start: date,
-        end: moment(date).add(1, 'day').utc().format(),
+        start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+        end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         completions,
         selects
       }
@@ -270,14 +269,14 @@ export default function Stats() {
     const daysBetweenRange = eachDayOfInterval({
       start: moment().toDate(),
       end: moment().subtract(365, 'days').toDate()
-    }).map((item: Date) => moment(item).format('YYYY-MM-DD[T]HH:mm:ss[Z]'))
+    })
     yearlyStats = daysBetweenRange.map(date => {
       const rng = seedrandom(moment(date).format('YYYY-MM-DD') + data?.me.id)
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 10)
       return {
-        start: date,
-        end: moment(date).add(1, 'day').utc().format(),
+        start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+        end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         completions,
         selects
       }
@@ -360,7 +359,6 @@ export default function Stats() {
   }
 
   if (!data?.me?.id) return <></>
-
   return (
     <div className="flex w-full flex-col gap-y-8">
       <LoadingWrapper
@@ -383,9 +381,8 @@ export default function Stats() {
       >
         <CompletionCharts
           dailyStats={dailyStats}
-          from={moment(startDate).toDate()}
-          to={moment(endDate).toDate()}
-          dateRange={DATE_RANGE}
+          from={moment().subtract(DATE_RANGE, 'day').toDate()}
+          to={moment().toDate()}
         />
       </LoadingWrapper>
 


### PR DESCRIPTION
Testing examples:

**Now in Shanghai, China, its 2024-04-22**
<img width="411" alt="sh22" src="https://github.com/TabbyML/tabby/assets/5305874/e80dfbb0-9441-4646-aa8d-0cc06f8355f0">

**Now in Los Angeles, its 2024-04-21**
<img width="389" alt="los21" src="https://github.com/TabbyML/tabby/assets/5305874/d67410f2-ff90-4b6d-a5f4-6e5d02e0a150">


**?sample=true page should cover all dates, no matter where you are**
<img width="403" alt="sh-sample data" src="https://github.com/TabbyML/tabby/assets/5305874/3e862ab4-9f89-4a70-bdf2-73a111e928f5">

**The report page should also address this inconsistency**
**Shanghai**
<img width="517" alt="sh4 22-report" src="https://github.com/TabbyML/tabby/assets/5305874/df17dc7e-7b4c-4667-85cc-6a98a036bb23">

**Los Angeles**
<img width="391" alt="los4 21-report" src="https://github.com/TabbyML/tabby/assets/5305874/7c9c7fba-bd3b-46de-b86b-7efbd9e8510d">

