### PR TITLE
fix(ui): optimize daily language stats data fetching

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/daily-activity.tsx
@@ -71,8 +71,11 @@ export function DailyActivity({
 
   dailyStats?.forEach(stats => {
     const date = moment(stats.start).format('YYYY-MM-DD')
-    dailyViewMap[date] = stats.views
-    dailySelectMap[date] = stats.selects
+    dailyViewMap[date] = dailyViewMap[date] || 0
+    dailySelectMap[date] = dailySelectMap[date] || 0
+
+    dailyViewMap[date] += stats.views
+    dailySelectMap[date] += stats.selects
   }, {})
 
   const daysBetweenRange = eachDayOfInterval({

--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -159,8 +159,7 @@ export function Report() {
     variables: {
       start: moment(dateRange.from).startOf('day').utc().format(),
       end: moment(dateRange.to).endOf('day').utc().format(),
-      users: selectedMember === KEY_SELECT_ALL ? undefined : [selectedMember],
-      languages: selectedLanguage.length === 0 ? undefined : selectedLanguage
+      users: selectedMember === KEY_SELECT_ALL ? undefined : [selectedMember]
     }
   })
   let dailyStats: DailyStatsQuery['dailyStats'] | undefined
@@ -170,6 +169,7 @@ export function Report() {
       end: dateRange.to || dateRange.from!
     })
     dailyStats = daysBetweenRange.map(date => {
+      const languages = [Language.Typescript, Language.Python, Language.Rust]
       const rng = seedrandom(
         moment(date).format('YYYY-MM-DD') + selectedMember + selectedLanguage
       )
@@ -180,7 +180,8 @@ export function Report() {
         end: moment(date).add(1, 'day').utc().format(),
         completions,
         selects,
-        views: completions
+        views: completions,
+        language: languages[selects % languages.length]
       }
     })
   } else {
@@ -189,9 +190,14 @@ export function Report() {
       end: item.end,
       completions: item.completions,
       selects: item.selects,
-      views: item.views
+      views: item.views,
+      language: item.language
     }))
   }
