### PR TITLE
fix(vim): fix agent exit wrong type bug

### DIFF
--- a/clients/vim/autoload/tabby/agent.vim
+++ b/clients/vim/autoload/tabby/agent.vim
@@ -52,7 +52,7 @@ function! s:OnError(data)
 endfunction
 
 function! s:OnExit()
-  let s:tabby = {}
+  let s:tabby = 0
   let s:tabby_status = 'exited'
 endfunction
 
@@ -61,7 +61,7 @@ function! tabby#agent#Close()
     return
   endif
   call tabby#job#Stop(s:tabby)
-  let s:tabby = {}
+  let s:tabby = 0
   let s:tabby_status = 'exited'
 endfunction
 


### PR DESCRIPTION
In the vim plugin, whenever the tabby-agent exits (unexpectedly) the s:tabby variable is set to `{}` instead of the numeric `0` to indicate that the agent job is not running.

This leads to the agent functions trying to send messages anyway and error messages being spammed for almost any editor event, for the wrong variable type and subsequent errors, like:
```
line    8:
E731: using Dictionary as a String
line   12:
E474: Invalid argument
```
and
```
Error detected while processing BufLeave Autocommands for "*"... [...]
```

Setting the s:tabby variable to `0` on agent exit solves it.