### PR TITLE
fix(agent&vscode): improve logging.

### DIFF
--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -35,7 +35,6 @@
     "dev": "tsup --watch --no-minify --no-treeshake",
     "build": "tsc --noEmit && tsup",
     "test": "mocha",
-    "test:watch": "env TEST_LOG_DEBUG=1 mocha --watch",
     "lint": "eslint --fix --ext .ts ./src && prettier --write .",
     "lint:check": "eslint --ext .ts ./src && prettier --check ."
   },

--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -55,7 +55,8 @@ export type AgentConfig = {
     calculateReplaceRange: any;
   };
   logs: {
-    level: "debug" | "error" | "silent";
+    // Controls the level of the logger written to the `~/.tabby-client/agent/logs/`
+    level: "silent" | "error" | "info" | "debug" | "trace";
   };
   tls: {
     // `bundled`, `system`, or a string point to cert file

--- a/clients/tabby-agent/src/AnonymousUsageLogger.ts
+++ b/clients/tabby-agent/src/AnonymousUsageLogger.ts
@@ -5,12 +5,12 @@ import { v4 as uuid } from "uuid";
 import type { paths as CloudApi } from "./types/cloudApi";
 import { name as agentName, version as agentVersion } from "../package.json";
 import { isBrowser } from "./env";
-import { logger } from "./logger";
+import { getLogger } from "./logger";
 import { DataStore } from "./dataStore";
 
 export class AnonymousUsageLogger {
   private anonymousUsageTrackingApi = createClient<CloudApi>({ baseUrl: "https://app.tabbyml.com/api" });
-  private logger = logger("AnonymousUsage");
+  private logger = getLogger("AnonymousUsage");
   private systemData = {
     agent: `${agentName}, ${agentVersion}`,
     browser: isBrowser ? navigator?.userAgent || "browser" : undefined,
@@ -35,7 +35,7 @@ export class AnonymousUsageLogger {
         try {
           await this.dataStore.save();
         } catch (error) {
-          this.logger.debug({ error }, "Error when saving anonymousId");
+          this.logger.error("Failed to save anonymous Id.", error);
         }
       }
     } else {
@@ -90,7 +90,7 @@ export class AnonymousUsageLogger {
         },
       });
     } catch (error) {
-      this.logger.error({ error }, "Error when sending anonymous usage data");
+      this.logger.error("Failed to send anonymous usage data.", error);
     }
   }
 }

--- a/clients/tabby-agent/src/LspServer.ts
+++ b/clients/tabby-agent/src/LspServer.ts
@@ -15,14 +15,14 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { name as agentName, version as agentVersion } from "../package.json";
 import { Agent, StatusChangedEvent, CompletionRequest, CompletionResponse } from "./Agent";
