### PR TITLE
fix(webserver): remove spaces in full repository names for gitlab

### DIFF
--- a/ee/tabby-webserver/src/cron/db/gitlab.rs
+++ b/ee/tabby-webserver/src/cron/db/gitlab.rs
@@ -77,7 +77,7 @@ async fn refresh_repositories_for_provider(
             .upsert_repository(
                 provider.id.clone(),
                 id,
-                repo.name_with_namespace,
+                repo.name_with_namespace.replace(' ', ""),
                 url.to_string(),
             )
             .await?;


### PR DESCRIPTION
cc @liangfung 