### PR TITLE
fix(ui): prevent storing useHealth cache for unauthorized error

### DIFF
--- a/ee/tabby-ui/lib/hooks/use-health.tsx
+++ b/ee/tabby-ui/lib/hooks/use-health.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import useSWR, { SWRResponse } from 'swr'
+import { SWRResponse } from 'swr'
+import useSWRImmutable from 'swr/immutable'
 
 import fetcher from '@/lib/tabby/fetcher'
 
@@ -19,5 +20,13 @@ export interface HealthInfo {
 }
 
 export function useHealth(): SWRResponse<HealthInfo> {
-  return useSWR('/v1/health', fetcher)
+  return useSWRImmutable('/v1/health', (url: string) => {
+    return fetcher(url, {
+      errorHandler: () => {
+        throw new Error('Unhealth')
+      }
+    })
+  }, {
+    shouldRetryOnError: false
+  })
 }

--- a/ee/tabby-ui/lib/hooks/use-health.tsx
+++ b/ee/tabby-ui/lib/hooks/use-health.tsx
@@ -20,13 +20,17 @@ export interface HealthInfo {
 }
 
 export function useHealth(): SWRResponse<HealthInfo> {
-  return useSWRImmutable('/v1/health', (url: string) => {
-    return fetcher(url, {
-      errorHandler: () => {
-        throw new Error('Unhealth')
-      }
-    })
-  }, {
-    shouldRetryOnError: false
-  })
+  return useSWRImmutable(
+    '/v1/health',
+    (url: string) => {
+      return fetcher(url, {
+        errorHandler: () => {
+          throw new Error('Unhealth')
+        }
+      })
+    },
+    {
+      shouldRetryOnError: false
+    }
+  )
 }

--- a/ee/tabby-ui/lib/hooks/use-health.tsx
+++ b/ee/tabby-ui/lib/hooks/use-health.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { SWRResponse } from 'swr'
-import useSWRImmutable from 'swr/immutable'
+import useSWR, { SWRResponse } from 'swr'
 
 import fetcher from '@/lib/tabby/fetcher'
 
@@ -20,7 +19,7 @@ export interface HealthInfo {
 }
 
 export function useHealth(): SWRResponse<HealthInfo> {
-  return useSWRImmutable(
+  return useSWR(
     '/v1/health',
     (url: string) => {
       return fetcher(url, {


### PR DESCRIPTION
#### How to reproduce the bug
logout -> clean sessionStorage -> manually open http://loclhost:8080

#### Why
Before login, useHealth received a 401 error in `http://localhost:8080`. useSWR will cache the data as undefined.
When quickly login and calling useHealth, it uses the cached data and returns undefined, causing the page to stop rendering.

#### How to fix
~Prevent the cache for a 401 error.~ No cache for any response error

#### Extra fix
~Using `useSWRImmutable` instead of `useSWR` to reduce the number of fetches.~

Screen record: https://jam.dev/c/f2838518-22ff-4c46-aa7c-1962fb72e08d