### PR TITLE
fix(ui): display a skeleton after switching repositories

### DIFF
--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -340,7 +340,11 @@ const FileTreeRenderer: React.FC = () => {
     )
 
   if (repositorySpecifier && !fileTreeData?.length) {
-    if (activePath && !fileMap?.[activePath]?.treeExpanded) {
+    if (
+      activePath &&
+      fileMap?.[activePath]?.isRepository &&
+      !fileMap?.[activePath]?.treeExpanded
+    ) {
       return <FileTreeSkeleton />
     }
 

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -19,6 +19,7 @@ import {
   IconSpinner
 } from '@/components/ui/icons'
 import { Skeleton } from '@/components/ui/skeleton'
+import { ListSkeleton } from '@/components/skeleton'
 
 import { SourceCodeBrowserContext, TFileMap } from './source-code-browser'
 import { resolveFileNameFromPath, resolveRepositoryInfoFromPath } from './utils'
@@ -275,7 +276,7 @@ const DirectoryTreeNode: React.FC<DirectoryTreeNodeProps> = ({
     onSelectTreeNode?.(node)
   }
 
-  const [loading] = useDebounceValue(isLoading, 300)
+  const [loading] = useDebounceValue(isLoading, 100)
 
   const existingChildren = !!node?.children?.length
 
@@ -340,6 +341,10 @@ const FileTreeRenderer: React.FC = () => {
     )
 
   if (repositorySpecifier && !fileTreeData?.length) {
+    if (activePath && !fileMap?.[activePath]?.treeExpanded) {
+      return <ListSkeleton />
+    }
+
     return (
       <div className="flex h-full items-center justify-center">No Data</div>
     )

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -330,6 +330,13 @@ const FileTreeRenderer: React.FC = () => {
     React.useContext(FileTreeContext)
   const { repositorySpecifier } = resolveRepositoryInfoFromPath(activePath)
 
+  const hasSelectedRepo = !!repositorySpecifier
+  const hasNoRepoEntries = hasSelectedRepo && !fileTreeData?.length
+  const fetchingRepoEntries =
+    activePath &&
+    fileMap?.[activePath]?.isRepository &&
+    !fileMap?.[activePath]?.treeExpanded
+
   if (!initialized) return <FileTreeSkeleton />
 
   if (isEmpty(fileMap))
@@ -339,22 +346,18 @@ const FileTreeRenderer: React.FC = () => {
       </div>
     )
 
-  if (repositorySpecifier && !fileTreeData?.length) {
-    if (
-      activePath &&
-      fileMap?.[activePath]?.isRepository &&
-      !fileMap?.[activePath]?.treeExpanded
-    ) {
+  if (!hasSelectedRepo) {
+    return null
+  }
+
+  if (hasNoRepoEntries) {
+    if (fetchingRepoEntries) {
       return <FileTreeSkeleton />
     }
 
     return (
       <div className="flex h-full items-center justify-center">No Data</div>
     )
-  }
-
-  if (!repositorySpecifier) {
-    return null
   }
 
   return (

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -19,7 +19,6 @@ import {
   IconSpinner
 } from '@/components/ui/icons'
 import { Skeleton } from '@/components/ui/skeleton'
-import { ListSkeleton } from '@/components/skeleton'
 
 import { SourceCodeBrowserContext, TFileMap } from './source-code-browser'
 import { resolveFileNameFromPath, resolveRepositoryInfoFromPath } from './utils'
@@ -342,7 +341,7 @@ const FileTreeRenderer: React.FC = () => {
 
   if (repositorySpecifier && !fileTreeData?.length) {
     if (activePath && !fileMap?.[activePath]?.treeExpanded) {
-      return <ListSkeleton />
+      return <FileTreeSkeleton />
     }
 
     return (

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -23,6 +23,7 @@ import {
   ResizablePanelGroup
 } from '@/components/ui/resizable'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
+import { ListSkeleton } from '@/components/skeleton'
 import { useTopbarProgress } from '@/components/topbar-progress-indicator'
 
 import { emitter, QuickActionEventPayload } from '../lib/event-emitter'
@@ -442,35 +443,39 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
       >
         <FileTreePanel />
       </ResizablePanel>
-      <ResizableHandle className="hidden w-1 bg-border/40 hover:bg-border active:bg-blue-500 lg:block" />
+      <ResizableHandle className="bg-border/40 hover:bg-border hidden w-1 active:bg-blue-500 lg:block" />
       <ResizablePanel defaultSize={80} minSize={30}>
         <div className="flex h-full flex-col overflow-y-auto px-4 pb-4">
           <FileDirectoryBreadcrumb className="py-4" />
-          <div>
-            {showDirectoryView && (
-              <DirectoryView
-                loading={fetchingSubTree}
-                initialized={initialized}
-                className={`rounded-lg border`}
-              />
-            )}
-            {showTextFileView && (
-              <TextFileView blob={fileBlob} contentLength={contentLength} />
-            )}
-            {showRawFileView && (
-              <RawFileView
-                blob={fileBlob}
-                isImage={fileViewType === 'image'}
-                contentLength={contentLength}
-              />
-            )}
-          </div>
+          {!initialized ? (
+            <ListSkeleton className="rounded-lg border p-4" />
+          ) : (
+            <div>
+              {showDirectoryView && (
+                <DirectoryView
+                  loading={fetchingSubTree}
+                  initialized={initialized}
+                  className={`rounded-lg border`}
+                />
+              )}
+              {showTextFileView && (
+                <TextFileView blob={fileBlob} contentLength={contentLength} />
+              )}
+              {showRawFileView && (
+                <RawFileView
+                  blob={fileBlob}
+                  isImage={fileViewType === 'image'}
+                  contentLength={contentLength}
+                />
+              )}
+            </div>
+          )}
         </div>
       </ResizablePanel>
       <>
         <ResizableHandle
           className={cn(
-            'hidden w-1 bg-border/40 hover:bg-border active:bg-blue-500',
+            'bg-border/40 hover:bg-border hidden w-1 active:bg-blue-500',
             chatSideBarVisible && 'block'
           )}
         />

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -443,7 +443,7 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
       >
         <FileTreePanel />
       </ResizablePanel>
-      <ResizableHandle className="bg-border/40 hover:bg-border hidden w-1 active:bg-blue-500 lg:block" />
+      <ResizableHandle className="hidden w-1 bg-border/40 hover:bg-border active:bg-blue-500 lg:block" />
       <ResizablePanel defaultSize={80} minSize={30}>
         <div className="flex h-full flex-col overflow-y-auto px-4 pb-4">
           <FileDirectoryBreadcrumb className="py-4" />
@@ -475,7 +475,7 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
       <>
         <ResizableHandle
           className={cn(
-            'bg-border/40 hover:bg-border hidden w-1 active:bg-blue-500',
+            'hidden w-1 bg-border/40 hover:bg-border active:bg-blue-500',
             chatSideBarVisible && 'block'
           )}
         />

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -355,7 +355,7 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
 
   React.useEffect(() => {
     const onFetchSubTree = () => {
-      if (subTree?.entries?.length && activePath) {
+      if (Array.isArray(subTree?.entries) && activePath) {
         const { repositorySpecifier } =
           resolveRepositoryInfoFromPath(activePath)
         let patchMap: TFileMap = {}


### PR DESCRIPTION
1. display a skeleton after switching repositories
  before: https://jam.dev/c/dd54032d-ad8b-497e-b03a-02baa0eda59e
  after: https://jam.dev/c/68f58438-73d3-4b7f-9032-7a7df0ae554f

2. Reduce the delay time for showing the loading indicator after clicking the expand button in the file tree.

