### PR TITLE
fix(ui): using views to represent completion data in analytics charts

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/reports/components/annual-activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/annual-activity.tsx
@@ -43,19 +43,19 @@ export function AnnualActivity({
   yearlyStats: DailyStatsInPastYearQuery['dailyStatsInPastYear'] | undefined
 }) {
   let lastYearActivities = 0
-  const dailyCompletionMap: Record<string, number> =
+  const dailyViewMap: Record<string, number> =
     yearlyStats?.reduce((acc, cur) => {
       const date = moment.utc(cur.start).format('YYYY-MM-DD')
-      lastYearActivities += cur.completions
+      lastYearActivities += cur.views
       lastYearActivities += cur.selects
-      return { ...acc, [date]: cur.completions }
+      return { ...acc, [date]: cur.views }
     }, {}) || {}
 
   const data = new Array(365)
     .fill('')
     .map((_, idx) => {
       const date = moment().subtract(idx, 'days').format('YYYY-MM-DD')
-      const count = dailyCompletionMap[date] || 0
+      const count = dailyViewMap[date] || 0
       const level = Math.min(4, Math.ceil(count / 5))
       return {
         date: date,

--- a/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
@@ -26,25 +26,25 @@ function BarTooltip({
   payload?: {
     name: string
     payload: {
-      completion: number
-      select: number
-      pending: number
+      views: number
+      selects: number
+      pendings: number
     }
   }[]
 }) {
   if (active && payload && payload.length) {
-    const { completion, select } = payload[0].payload
-    if (!completion) return null
+    const { views, selects } = payload[0].payload
+    if (!views) return null
     return (
       <Card>
         <CardContent className="flex flex-col gap-y-0.5 px-4 py-2 text-sm">
           <p className="flex items-center">
             <span className="mr-3 inline-block w-20">Completion:</span>
-            <b>{completion}</b>
+            <b>{views}</b>
           </p>
           <p className="flex items-center">
             <span className="mr-3 inline-block w-20">Acceptance:</span>
-            <b>{select}</b>
+            <b>{selects}</b>
           </p>
           <p className="text-muted-foreground">{label}</p>
         </CardContent>
@@ -66,12 +66,12 @@ export function DailyActivity({
   const from = dateRange.from || new Date()
   const to = dateRange.to || from
 
-  const dailyCompletionMap: Record<string, number> = {}
+  const dailyViewMap: Record<string, number> = {}
   const dailySelectMap: Record<string, number> = {}
 
   dailyStats?.forEach(stats => {
     const date = moment(stats.start).format('YYYY-MM-DD')
-    dailyCompletionMap[date] = stats.completions
+    dailyViewMap[date] = stats.views
     dailySelectMap[date] = stats.selects
   }, {})
 
@@ -82,14 +82,14 @@ export function DailyActivity({
 
   const chartData = daysBetweenRange.map(date => {
     const dateKey = moment(date).format('YYYY-MM-DD')
-    const completion = dailyCompletionMap[dateKey] || 0
-    const select = dailySelectMap[dateKey] || 0
-    const pending = completion - select
+    const views = dailyViewMap[dateKey] || 0
+    const selects = dailySelectMap[dateKey] || 0
+    const pendings = views - selects
     return {
       name: moment(date).format('D MMM'),
-      completion,
-      select,
-      pending
+      views,
+      selects,
+      pendings
     }
   })
   return (
@@ -108,13 +108,13 @@ export function DailyActivity({
           }}
         >
           <Bar
-            dataKey="select"
+            dataKey="selects"
             stackId="stats"
             fill={theme === 'dark' ? '#e8e1d3' : '#54452c'}
             radius={3}
           />
           <Bar
-            dataKey="pending"
+            dataKey="pendings"
             stackId="stats"
             fill={theme === 'dark' ? '#423929' : '#e8e1d3'}
             radius={3}

--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -76,12 +76,12 @@ function StatsSummary({
 }: {
   dailyStats?: DailyStatsQuery['dailyStats']
 }) {
-  const totalCompletions = sum(dailyStats?.map(stats => stats.completions))
+  const totalViews = sum(dailyStats?.map(stats => stats.views))
   const totalAcceptances = sum(dailyStats?.map(stats => stats.selects))
   const acceptRate =
     totalAcceptances === 0
       ? 0
-      : ((totalAcceptances / totalCompletions) * 100).toFixed(2)
+      : ((totalAcceptances / totalViews) * 100).toFixed(2)
   return (
     <div className="flex w-full flex-col items-start justify-center space-y-3 md:flex-row md:items-center md:space-x-6 md:space-y-0 xl:justify-start">
       <Card className="flex flex-1 flex-col justify-between self-stretch bg-primary-foreground/30 lg:block">
@@ -103,7 +103,7 @@ function StatsSummary({
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
-            {numeral(totalCompletions).format('0,0')}
+            {numeral(totalViews).format('0,0')}
           </div>
         </CardContent>
       </Card>
@@ -179,7 +179,8 @@ export function Report() {
         start: moment(date).utc().format(),
         end: moment(date).add(1, 'day').utc().format(),
         completions,
-        selects
+        selects,
+        views: completions
       }
     })
   } else {
@@ -187,7 +188,8 @@ export function Report() {
       start: item.start,
       end: item.end,
       completions: item.completions,
-      selects: item.selects
+      selects: item.selects,
+      views: item.views
     }))
   }
 
@@ -214,7 +216,8 @@ export function Report() {
         start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         completions,
-        selects
+        selects,
+        views: completions
       }
     })
   } else {
@@ -222,7 +225,8 @@ export function Report() {
       start: item.start,
       end: item.end,
       completions: item.completions,
-      selects: item.selects
+      selects: item.selects,
+      views: item.views
     }))
   }
 

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -133,19 +133,14 @@ export function CompletionCharts({
 
   // Data for charts
   const averageAcceptance =
-    totalViews === 0
-      ? 0
-      : ((totalAccepts / totalViews) * 100).toFixed(2)
+    totalViews === 0 ? 0 : ((totalAccepts / totalViews) * 100).toFixed(2)
   const acceptRateData = daysBetweenRange.map(date => {
     const dateKey = moment(date).format('YYYY-MM-DD')
     const views = dailyViewMap[dateKey] || 0
     const selects = dailySelectMap[dateKey] || 0
     return {
       name: moment(date).format('D MMM'),
-      value:
-        views === 0
-          ? 0
-          : parseFloat(((selects / views) * 100).toFixed(2)),
+      value: views === 0 ? 0 : parseFloat(((selects / views) * 100).toFixed(2)),
       selects,
       views
     }

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -22,6 +22,7 @@ export type LanguageStats = Record<
   {
     selects: number
     completions: number
+    views: number
     name: Language
   }
 >
@@ -35,15 +36,15 @@ function LineTooltip({
     name: string
     payload: {
       name: string
-      select: number
+      selects: number
       value: string
-      completion: number
+      views: number
     }
   }[]
 }) {
   if (active && payload && payload.length) {
-    const { value, completion, name } = payload[0].payload
-    if (!completion) return null
+    const { value, views, name } = payload[0].payload
+    if (!views) return null
     return (
       <Card>
         <CardContent className="flex flex-col gap-y-0.5 px-4 py-2 text-sm">
@@ -70,29 +71,29 @@ function BarTooltip({
     name: string
     payload: {
       name: string
-      completion: number
-      select: number
-      pending: number
+      views: number
+      selects: number
+      pendings: number
     }
   }[]
-  type: 'accept' | 'completion' | 'all'
+  type: 'accept' | 'view' | 'all'
 }) {
   if (active && payload && payload.length) {
-    const { completion, select, name } = payload[0].payload
-    if (!completion) return null
+    const { views, selects, name } = payload[0].payload
+    if (!views) return null
     return (
       <Card>
         <CardContent className="flex flex-col gap-y-0.5 px-4 py-2 text-sm">
-          {(type === 'completion' || type === 'all') && (
+          {(type === 'view' || type === 'all') && (
             <p className="flex items-center">
               <span className="mr-3 inline-block w-20">Completions:</span>
-              <b>{completion}</b>
+              <b>{views}</b>
             </p>
           )}
           {(type === 'accept' || type === 'all') && (
             <p className="flex items-center">
               <span className="mr-3 inline-block w-20">Acceptances:</span>
-              <b>{select}</b>
+              <b>{selects}</b>
             </p>
           )}
           <p className="text-muted-foreground">{name}</p>
@@ -114,7 +115,7 @@ export function CompletionCharts({
   dailyStats?: DailyStatsQuery['dailyStats']
 }) {
   const { theme } = useTheme()
-  const totalCompletions = sum(dailyStats?.map(stats => stats.completions))
+  const totalViews = sum(dailyStats?.map(stats => stats.views))
   const totalAccepts = sum(dailyStats?.map(stats => stats.selects))
   const daysBetweenRange = eachDayOfInterval({
     start: from,
@@ -122,46 +123,46 @@ export function CompletionCharts({
   })
 
   // Mapping data of { date: amount }
-  const dailyCompletionMap: Record<string, number> = {}
+  const dailyViewMap: Record<string, number> = {}
   const dailySelectMap: Record<string, number> = {}
   dailyStats?.forEach(stats => {
     const date = moment(stats.start).format('YYYY-MM-DD')
-    dailyCompletionMap[date] = stats.completions
+    dailyViewMap[date] = stats.views
     dailySelectMap[date] = stats.selects
   }, {})
 
   // Data for charts
   const averageAcceptance =
-    totalCompletions === 0
+    totalViews === 0
       ? 0
-      : ((totalAccepts / totalCompletions) * 100).toFixed(2)
+      : ((totalAccepts / totalViews) * 100).toFixed(2)
   const acceptRateData = daysBetweenRange.map(date => {
     const dateKey = moment(date).format('YYYY-MM-DD')
-    const completion = dailyCompletionMap[dateKey] || 0
-    const select = dailySelectMap[dateKey] || 0
+    const views = dailyViewMap[dateKey] || 0
+    const selects = dailySelectMap[dateKey] || 0
     return {
       name: moment(date).format('D MMM'),
       value:
-        completion === 0
+        views === 0
           ? 0
-          : parseFloat(((select / completion) * 100).toFixed(2)),
-      select,
-      completion
+          : parseFloat(((selects / views) * 100).toFixed(2)),
+      selects,
+      views
     }
   })
-  const completionData = daysBetweenRange.map(date => {
+  const viewData = daysBetweenRange.map(date => {
     const dateKey = moment(date).format('YYYY-MM-DD')
-    const completion = dailyCompletionMap[dateKey] || 0
-    const select = dailySelectMap[dateKey] || 0
-    const pending = completion - select
+    const views = dailyViewMap[dateKey] || 0
+    const selects = dailySelectMap[dateKey] || 0
+    const pendings = views - selects
     return {
       name: moment(date).format('D MMM'),
-      completion,
-      select,
-      pending: completion === 0 ? 0.5 : pending,
-      realPending: completion === 0 ? 0 : pending,
-      completionPlaceholder: completion === 0 ? 0.5 : 0,
-      selectPlaceholder: select === 0 ? 0.5 : 0
+      views,
+      selects,
+      pending: views === 0 ? 0.5 : pendings,
+      realPending: views === 0 ? 0 : pendings,
+      viewPlaceholder: views === 0 ? 0.5 : 0,
+      selectPlaceholder: selects === 0 ? 0.5 : 0
     }
   })
   return (
@@ -204,35 +205,35 @@ export function CompletionCharts({
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
-              {numeral(totalCompletions).format('0,0')}
+              {numeral(totalViews).format('0,0')}
             </div>
           </CardContent>
 
           <ResponsiveContainer width="100%" height={60}>
             <BarChart
-              data={completionData}
+              data={viewData}
               margin={{
-                top: totalCompletions === 0 ? 40 : 5,
+                top: totalViews === 0 ? 40 : 5,
                 right: 20,
                 left: 20,
                 bottom: 5
               }}
             >
               <Bar
-                dataKey="completion"
+                dataKey="views"
                 stackId="stats"
                 fill={theme === 'dark' ? '#e8e1d3' : '#54452c'}
                 radius={3}
               />
               <Bar
-                dataKey="completionPlaceholder"
+                dataKey="viewPlaceholder"
                 stackId="stats"
                 fill={theme === 'dark' ? '#423929' : '#e8e1d3'}
                 radius={3}
               />
               <Tooltip
                 cursor={{ fill: 'transparent' }}
-                content={<BarTooltip type="completion" />}
+                content={<BarTooltip type="view" />}
               />
             </BarChart>
           </ResponsiveContainer>
@@ -252,16 +253,16 @@ export function CompletionCharts({
 
           <ResponsiveContainer width="100%" height={60}>
             <BarChart
-              data={completionData}
+              data={viewData}
               margin={{
-                top: totalCompletions === 0 ? 40 : 5,
+                top: totalViews === 0 ? 40 : 5,
                 right: 20,
                 left: 20,
                 bottom: 5
               }}
             >
               <Bar
-                dataKey="select"
+                dataKey="selects"
                 stackId="stats"
                 fill={theme === 'dark' ? '#e8e1d3' : '#54452c'}
                 radius={3}

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -41,9 +41,10 @@ import { CompletionCharts, type LanguageStats } from './completion-charts'
 const DATE_RANGE = 6
 
 type LanguageData = {
-  name: Language | 'NONE'
-  selects: number
-  completions: number
+  name: Language | 'NONE';
+  selects: number;
+  completions: number;
+  views: number;
 }[]
 
 // Find auto-completion stats of each language
@@ -83,6 +84,7 @@ function useLanguageStats({
       newLanguageStats[language] = newLanguageStats[language] || {
         selects: 0,
         completions: 0,
+        views: 0,
         name: Object.values(Language)[lanIdx]
       }
       newLanguageStats[language].selects += sum(
@@ -90,6 +92,9 @@ function useLanguageStats({
       )
       newLanguageStats[language].completions += sum(
         data.dailyStats.map(stats => stats.completions)
+      )
+      newLanguageStats[language].views += sum(
+        data.dailyStats.map(stats => stats.views)
       )
 
       const newLanIdx = lanIdx + 1
@@ -152,7 +157,7 @@ const LanguageLabel: React.FC<
   const { x, y, value, languageData, theme } = props
   const myLanguageData = languageData.find(data => data.name === value)
 
-  if (!myLanguageData || myLanguageData.completions === 0) {
+  if (!myLanguageData || myLanguageData.views === 0) {
     return null
   }
 
@@ -180,21 +185,21 @@ function LanguageTooltip({
     name: string
     payload: {
       name: Language | 'NONE'
-      completions: number
+      views: number
       selects: number
     }
   }[]
 }) {
   if (active && payload && payload.length) {
-    const { completions, selects, name } = payload[0].payload
-    const activities = completions + selects
+    const { views, selects, name } = payload[0].payload
+    const activities = views + selects
     if (!activities || name === 'NONE') return null
     return (
       <Card>
         <CardContent className="flex flex-col gap-y-0.5 px-4 py-2 text-sm">
           <p className="flex items-center">
             <span className="mr-3 inline-block w-20">Completions:</span>
-            <b>{completions}</b>
+            <b>{views}</b>
           </p>
           <p className="text-muted-foreground">
             {toProgrammingLanguageDisplayName(name)}
@@ -245,7 +250,8 @@ export default function Stats() {
         start: moment(date).utc().format(),
         end: moment(date).add(1, 'day').utc().format(),
         completions,
-        selects
+        selects,
+        views: completions,
       }
     })
   } else {
@@ -253,7 +259,8 @@ export default function Stats() {
       start: item.start,
       end: item.end,
       completions: item.completions,
-      selects: item.selects
+      selects: item.selects,
+      views: item.views
     }))
   }
 
@@ -279,7 +286,8 @@ export default function Stats() {
         start: moment(date).format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         end: moment(date).add(1, 'day').format('YYYY-MM-DD[T]HH:mm:ss[Z]'),
         completions,
-        selects
+        selects,
+        views: completions
       }
     })
   } else {
@@ -287,15 +295,16 @@ export default function Stats() {
       start: item.start,
       end: item.end,
       completions: item.completions,
-      selects: item.selects
+      selects: item.selects,
+      views: item.views
     }))
   }
   const dailyCompletionMap: Record<string, number> =
     yearlyStats?.reduce((acc, cur) => {
       const date = moment.utc(cur.start).format('YYYY-MM-DD')
-      lastYearActivities += cur.completions
+      lastYearActivities += cur.views
       lastYearActivities += cur.selects
-      return { ...acc, [date]: cur.completions }
+      return { ...acc, [date]: cur.views }
     }, {}) || {}
   const activities = new Array(365)
     .fill('')
@@ -327,12 +336,14 @@ export default function Stats() {
       {
         name: Language.Rust,
         completions: rustCompletion,
-        selects: rustCompletion
+        selects: rustCompletion,
+        views: rustCompletion,
       },
       {
         name: Language.Python,
         completions: pythonCompletion,
-        selects: pythonCompletion
+        selects: pythonCompletion,
+        views: pythonCompletion
       }
     ]
   } else {
@@ -341,20 +352,22 @@ export default function Stats() {
         return {
           name: stats.name,
           selects: stats.selects,
-          completions: stats.completions
+          completions: stats.completions,
+          views: stats.views
         }
       })
-      .filter(item => item.completions)
+      .filter(item => item.views)
       .slice(0, 5)
   }
-  languageData = languageData.sort((a, b) => b.completions - a.completions)
+  languageData = languageData.sort((a, b) => b.views - a.views)
   if (languageData.length === 0) {
-    // Placeholder when there is no completions
+    // Placeholder when there is no views
     languageData = [
       {
         name: 'NONE',
         selects: 0,
-        completions: 0.01
+        completions: 0.01,
+        views: 0.01
       }
     ]
   }
@@ -406,7 +419,7 @@ export default function Stats() {
                 barCategoryGap={12}
                 margin={{ top: 5, right: 5, left: 5, bottom: 5 }}
               >
-                <Bar dataKey="completions" radius={3}>
+                <Bar dataKey="views" radius={3}>
                   <LabelList
                     dataKey="name"
                     content={

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -41,10 +41,10 @@ import { CompletionCharts, type LanguageStats } from './completion-charts'
 const DATE_RANGE = 6
 
 type LanguageData = {
-  name: Language | 'NONE';
-  selects: number;
-  completions: number;
-  views: number;
+  name: Language | 'NONE'
+  selects: number
+  completions: number
+  views: number
 }[]
 
 // Find auto-completion stats of each language
@@ -251,7 +251,7 @@ export default function Stats() {
         end: moment(date).add(1, 'day').utc().format(),
         completions,
         selects,
-        views: completions,
+        views: completions
       }
     })
   } else {
@@ -337,7 +337,7 @@ export default function Stats() {
         name: Language.Rust,
         completions: rustCompletion,
         selects: rustCompletion,
-        views: rustCompletion,
+        views: rustCompletion
       },
       {
         name: Language.Python,

--- a/ee/tabby-ui/lib/tabby/query.ts
+++ b/ee/tabby-ui/lib/tabby/query.ts
@@ -144,6 +144,7 @@ export const queryDailyStatsInPastYear = graphql(/* GraphQL */ `
       end
       completions
       selects
+      views
     }
   }
 `)
@@ -160,6 +161,7 @@ export const queryDailyStats = graphql(/* GraphQL */ `
       end
       completions
       selects
+      views
     }
   }
 `)


### PR DESCRIPTION
Replace `.completions` with `views` in all places, but the text on the page is still named 'Completions'.

Including:
* Home page - yearly activity
* Home page - daily charts
* Home page - language charts
* Report page - yearly activity
* Report page - daily charts

![views](https://github.com/TabbyML/tabby/assets/5305874/7ad0ca01-0444-4e5d-ac9e-ce455d0f62f4)

