### PR TITLE
fix(ui): do not display Content-Length when it is not set

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/[kind]/detail/components/add-repository-form.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/[kind]/detail/components/add-repository-form.tsx
@@ -75,6 +75,8 @@ export default function LinkRepositoryForm({
   const form = useForm<LinkRepositoryFormValues>({
     resolver: zodResolver(formSchema)
   })
+  const [searchValue, setSearchValue] = React.useState<string>()
+  const commandListRef = React.useRef<HTMLDivElement>(null)
 
   const { isSubmitting } = form.formState
 
@@ -131,6 +133,18 @@ export default function LinkRepositoryForm({
     }
   }
 
+  const scrollCommandListToTop = () => {
+    requestAnimationFrame(() => {
+      if (commandListRef.current) {
+        commandListRef.current.scrollTop = 0
+      }
+    })
+  }
+
+  const onSearchChange = () => {
+    scrollCommandListToTop()
+  }
+
   return (
     <Form {...form}>
       <div className="grid gap-2">
@@ -165,9 +179,15 @@ export default function LinkRepositoryForm({
                     align="start"
                     side="bottom"
                   >
-                    <Command>
-                      <CommandInput placeholder="Search repository..." />
-                      <CommandList className="max-h-60">
+                    <Command className="transition-all">
+                      <CommandInput
+                        placeholder="Search repository..."
+                        onValueChange={onSearchChange}
+                      />
+                      <CommandList
+                        className="max-h-[30vh]"
+                        ref={commandListRef}
+                      >
                         <CommandEmpty>{emptyText}</CommandEmpty>
                         <CommandGroup>
                           {providerStatus !==

--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/[kind]/detail/components/github-provider-detail.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/[kind]/detail/components/github-provider-detail.tsx
@@ -171,7 +171,7 @@ const LinkedRepoTable: React.FC<{
           <TableHead className="w-[45%]">URL</TableHead>
           <TableHead className="text-right">
             <Dialog open={open} onOpenChange={setOpen}>
-              <DialogContent>
+              <DialogContent className="top-[20vh]">
                 <DialogHeader className="gap-3">
                   <DialogTitle>Add new repository</DialogTitle>
                   <DialogDescription>

--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/components/tabs-header.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/components/tabs-header.tsx
@@ -17,7 +17,6 @@ export default function GitTabsHeader() {
         <TabsList className="grid grid-cols-3">
           <TabsTrigger value="git" asChild>
             <Link href="/settings/repository/git">
-              <IconFolderGit />
               <span className="ml-2">Git</span>
             </Link>
           </TabsTrigger>

--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/components/tabs-header.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/components/tabs-header.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useParams } from 'next/navigation'
 
 import { RepositoryKind } from '@/lib/gql/generates/graphql'
-import { IconFolderGit, IconGitHub, IconGitLab } from '@/components/ui/icons'
+import { IconGitHub, IconGitLab } from '@/components/ui/icons'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 export default function GitTabsHeader() {

--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/components/tabs-header.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/repository/components/tabs-header.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { useParams } from 'next/navigation'
 
 import { RepositoryKind } from '@/lib/gql/generates/graphql'
-import { IconGit, IconGitHub, IconGitLab } from '@/components/ui/icons'
+import { IconFolderGit, IconGitHub, IconGitLab } from '@/components/ui/icons'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 export default function GitTabsHeader() {
@@ -17,7 +17,7 @@ export default function GitTabsHeader() {
         <TabsList className="grid grid-cols-3">
           <TabsTrigger value="git" asChild>
             <Link href="/settings/repository/git">
-              <IconGit />
+              <IconFolderGit />
               <span className="ml-2">Git</span>
             </Link>
           </TabsTrigger>

--- a/ee/tabby-ui/app/files/components/blob-header.tsx
+++ b/ee/tabby-ui/app/files/components/blob-header.tsx
@@ -3,7 +3,6 @@
 import React from 'react'
 import Image from 'next/image'
 import tabbyLogo from '@/assets/tabby.png'
-import { isNil } from 'lodash-es'
 import prettyBytes from 'pretty-bytes'
 import { toast } from 'sonner'
 
@@ -54,9 +53,7 @@ export const BlobHeader: React.FC<BlobHeaderProps> = ({
     enableCodeBrowserQuickActionBar.value &&
     !chatSideBarVisible
 
-  const contentLengthText = !isNil(contentLength)
-    ? prettyBytes(contentLength)
-    : ''
+  const contentLengthText = contentLength ? prettyBytes(contentLength) : ''
 
   const onCopy: React.MouseEventHandler<HTMLButtonElement> = async () => {
     if (isCopied || !blob) return

--- a/ee/tabby-ui/app/files/components/file-directory-view.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-view.tsx
@@ -133,7 +133,6 @@ function getCurrentDirFromTree(
   treeData: TFileTreeNode[],
   path: string | undefined
 ): TFileTreeNode[] {
-  // const regx = new RegExp(`${path}\/[\\w\.\-]+$`)
   if (!treeData?.length) return []
   if (!path) {
     const repos = treeData.map(x => omit(x, 'children')) || []

--- a/ee/tabby-ui/app/files/components/repository-kind-icon.tsx
+++ b/ee/tabby-ui/app/files/components/repository-kind-icon.tsx
@@ -1,5 +1,9 @@
 import { RepositoryKind } from '@/lib/gql/generates/graphql'
-import { IconGit, IconGitHub, IconGitLab } from '@/components/ui/icons'
+import {
+  IconDirectorySolid,
+  IconGitHub,
+  IconGitLab
+} from '@/components/ui/icons'
 
 export function RepositoryKindIcon({
   kind,
@@ -10,7 +14,7 @@ export function RepositoryKindIcon({
 }) {
   switch (kind) {
     case RepositoryKind.Git:
-      return <IconGit />
+      return <IconDirectorySolid style={{ color: 'rgb(84, 174, 255)' }} />
     case RepositoryKind.Github:
       return <IconGitHub />
     case RepositoryKind.Gitlab:


### PR DESCRIPTION
1. Do not display Content-Length when it is not set
<img width="1213" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/bdde4fb2-6586-401a-a996-f4dd01e09fd6">

2. Scroll bar should keep at top when inputing
https://jam.dev/c/a1d76cd0-816f-48c6-b7ae-bd5c7673b1dc

3. Change the icon for git repositories
<img width="327" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/a5388a37-414a-4da1-85ec-198970a62d20">
<img width="930" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/d12e7c3e-4d3e-4fb3-bf8d-5d82f5173c82">
