### PR TITLE
fix(ui): refactor demo-banner to fix ui bugs

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
@@ -4,20 +4,16 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
 import { Header } from '@/components/header'
 
-import { useTheme } from 'next-themes'
-
 export default function MainContent({
   children
 }: {
   children: React.ReactNode
 }) {
-  const { theme } = useTheme()
   const [isShowDemoBanner] = useShowDemoBanner()
   
   const style = isShowDemoBanner
     ? { height: `calc(100vh - ${BANNER_HEIGHT})` }
     : { height: '100vh' }
-    console.log('MainContent isShowDemoBanner', isShowDemoBanner)
   return (
     <>
       {/* Wraps right hand side into ScrollArea, making scroll bar consistent across all browsers */}

--- a/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
@@ -10,14 +10,17 @@ export default function MainContent({
   children: React.ReactNode
 }) {
   const [isShowDemoBanner] = useShowDemoBanner()
-  
+
   const style = isShowDemoBanner
     ? { height: `calc(100vh - ${BANNER_HEIGHT})` }
     : { height: '100vh' }
   return (
     <>
       {/* Wraps right hand side into ScrollArea, making scroll bar consistent across all browsers */}
-      <ScrollArea className={'flex flex-1 flex-col transition-all'} style={style}>
+      <ScrollArea
+        className={'flex flex-1 flex-col transition-all'}
+        style={style}
+      >
         <Header />
         <div className="flex-1 p-4 lg:p-10">{children}</div>
       </ScrollArea>

--- a/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
@@ -4,19 +4,24 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
 import { Header } from '@/components/header'
 
+import { useTheme } from 'next-themes'
+
 export default function MainContent({
   children
 }: {
   children: React.ReactNode
 }) {
+  const { theme } = useTheme()
   const [isShowDemoBanner] = useShowDemoBanner()
+  
   const style = isShowDemoBanner
     ? { height: `calc(100vh - ${BANNER_HEIGHT})` }
     : { height: '100vh' }
+    console.log('MainContent isShowDemoBanner', isShowDemoBanner)
   return (
     <>
       {/* Wraps right hand side into ScrollArea, making scroll bar consistent across all browsers */}
-      <ScrollArea className={'flex flex-1 flex-col'} style={style}>
+      <ScrollArea className={'flex flex-1 flex-col transition-all'} style={style}>
         <Header />
         <div className="flex-1 p-4 lg:p-10">{children}</div>
       </ScrollArea>

--- a/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
@@ -41,7 +41,10 @@ export default function Sidebar({ children, className }: SidebarProps) {
     <ScrollArea
       className={cn('grid overflow-hidden md:grid-cols-[280px_1fr]', className)}
     >
-      <div className="hidden w-[280px] border-r pt-4 transition-all md:block" style={style}>
+      <div
+        className="hidden w-[280px] border-r pt-4 transition-all md:block"
+        style={style}
+      >
         <nav className="flex h-full flex-col overflow-hidden text-sm font-medium">
           <Link href="/" className="flex justify-center pb-4">
             <Image

--- a/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
@@ -41,7 +41,7 @@ export default function Sidebar({ children, className }: SidebarProps) {
     <ScrollArea
       className={cn('grid overflow-hidden md:grid-cols-[280px_1fr]', className)}
     >
-      <div className="hidden h-full w-[280px] border-r pt-4 transition-all md:block" style={style}>
+      <div className="hidden w-[280px] border-r pt-4 transition-all md:block" style={style}>
         <nav className="flex h-full flex-col overflow-hidden text-sm font-medium">
           <Link href="/" className="flex justify-center pb-4">
             <Image

--- a/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
@@ -40,9 +40,8 @@ export default function Sidebar({ children, className }: SidebarProps) {
   return (
     <ScrollArea
       className={cn('grid overflow-hidden md:grid-cols-[280px_1fr]', className)}
-      style={style}
     >
-      <div className="hidden w-[280px] border-r pt-4 md:block">
+      <div className="hidden h-full w-[280px] border-r pt-4 transition-all md:block" style={style}>
         <nav className="flex h-full flex-col overflow-hidden text-sm font-medium">
           <Link href="/" className="flex justify-center pb-4">
             <Image

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -22,8 +22,8 @@ import {
   ResizablePanel,
   ResizablePanelGroup
 } from '@/components/ui/resizable'
-import { useTopbarProgress } from '@/components/topbar-progress-indicator'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
+import { useTopbarProgress } from '@/components/topbar-progress-indicator'
 
 import { emitter, QuickActionEventPayload } from '../lib/event-emitter'
 import { ChatSideBar } from './chat-side-bar'

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -23,6 +23,7 @@ import {
   ResizablePanelGroup
 } from '@/components/ui/resizable'
 import { useTopbarProgress } from '@/components/topbar-progress-indicator'
+import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
 
 import { emitter, QuickActionEventPayload } from '../lib/event-emitter'
 import { ChatSideBar } from './chat-side-bar'
@@ -479,9 +480,15 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
 }
 
 const SourceCodeBrowser: React.FC<SourceCodeBrowserProps> = props => {
+  const [isShowDemoBanner] = useShowDemoBanner()
+  const style = isShowDemoBanner
+    ? { height: `calc(100vh - ${BANNER_HEIGHT})` }
+    : { height: '100vh' }
   return (
     <SourceCodeBrowserContextProvider>
-      <SourceCodeBrowserRenderer className="source-code-browser" {...props} />
+      <div className="transition-all" style={style}>
+        <SourceCodeBrowserRenderer className="source-code-browser" {...props} />
+      </div>
     </SourceCodeBrowserContextProvider>
   )
 }

--- a/ee/tabby-ui/app/files/page.tsx
+++ b/ee/tabby-ui/app/files/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex flex-col">
       <SourceCodeBrowser className="flex-1 overflow-hidden" />
     </div>
   )

--- a/ee/tabby-ui/app/playground/components/chat-sessions.tsx
+++ b/ee/tabby-ui/app/playground/components/chat-sessions.tsx
@@ -19,8 +19,8 @@ import {
   TooltipContent,
   TooltipTrigger
 } from '@/components/ui/tooltip'
-import { ListSkeleton } from '@/components/skeleton'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
+import { ListSkeleton } from '@/components/skeleton'
 
 import { ClearChatsButton } from './clear-chats-button'
 import { EditChatTitleDialog } from './edit-chat-title-dialog'
@@ -55,7 +55,7 @@ export const ChatSessions = ({ className }: ChatSessionsProps) => {
     : { height: '100vh' }
   return (
     <>
-      <div className={cn("transition-all", className)} style={style}>
+      <div className={cn('transition-all', className)} style={style}>
         <div className="flex w-[279px] flex-col gap-2">
           <div className="shrink-0 pb-0 pl-3 pt-2">
             <Button

--- a/ee/tabby-ui/app/playground/components/chat-sessions.tsx
+++ b/ee/tabby-ui/app/playground/components/chat-sessions.tsx
@@ -20,6 +20,7 @@ import {
   TooltipTrigger
 } from '@/components/ui/tooltip'
 import { ListSkeleton } from '@/components/skeleton'
+import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
 
 import { ClearChatsButton } from './clear-chats-button'
 import { EditChatTitleDialog } from './edit-chat-title-dialog'
@@ -32,6 +33,7 @@ export const ChatSessions = ({ className }: ChatSessionsProps) => {
   const _hasHydrated = useStore(useChatStore, state => state._hasHydrated)
   const chats = useStore(useChatStore, state => state.chats)
   const activeChatId = useStore(useChatStore, state => state.activeChatId)
+  const [isShowDemoBanner] = useShowDemoBanner()
 
   const onDeleteClick = (
     e: React.MouseEvent<HTMLButtonElement>,
@@ -48,10 +50,13 @@ export const ChatSessions = ({ className }: ChatSessionsProps) => {
     clearChats()
   }
 
+  const style = isShowDemoBanner
+    ? { height: `calc(100vh - ${BANNER_HEIGHT})` }
+    : { height: '100vh' }
   return (
     <>
-      <div className={cn(className)}>
-        <div className="fixed inset-y-0 left-0 flex w-[279px] flex-col gap-2">
+      <div className={cn("transition-all", className)} style={style}>
+        <div className="flex w-[279px] flex-col gap-2">
           <div className="shrink-0 pb-0 pl-3 pt-2">
             <Button
               className="h-12 w-full justify-start"

--- a/ee/tabby-ui/components/demo-banner.tsx
+++ b/ee/tabby-ui/components/demo-banner.tsx
@@ -47,8 +47,13 @@ export const ShowDemoBannerProvider = ({
   )
 }
 
-export function useShowDemoBanner(): [boolean, React.Dispatch<React.SetStateAction<boolean>>] {
-  const { isShowDemoBanner, setIsShowDemoBanner } = React.useContext(ShowDemoBannerContext)
+export function useShowDemoBanner(): [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>
+] {
+  const { isShowDemoBanner, setIsShowDemoBanner } = React.useContext(
+    ShowDemoBannerContext
+  )
   return [isShowDemoBanner, setIsShowDemoBanner]
 }
 

--- a/ee/tabby-ui/components/demo-banner.tsx
+++ b/ee/tabby-ui/components/demo-banner.tsx
@@ -33,6 +33,9 @@ export const ShowDemoBannerProvider = ({
   const [isShowDemoBanner, setIsShowDemoBanner] = React.useState(false)
 
   React.useEffect(() => {
+    const isInIframe = window.self !== window.top;
+    if (isInIframe) return
+
     if (!isNil(isDemoMode)) {
       setIsShowDemoBanner(isDemoMode)
     }

--- a/ee/tabby-ui/components/demo-banner.tsx
+++ b/ee/tabby-ui/components/demo-banner.tsx
@@ -33,7 +33,7 @@ export const ShowDemoBannerProvider = ({
   const [isShowDemoBanner, setIsShowDemoBanner] = React.useState(false)
 
   React.useEffect(() => {
-    const isInIframe = window.self !== window.top;
+    const isInIframe = window.self !== window.top
     if (isInIframe) return
 
     if (!isNil(isDemoMode)) {

--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -10,6 +10,7 @@ import { client } from '@/lib/tabby/gql'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
 import { TopbarProgressProvider } from './topbar-progress-indicator'
+import { ShowDemoBannerProvider } from '@/components/demo-banner'
 
 export function Providers({ children, ...props }: ThemeProviderProps) {
   return (
@@ -18,8 +19,10 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
         <TooltipProvider>
           <AuthProvider>
             <TopbarProgressProvider>
-              <EnsureSignin />
-              {children}
+              <ShowDemoBannerProvider>
+                <EnsureSignin />
+                {children}
+              </ShowDemoBannerProvider>
             </TopbarProgressProvider>
           </AuthProvider>
         </TooltipProvider>

--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -8,9 +8,9 @@ import { Provider as UrqlProvider } from 'urql'
 import { AuthProvider, useAuthenticatedSession } from '@/lib/tabby/auth'
 import { client } from '@/lib/tabby/gql'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { ShowDemoBannerProvider } from '@/components/demo-banner'
 
 import { TopbarProgressProvider } from './topbar-progress-indicator'
-import { ShowDemoBannerProvider } from '@/components/demo-banner'
 
 export function Providers({ children, ...props }: ThemeProviderProps) {
   return (


### PR DESCRIPTION
* Refactor the demo-banner component to use Context instead of a simple hook because a hook cannot trigger re-renders in other components.
* Testing more pages/layouts with and without the banners.

`/api`
<img width="1792" alt="1" src="https://github.com/TabbyML/tabby/assets/5305874/3346e589-eafd-4bdc-b74e-49600ffbdeed">

`/playground`
<img width="1787" alt="2" src="https://github.com/TabbyML/tabby/assets/5305874/49e192e5-6061-46e2-87a0-bc1959ac30f3">

`/files`
<img width="1776" alt="3" src="https://github.com/TabbyML/tabby/assets/5305874/62cf3a29-89d8-4f67-88b6-3ab8ee2d5cc4">

`/auth`
<img width="2028" alt="4" src="https://github.com/TabbyML/tabby/assets/5305874/0badae39-ade0-4927-a535-9654871b3d49">
