### PR TITLE
fix(ui): analytics daily report date query and display

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
@@ -70,7 +70,7 @@ export function DailyActivity({
   const dailySelectMap: Record<string, number> = {}
 
   dailyStats?.forEach(stats => {
-    const date = moment.utc(stats.start).format('YYYY-MM-DD')
+    const date = moment(stats.start).format('YYYY-MM-DD')
     dailyCompletionMap[date] = stats.completions
     dailySelectMap[date] = stats.selects
   }, {})

--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -157,12 +157,8 @@ export function Report() {
   const [{ data: dailyStatsData, fetching: fetchingDailyState }] = useQuery({
     query: queryDailyStats,
     variables: {
-      start: moment(dateRange.from)
-        .startOf('day')
-        .utc()
-        .format(),
-      end: moment(dateRange.to).endOf('day').utc()
-      .format(),
+      start: moment(dateRange.from).startOf('day').utc().format(),
+      end: moment(dateRange.to).endOf('day').utc().format(),
       users: selectedMember === KEY_SELECT_ALL ? undefined : [selectedMember],
       languages: selectedLanguage.length === 0 ? undefined : selectedLanguage
     }
@@ -180,10 +176,8 @@ export function Report() {
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 10)
       return {
-        start: moment(date).utc()
-        .format(),
-        end: moment(date).add(1, 'day').utc()
-        .format(),
+        start: moment(date).utc().format(),
+        end: moment(date).add(1, 'day').utc().format(),
         completions,
         selects
       }

--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -159,8 +159,10 @@ export function Report() {
     variables: {
       start: moment(dateRange.from)
         .startOf('day')
-        .format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
-      end: moment(dateRange.to).endOf('day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+        .utc()
+        .format(),
+      end: moment(dateRange.to).endOf('day').utc()
+      .format(),
       users: selectedMember === KEY_SELECT_ALL ? undefined : [selectedMember],
       languages: selectedLanguage.length === 0 ? undefined : selectedLanguage
     }
@@ -178,8 +180,10 @@ export function Report() {
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 10)
       return {
-        start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
-        end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+        start: moment(date).utc()
+        .format(),
+        end: moment(date).add(1, 'day').utc()
+        .format(),
         completions,
         selects
       }

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -125,7 +125,7 @@ export function CompletionCharts({
   const dailyCompletionMap: Record<string, number> = {}
   const dailySelectMap: Record<string, number> = {}
   dailyStats?.forEach(stats => {
-    const date = moment.utc(stats.start).format('YYYY-MM-DD')
+    const date = moment(stats.start).format('YYYY-MM-DD')
     dailyCompletionMap[date] = stats.completions
     dailySelectMap[date] = stats.selects
   }, {})

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -217,8 +217,8 @@ export default function Stats() {
   const startDate = moment()
     .subtract(DATE_RANGE, 'day')
     .startOf('day')
-    .format('YYYY-MM-DD[T]HH:mm:ss[Z]')
-  const endDate = moment().endOf('day').format('YYYY-MM-DD[T]HH:mm:ss[Z]')
+    .utc().format()
+  const endDate = moment().endOf('day').utc().format()
 
   // Query stats of selected date range
   const [{ data: dailyStatsData, fetching: fetchingDailyState }] = useQuery({
@@ -241,8 +241,8 @@ export default function Stats() {
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 25)
       return {
-        start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
-        end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
+        start: moment(date).utc().format(),
+        end: moment(date).add(1, 'day').utc().format(),
         completions,
         selects
       }
@@ -255,6 +255,7 @@ export default function Stats() {
       selects: item.selects
     }))
   }
+
 
   // Query yearly stats
   const [{ data: yearlyStatsData, fetching: fetchingYearlyStats }] = useQuery({

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -217,7 +217,8 @@ export default function Stats() {
   const startDate = moment()
     .subtract(DATE_RANGE, 'day')
     .startOf('day')
-    .utc().format()
+    .utc()
+    .format()
   const endDate = moment().endOf('day').utc().format()
 
   // Query stats of selected date range
@@ -255,7 +256,6 @@ export default function Stats() {
       selects: item.selects
     }))
   }
-
 
   // Query yearly stats
   const [{ data: yearlyStatsData, fetching: fetchingYearlyStats }] = useQuery({


### PR DESCRIPTION
To support the backend changes in this PR: https://github.com/TabbyML/tabby/pull/1920

**Fix query date range**
Before: `2024-04-16T00:00:00Z - 2024-04-24T00:00:00Z`
After: `2024-04-15T16:00:00Z - 2024-04-23T15:59:59Z`

**Fix date display**
Before: `2024-04-15T16:00:00Z` will be counted as `2024-04-15`.
After: `2024-04-15T16:00:00Z` will be counted as `2024-04-16`

Tested:
pages: home / reports / ?sampe=true
timezone: Shanghai / Los Angeles