-import { logger } from "./logger";
+import { getLogger } from "./logger";
 import { splitLines, isCanceledError } from "./utils";
 
 export class LspServer {
   private readonly connection = createConnection();
   private readonly documents = new TextDocuments(TextDocument);
 
-  private readonly logger = logger("LspServer");
+  private readonly logger = getLogger("LSP");
 
   private agent?: Agent;
 
@@ -62,7 +62,8 @@ export class LspServer {
   // LSP interface methods
 
   async initialize(params: InitializeParams): Promise<InitializeResult> {
-    this.logger.debug({ params }, "LSP: initialize: request");
+    this.logger.debug("[-->] Initialize Request");
+    this.logger.trace("Initialize params:", params);
     if (!this.agent) {
       throw new Error(`Agent not bound.\n`);
     }
@@ -102,52 +103,58 @@ export class LspServer {
         version: agentVersion,
       },
     };
+    this.logger.debug("[<--] Initialize Response");
+    this.logger.trace("Initialize result:", result);
     return result;
   }
 
   async shutdown() {
-    this.logger.debug("LSP: shutdown: request");
+    this.logger.debug("[-->] shutdown");
     if (!this.agent) {
       throw new Error(`Agent not bound.\n`);
     }
 
     await this.agent.finalize();
+    this.logger.debug("[<--] shutdown");
   }
 
   exit() {
-    this.logger.debug("LSP: exit: request");
+    this.logger.debug("[-->] exit");
     return process.exit(0);
   }
 
   async showMessage(params: ShowMessageParams) {
-    this.logger.debug({ params }, "LSP server notification: window/showMessage");
+    this.logger.debug("[<--] window/showMessage");
+    this.logger.trace("ShowMessage params:", params);
     await this.connection.sendNotification("window/showMessage", params);
   }
 
   async completion(params: CompletionParams): Promise<CompletionList> {
-    this.logger.debug({ params }, "LSP: textDocument/completion: request");
+    this.logger.debug("[-->] textDocument/completion");
+    this.logger.trace("Completion params:", params);
     if (!this.agent) {
       throw new Error(`Agent not bound.\n`);
     }
 
-    try {
-      const request = this.buildCompletionRequest(params);
-      const response = await this.agent.provideCompletions(request);
-      const completionList = this.toCompletionList(response, params);
-      this.logger.debug({ completionList }, "LSP: textDocument/completion: response");
-      return completionList;
-    } catch (error) {
-      if (isCanceledError(error)) {
-        this.logger.debug({ error }, "LSP: textDocument/completion: canceled");
-      } else {
-        this.logger.error({ error }, "LSP: textDocument/completion: error");
-      }
-    }
-
-    return {
+    let completionList: CompletionList = {
       isIncomplete: true,
       items: [],
     };
+    try {
+      const request = this.buildCompletionRequest(params);
+      const response = await this.agent.provideCompletions(request);
+      completionList = this.toCompletionList(response, params);
+    } catch (error) {
+      if (isCanceledError(error)) {
+        this.logger.debug("Completion request canceled.");
+      } else {
+        this.logger.error("Completion request failed.", error);
+      }
+    }
+
+    this.logger.debug("[<--] textDocument/completion");
+    this.logger.trace("Completion result:", completionList);
+    return completionList;
   }
 
   private buildCompletionRequest(

--- a/clients/tabby-agent/src/configFile.ts
+++ b/clients/tabby-agent/src/configFile.ts
@@ -8,7 +8,7 @@ import deepEqual from "deep-equal";
 import { getProperty, deleteProperty } from "dot-prop";
 import type { PartialAgentConfig } from "./AgentConfig";
 import { isBrowser } from "./env";
-import { logger } from "./logger";
+import { getLogger } from "./logger";
 
 const configTomlTemplate = `## Tabby agent configuration file
 
@@ -93,7 +93,7 @@ function validateConfig(config: PartialAgentConfig): PartialAgentConfig {
 class ConfigFile extends EventEmitter {
   private data: PartialAgentConfig = {};
   private watcher?: chokidar.FSWatcher;
-  private logger = logger("ConfigFile");
+  private logger = getLogger("ConfigFile");
 
   constructor(private readonly filepath: string) {
     super();
@@ -117,7 +117,7 @@ class ConfigFile extends EventEmitter {
       if (error instanceof Error && "code" in error && error.code === "ENOENT") {
         await this.createTemplate();
       } else {
-        this.logger.error({ error }, "Failed to load config file");
+        this.logger.error("Failed to load config file.", error);
       }
     }
   }
@@ -141,7 +141,7 @@ class ConfigFile extends EventEmitter {
     try {
       await fs.outputFile(this.filepath, configTomlTemplate);
     } catch (error) {
-      this.logger.error({ error }, "Failed to create config template file");
+      this.logger.error("Failed to create config template file.", error);
     }
   }
 }

--- a/clients/tabby-agent/src/env.ts
+++ b/clients/tabby-agent/src/env.ts
@@ -1,4 +1,3 @@
 // FIXME: refactor env variables for running tests
 export const isBrowser = !!process.env["IS_BROWSER"];
 export const isTest = !!process.env["IS_TEST"];
-export const testLogDebug = !!process.env["TEST_LOG_DEBUG"];

--- a/clients/tabby-agent/src/loadCaCerts.ts
+++ b/clients/tabby-agent/src/loadCaCerts.ts
@@ -6,7 +6,7 @@ import * as macCa from "mac-ca";
 import type { AgentConfig } from "./AgentConfig";
 import { isBrowser } from "./env";
 import "./ArrayExt";
-import { logger as getLogger } from "./logger";
+import { getLogger } from "./logger";
 
 type Cert = string | winCa.Certificate;
 

--- a/clients/tabby-agent/src/logger.ts
+++ b/clients/tabby-agent/src/logger.ts
@@ -43,7 +43,7 @@ class TaggedLogger implements Logger {
   }
 
   error(msg: string, error: any): void {
-    this.baseLogger.error(this.tagMsg(msg), error);
+    this.baseLogger.error(this.tagMsg(msg), { error });
   }
   warn(msg: string): void {
     this.baseLogger.warn(this.tagMsg(msg));

--- a/clients/tabby-agent/src/postprocess/base.ts
+++ b/clients/tabby-agent/src/postprocess/base.ts
@@ -1,5 +1,5 @@
 import { CompletionResponse, CompletionResponseChoice, CompletionContext } from "../CompletionContext";
-import { logger as getLogger } from "../logger";
+import { getLogger } from "../logger";
 import "../ArrayExt";
 
 type PostprocessFilterBase<T extends string | CompletionResponseChoice> = (

--- a/clients/tabby-agent/src/postprocess/calculateReplaceRangeByBracketStack.ts
+++ b/clients/tabby-agent/src/postprocess/calculateReplaceRangeByBracketStack.ts
@@ -18,16 +18,15 @@ export function calculateReplaceRangeByBracketStack(
   }
   if (suffixText.startsWith(unpaired)) {
     choice.replaceRange.end = context.position + unpaired.length;
-    logger.trace(
-      { context, completion: choice.text, range: choice.replaceRange, unpaired },
-      "Adjust replace range by bracket stack",
-    );
   } else if (unpaired.startsWith(suffixText)) {
     choice.replaceRange.end = context.position + suffixText.length;
-    logger.trace(
-      { context, completion: choice.text, range: choice.replaceRange, unpaired },
-      "Adjust replace range by bracket stack",
-    );
   }
+  logger.trace("Adjust replace range by bracket stack.", {
+    position: context.position,
+    currentLineSuffix,
+    completionText: choice.text,
+    unpaired,
+    replaceRange: choice.replaceRange,
+  });
   return choice;
 }

--- a/clients/tabby-agent/src/postprocess/dropDuplicated.ts
+++ b/clients/tabby-agent/src/postprocess/dropDuplicated.ts
@@ -30,10 +30,7 @@ export function dropDuplicated(): PostprocessFilter {
     const threshold = Math.max(1, 0.05 * inputToCompare.length, 0.05 * suffixToCompare.length);
     const distance = calcDistance(inputToCompare, suffixToCompare);
     if (distance <= threshold) {
-      logger.debug(
-        { inputLines, suffixLines, inputToCompare, suffixToCompare, distance, threshold },
-        "Drop completion due to duplicated.",
-      );
+      logger.trace("Drop completion due to duplicated.", { inputToCompare, suffixToCompare, distance, threshold });
       return null;
     }
     return input;

--- a/clients/tabby-agent/src/postprocess/formatIndentation.ts
+++ b/clients/tabby-agent/src/postprocess/formatIndentation.ts
@@ -94,7 +94,7 @@ export function formatIndentation(): PostprocessFilter {
         return indentation.repeat(level) + rest;
       }
     });
-    logger.debug({ prefixLines, suffixLines, inputLines, formatted }, "Format indentation.");
+    logger.trace("Format indentation.", { inputLines, formatted });
     return formatted.join("");
   };
 }

--- a/clients/tabby-agent/src/postprocess/limitScopeByIndentation.ts
+++ b/clients/tabby-agent/src/postprocess/limitScopeByIndentation.ts
@@ -112,10 +112,12 @@ export function limitScopeByIndentation(config: AgentConfig["postprocess"]["limi
       index++;
     }
     if (index < inputLines.length) {
-      logger.debug(
-        { inputLines, prefixLines, suffixLines, scopeLineCount: index },
-        "Remove content out of indent scope",
-      );
+      logger.trace("Remove content out of indent scope.", {
+        inputLines,
+        prefixLines,
+        suffixLines,
+        trimAtInputLine: index,
+      });
       return inputLines.slice(0, index).join("").trimEnd();
     }
     return input;

--- a/clients/tabby-agent/src/postprocess/removeDuplicatedBlockClosingLine.ts
+++ b/clients/tabby-agent/src/postprocess/removeDuplicatedBlockClosingLine.ts
@@ -34,7 +34,7 @@ export function removeDuplicatedBlockClosingLine(): PostprocessFilter {
       inputEndingLine.startsWith(suffixBeginningLine.trimEnd()) ||
       suffixBeginningLine.startsWith(inputEndingLine.trimEnd())
     ) {
-      logger.debug({ inputLines, suffixLines }, "Removing duplicated block closing line");
+      logger.trace("Remove duplicated block closing line.", { inputLines, suffixLines });
       return inputLines
         .slice(0, inputLines.length - 1)
         .join("")

--- a/clients/tabby-agent/src/postprocess/removeLineEndsWithRepetition.ts
+++ b/clients/tabby-agent/src/postprocess/removeLineEndsWithRepetition.ts
@@ -19,14 +19,11 @@ export function removeLineEndsWithRepetition(): PostprocessFilter {
     for (const test of repetitionTests) {
       const match = inputLines[index]!.match(test);
       if (match) {
-        logger.debug(
-          {
-            inputLines,
-            lineNumber: index,
-            match,
-          },
-          "Remove line ends with repetition.",
-        );
+        logger.trace("Remove line ends with repetition.", {
+          inputLines,
+          lineNumber: index,
+          match,
+        });
         if (index < 1) return null;
         return inputLines.slice(0, index).join("").trimEnd();
       }

--- a/clients/tabby-agent/src/postprocess/removeRepetitiveBlocks.ts
+++ b/clients/tabby-agent/src/postprocess/removeRepetitiveBlocks.ts
@@ -39,13 +39,10 @@ export function removeRepetitiveBlocks(): PostprocessFilter {
       }
     }
     if (repetitionCount >= repetitionThreshold) {
-      logger.debug(
-        {
-          inputBlocks,
-          repetitionCount,
-        },
-        "Remove repetitive blocks.",
-      );
+      logger.trace("Remove repetitive blocks.", {
+        inputBlocks,
+        repetitionCount,
+      });
       return inputBlocks
         .slice(0, index + 1)
         .join("")

--- a/clients/tabby-agent/src/postprocess/removeRepetitiveLines.ts
+++ b/clients/tabby-agent/src/postprocess/removeRepetitiveLines.ts
@@ -31,13 +31,10 @@ export function removeRepetitiveLines(): PostprocessFilter {
       }
     }
     if (repetitionCount >= repetitionThreshold) {
-      logger.debug(
-        {
-          inputLines,
-          repetitionCount,
-        },
-        "Remove repetitive lines.",
-      );
+      logger.trace("Remove repetitive lines.", {
+        inputLines,
+        repetitionCount,
+      });
       return inputLines
         .slice(0, index + 1)
         .join("")

--- a/clients/tabby-agent/src/postprocess/trimMultiLineInSingleLineMode.ts
+++ b/clients/tabby-agent/src/postprocess/trimMultiLineInSingleLineMode.ts
@@ -11,11 +11,11 @@ export function trimMultiLineInSingleLineMode(): PostprocessFilter {
       if (inputLine.endsWith(suffix)) {
         const trimmedInputLine = inputLine.slice(0, -suffix.length);
         if (trimmedInputLine.length > 0) {
-          logger.debug({ inputLines, trimmedInputLine }, "Trim content with multiple lines");
+          logger.trace("Trim content with multiple lines.", { inputLines, trimmedInputLine });
           return trimmedInputLine;
         }
       }
-      logger.debug({ inputLines }, "Drop content with multiple lines");
+      logger.trace("Drop content with multiple lines.", { inputLines });
       return null;
     }
     return input;

--- a/clients/tabby-agent/src/utils.ts
+++ b/clients/tabby-agent/src/utils.ts
@@ -233,6 +233,10 @@ export function isCanceledError(error: any) {
   return error instanceof Error && error.name === "AbortError";
 }
 
+export function isUnauthorizedError(error: any) {
+  return error instanceof HttpError && [401, 403].includes(error.status);
+}
+
 export function errorToString(error: Error & { cause?: Error }) {
   let message = error.message || error.toString();
   if (error.cause) {

--- a/clients/vscode/src/commands.ts
+++ b/clients/vscode/src/commands.ts
@@ -12,7 +12,6 @@ import {
 } from "vscode";
 import os from "os";
 import { strict as assert } from "assert";
-import { logger } from "./logger";
 import { agent } from "./agent";
 import { notifications } from "./notifications";
 import { TabbyCompletionProvider } from "./TabbyCompletionProvider";
@@ -66,7 +65,6 @@ const setApiEndpoint: Command = {
       })
       .then((url) => {
         if (url) {
-          logger().debug("Set Tabby Server URL: ", url);
           configuration.update("api.endpoint", url, configTarget, false);
         }
       });
@@ -89,11 +87,9 @@ const setApiToken = (context: ExtensionContext): Command => {
             return; // User canceled
           }
           if (token.length > 0) {
-            logger().debug("Set token: ", token);
             context.globalState.update("server.token", token);
             agent().updateConfig("server.token", token);
           } else {
-            logger().debug("Clear token.");
             context.globalState.update("server.token", undefined);
             agent().clearConfig("server.token");
           }
@@ -179,7 +175,6 @@ const openAuthPage: Command = {
           if (error.name === "AbortError") {
             return;
           }
-          logger().error("Error auth", { error });
           notifications.showInformationWhenAuthFailed();
         } finally {
           callbacks?.onAuthEnd?.();

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -1,17 +1,19 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import { ExtensionContext, commands, languages, workspace } from "vscode";
-import { logger } from "./logger";
+import { getLogger } from "./logger";
 import { createAgentInstance, disposeAgentInstance } from "./agent";
 import { tabbyCommands } from "./commands";
 import { TabbyCompletionProvider } from "./TabbyCompletionProvider";
 import { TabbyStatusBarItem } from "./TabbyStatusBarItem";
 import { RecentlyChangedCodeSearch } from "./RecentlyChangedCodeSearch";
 
+const logger = getLogger();
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export async function activate(context: ExtensionContext) {
-  logger().info("Activating Tabby extension");
+  logger.info("Activating Tabby extension...");
   const agent = await createAgentInstance(context);
   const completionProvider = new TabbyCompletionProvider();
   context.subscriptions.push(languages.registerInlineCompletionItemProvider({ pattern: "**" }, completionProvider));
@@ -62,10 +64,12 @@ export async function activate(context: ExtensionContext) {
     }
   });
   updateIsExplainCodeEnabledContextVariable();
+  logger.info("Tabby extension activated.");
 }
 
 // this method is called when your extension is deactivated
 export async function deactivate() {
-  logger().info("Deactivating Tabby extension");
+  logger.info("Deactivating Tabby extension...");
   await disposeAgentInstance();
+  logger.info("Tabby extension deactivated.");
 }

--- a/clients/vscode/src/logger.ts
+++ b/clients/vscode/src/logger.ts
@@ -9,7 +9,7 @@ export function getLogChannel(): LogOutputChannel {
   return instance;
 }
 
-export function logger(tag: string = "Tabby"): LogOutputChannel {
+export function getLogger(tag: string = "Tabby"): LogOutputChannel {
   const rawLogger = getLogChannel();
   const tagMessage = (message: string) => {
     return `[${tag}] ${message}`;

--- a/clients/vscode/src/notifications.ts
+++ b/clients/vscode/src/notifications.ts
@@ -4,7 +4,6 @@ import type {
   SlowCompletionResponseTimeIssue,
   ConnectionFailedIssue,
 } from "tabby-agent";
-import { logger } from "./logger";
 import { agent } from "./agent";
 
 function showInformationWhenInitializing() {
@@ -79,7 +78,6 @@ function showInformationWhenInlineSuggestDisabled() {
     .then((selection) => {
       switch (selection) {
         case "Enable":
-          logger().debug(`Set editor.inlineSuggest.enabled: true.`);
           workspace.getConfiguration("editor").update("inlineSuggest.enabled", true, ConfigurationTarget.Global, false);
           break;
         case "Settings":


### PR DESCRIPTION
Complete TAB-606 TAB-620

Changes:
Refine all logging levels to `error`, `info`, `debug`, and `trace`. All runtime variable values will only be logged at the `trace` level.

Preview in VSCode Output:
![Screenshot from 2024-05-09 10-29-25](https://github.com/TabbyML/tabby/assets/13573879/fc4b84cc-24d3-44ab-b7ac-8a0524671209)
