### PR TITLE
fix(ui): adjust style of selected repository in code browser

### DIFF
--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -208,13 +208,20 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
           value={repositorySpecifier}
         >
           <SelectTrigger>
-            <SelectValue>
-              <div className="flex items-center gap-2">
-                <RepositoryKindIcon
-                  kind={repositoryKind}
-                  fallback={<IconFolderGit />}
-                />
-                <span className={repositoryName ? '' : 'text-muted-foreground'}>
+            <SelectValue asChild>
+              <div className="flex items-center gap-2 overflow-hidden">
+                <div className="shrink-0">
+                  <RepositoryKindIcon
+                    kind={repositoryKind}
+                    fallback={<IconFolderGit />}
+                  />
+                </div>
+                <span
+                  className={cn(
+                    'truncate',
+                    !repositoryName && 'text-muted-foreground'
+                  )}
+                >
                   {repositoryName || 'Pick a repository'}
                 </span>
               </div>


### PR DESCRIPTION
Before:
<img width="301" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/ef261ba4-44e1-4043-afea-df11306a7874">

After:
<img width="297" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/486e96d6-fc1e-494e-b702-2e4a23595ec9">