+  dailyStats = dailyStats?.filter(stats => {
+    if (selectedLanguage.length === 0) return true
+    return selectedLanguage.includes(stats.language)
+  })
 
   // Query yearly stats
   const [{ data: yearlyStatsData, fetching: fetchingYearlyStats }] = useQuery({

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -123,7 +123,6 @@ export function CompletionCharts({
     dailySelectMap[date] += stats.selects
   }, {})
 
-  // Prepare and structure data for populating the language usage charts
   const averageAcceptance =
     totalViews === 0 ? 0 : ((totalAccepts / totalViews) * 100).toFixed(2)
   const acceptRateData = daysBetweenRange.map(date => {

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -14,18 +14,8 @@ import {
   Tooltip
 } from 'recharts'
 
-import { DailyStatsQuery, Language } from '@/lib/gql/generates/graphql'
+import { DailyStatsQuery } from '@/lib/gql/generates/graphql'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-
-export type LanguageStats = Record<
-  Language,
-  {
-    selects: number
-    completions: number
-    views: number
-    name: Language
-  }
->
 
 function LineTooltip({
   active,
@@ -127,8 +117,11 @@ export function CompletionCharts({
   const dailySelectMap: Record<string, number> = {}
   dailyStats?.forEach(stats => {
     const date = moment(stats.start).format('YYYY-MM-DD')
-    dailyViewMap[date] = stats.views
-    dailySelectMap[date] = stats.selects
+    dailyViewMap[date] = dailyViewMap[date] || 0
+    dailySelectMap[date] = dailySelectMap[date] || 0
+
+    dailyViewMap[date] += stats.views
+    dailySelectMap[date] += stats.selects
   }, {})
 
   // Data for charts

--- a/ee/tabby-ui/app/(home)/components/completion-charts.tsx
+++ b/ee/tabby-ui/app/(home)/components/completion-charts.tsx
@@ -112,7 +112,6 @@ export function CompletionCharts({
     end: to
   })
 
-  // Mapping data of { date: amount }
   const dailyViewMap: Record<string, number> = {}
   const dailySelectMap: Record<string, number> = {}
   dailyStats?.forEach(stats => {
@@ -124,7 +123,7 @@ export function CompletionCharts({
     dailySelectMap[date] += stats.selects
   }, {})
 
-  // Data for charts
+  // Prepare and structure data for populating the language usage charts
   const averageAcceptance =
     totalViews === 0 ? 0 : ((totalAccepts / totalViews) * 100).toFixed(2)
   const acceptRateData = daysBetweenRange.map(date => {

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -257,7 +257,7 @@ export default function Stats() {
     })
     .reverse()
 
-  // Make data for language charts
+  // Prepare and structure data for populating the language usage charts
   const languageStats = {} as LanguageStats
   dailyStats?.forEach(stats => {
     languageStats[stats.language] = languageStats[stats.language] || { views: 0, name: stats.language }

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useWindowSize } from '@uidotdev/usehooks'
 import { eachDayOfInterval } from 'date-fns'
-import { sum } from 'lodash-es'
 import moment from 'moment'
 import { useTheme } from 'next-themes'
 import ReactActivityCalendar from 'react-activity-calendar'
@@ -29,90 +27,28 @@ import {
 } from '@/lib/gql/generates/graphql'
 import { useMe } from '@/lib/hooks/use-me'
 import { toProgrammingLanguageDisplayName } from '@/lib/language-utils'
-import { QueryVariables } from '@/lib/tabby/gql'
 import { queryDailyStats, queryDailyStatsInPastYear } from '@/lib/tabby/query'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import LoadingWrapper from '@/components/loading-wrapper'
 
 import languageColors from '../language-colors.json'
-import { CompletionCharts, type LanguageStats } from './completion-charts'
+import { CompletionCharts } from './completion-charts'
 
 const DATE_RANGE = 6
 
 type LanguageData = {
   name: Language | 'NONE'
-  selects: number
-  completions: number
   views: number
 }[]
 
-// Find auto-completion stats of each language
-function useLanguageStats({
-  start,
-  end,
-  users
-}: {
-  start: Date
-  end: Date
-  users?: string
-}) {
-  const languages = Object.values(Language)
-  const [lanIdx, setLanIdx] = useState(0)
-  const [queryVariables, setQueryVariables] = useState<
-    QueryVariables<typeof queryDailyStats>
-  >({
-    start: moment(start).utc().format(),
-    end: moment(end).utc().format(),
-    users,
-    languages: languages[0]
-  })
-  const [languageStats, setLanguageStats] = useState<LanguageStats>(
-    {} as LanguageStats
-  )
-
-  const [{ data, fetching }] = useQuery({
-    query: queryDailyStats,
-    variables: queryVariables
-  })
-
-  useEffect(() => {
-    if (lanIdx >= languages.length) return
-    if (!fetching && data?.dailyStats) {
-      const language = languages[lanIdx]
-      const newLanguageStats = { ...languageStats }
-      newLanguageStats[language] = newLanguageStats[language] || {
-        selects: 0,
-        completions: 0,
-        views: 0,
-        name: Object.values(Language)[lanIdx]
-      }
-      newLanguageStats[language].selects += sum(
-        data.dailyStats.map(stats => stats.selects)
-      )
-      newLanguageStats[language].completions += sum(
-        data.dailyStats.map(stats => stats.completions)
-      )
-      newLanguageStats[language].views += sum(
-        data.dailyStats.map(stats => stats.views)
-      )
-
-      const newLanIdx = lanIdx + 1
-      setLanguageStats(newLanguageStats)
-      setLanIdx(newLanIdx)
-      if (newLanIdx < languages.length) {
-        setQueryVariables({
-          start: moment(start).utc().format(),
-          end: moment(end).utc().format(),
-          users,
-          languages: languages[newLanIdx]
-        })
-      }
-    }
-  }, [queryVariables, lanIdx, fetching])
-
-  return [languageStats]
-}
+type LanguageStats = Record<
+  Language,
+  {
+    views: number
+    name: Language
+  }
+>
 
 const getLanguageColorMap = (): Record<string, string> => {
   return Object.entries(languageColors).reduce((acc, cur) => {
@@ -186,14 +122,12 @@ function LanguageTooltip({
     payload: {
       name: Language | 'NONE'
       views: number
-      selects: number
     }
   }[]
 }) {
   if (active && payload && payload.length) {
-    const { views, selects, name } = payload[0].payload
-    const activities = views + selects
-    if (!activities || name === 'NONE') return null
+    const { views, name } = payload[0].payload
+    if (!views || name === 'NONE') return null
     return (
       <Card>
         <CardContent className="flex flex-col gap-y-0.5 px-4 py-2 text-sm">
@@ -243,6 +177,7 @@ export default function Stats() {
       end: moment().toDate()
     })
     dailyStats = daysBetweenRange.map(date => {
+      const languages = [Language.Typescript, Language.Python, Language.Rust]
       const rng = seedrandom(moment(date).format('YYYY-MM-DD') + data?.me.id)
       const selects = Math.ceil(rng() * 20)
       const completions = selects + Math.floor(rng() * 25)
@@ -251,7 +186,8 @@ export default function Stats() {
         end: moment(date).add(1, 'day').utc().format(),
         completions,
         selects,
-        views: completions
+        views: completions,
+        language: languages[selects % languages.length]
       }
     })
   } else {
@@ -260,7 +196,8 @@ export default function Stats() {
       end: item.end,
       completions: item.completions,
       selects: item.selects,
-      views: item.views
+      views: item.views,
+      language: item.language
     }))
   }
 
@@ -320,53 +257,27 @@ export default function Stats() {
     })
     .reverse()
 
-  // Query language stats
-  const [languageStats] = useLanguageStats({
-    start: moment(startDate).toDate(),
-    end: moment(endDate).toDate(),
-    users: data?.me?.id
+  // Make data for language charts
+  const languageStats = {} as LanguageStats
+  dailyStats?.forEach(stats => {
+    languageStats[stats.language] = languageStats[stats.language] || { views: 0, name: stats.language }
+    languageStats[stats.language].views += stats.views
   })
-
-  let languageData: LanguageData | []
-  if (sample) {
-    const rng = seedrandom(data?.me.id)
-    const rustCompletion = Math.ceil(rng() * 40)
-    const pythonCompletion = Math.ceil(rng() * 25)
-    languageData = [
-      {
-        name: Language.Rust,
-        completions: rustCompletion,
-        selects: rustCompletion,
-        views: rustCompletion
-      },
-      {
-        name: Language.Python,
-        completions: pythonCompletion,
-        selects: pythonCompletion,
-        views: pythonCompletion
+  let languageData: LanguageData = Object.entries(languageStats)
+    .map(([_, stats]) => {
+      return {
+        name: stats.name,
+        views: stats.views
       }
-    ]
-  } else {
-    languageData = Object.entries(languageStats)
-      .map(([_, stats]) => {
-        return {
-          name: stats.name,
-          selects: stats.selects,
-          completions: stats.completions,
-          views: stats.views
-        }
-      })
-      .filter(item => item.views)
-      .slice(0, 5)
-  }
-  languageData = languageData.sort((a, b) => b.views - a.views)
+    })
+    .filter(item => item.views)
+    .sort((a, b) => b.views - a.views)
+    .slice(0, 5)
   if (languageData.length === 0) {
     // Placeholder when there is no views
     languageData = [
       {
         name: 'NONE',
-        selects: 0,
-        completions: 0.01,
         views: 0.01
       }
     ]

--- a/ee/tabby-ui/app/(home)/components/stats.tsx
+++ b/ee/tabby-ui/app/(home)/components/stats.tsx
@@ -260,7 +260,10 @@ export default function Stats() {
   // Prepare and structure data for populating the language usage charts
   const languageStats = {} as LanguageStats
   dailyStats?.forEach(stats => {
-    languageStats[stats.language] = languageStats[stats.language] || { views: 0, name: stats.language }
+    languageStats[stats.language] = languageStats[stats.language] || {
+      views: 0,
+      name: stats.language
+    }
     languageStats[stats.language].views += stats.views
   })
   let languageData: LanguageData = Object.entries(languageStats)

--- a/ee/tabby-ui/lib/tabby/query.ts
+++ b/ee/tabby-ui/lib/tabby/query.ts
@@ -162,6 +162,7 @@ export const queryDailyStats = graphql(/* GraphQL */ `
       completions
       selects
       views
+      language
     }
   }
 `)


### PR DESCRIPTION
### Home Page:
- Removing redundant API calls for the language charts
- Reconstructed the data from `dailyStats` to populate the language charts
- Updated the sample page to include language charts for Rust, Python, and TypeScript

### Report page:
- Removing the `language` parameter in the `dailyStats` request
- Moved language selection logic to the frontend, no extra API requests
- Updated the sample page to include the data for Rust, Python, and TypeScript

fix TAB-557