### PR TITLE
feat(client): update chat-pannel and switch to threads

### DIFF
--- a/clients/tabby-chat-panel/dist/index.cjs
+++ b/clients/tabby-chat-panel/dist/index.cjs
@@ -1,21 +1,17 @@
 'use strict';
 
-function createClient(createFn, target) {
-  return createFn(target, {
-    callable: ["init", "sendMessage"]
-  });
+const threads = require('@quilted/threads');
+
+function createClient(target) {
+  return threads.createThreadFromIframe(target);
 }
-function createServer(createFn, api, target) {
-  const opts = {
+function createServer(api) {
+  return threads.createThreadFromInsideIframe({
     expose: {
       init: api.init,
       sendMessage: api.sendMessage
     }
-  };
-  if (target)
-    return createFn(target, opts);
-  const createFnWithoutTarget = createFn;
-  return createFnWithoutTarget(opts);
+  });
 }
 
 exports.createClient = createClient;

--- a/clients/tabby-chat-panel/dist/index.cjs
+++ b/clients/tabby-chat-panel/dist/index.cjs
@@ -1,16 +1,21 @@
 'use strict';
 
-const rpc = require('@remote-ui/rpc');
-
-function createClient(endpoint) {
-  return rpc.createEndpoint(endpoint);
-}
-function createServer(endpoint, api) {
-  const server = rpc.createEndpoint(endpoint);
-  server.expose({
-    init: api.init
+function createClient(createFn, target) {
+  return createFn(target, {
+    callable: ["init", "sendMessage"]
   });
-  return server;
+}
+function createServer(createFn, api, target) {
+  const opts = {
+    expose: {
+      init: api.init,
+      sendMessage: api.sendMessage
+    }
+  };
+  if (target)
+    return createFn(target, opts);
+  const createFnWithoutTarget = createFn;
+  return createFnWithoutTarget(opts);
 }
 
 exports.createClient = createClient;

--- a/clients/tabby-chat-panel/dist/index.d.cts
+++ b/clients/tabby-chat-panel/dist/index.d.cts
@@ -1,15 +1,14 @@
-import { ThreadOptions } from '@quilted/threads';
+import * as _quilted_threads from '@quilted/threads';
 
-type LineRange = {
+interface LineRange {
     start: number;
-    end: number;
-};
-type FileContext = {
+    end?: number;
+}
+interface FileContext {
     kind: 'file';
     range: LineRange;
-    filename: string;
-    link: string;
-};
+    filepath: string;
+}
 type Context = FileContext;
 interface FetcherOptions {
     authorization: string;
@@ -26,8 +25,7 @@ interface ChatMessage {
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-type CreateThreadFn = ((target: any, opts: ThreadOptions<Api>) => Record<string, any>) | ((opts: ThreadOptions<Api>) => Record<string, any>);
-declare function createClient(createFn: CreateThreadFn, target: any): Api;
-declare function createServer(createFn: CreateThreadFn, api: Api, target?: any): Record<string, any>;
+declare function createClient(target: HTMLIFrameElement): _quilted_threads.Thread<Record<string, never>>;
+declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
 
 export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.cts
+++ b/clients/tabby-chat-panel/dist/index.d.cts
@@ -1,30 +1,33 @@
-import * as _remote_ui_rpc from '@remote-ui/rpc';
-import { MessageEndpoint } from '@remote-ui/rpc';
+import { ThreadOptions } from '@quilted/threads';
 
-interface LineRange {
+type LineRange = {
     start: number;
     end: number;
-}
-interface FileContext {
+};
+type FileContext = {
     kind: 'file';
     range: LineRange;
     filename: string;
     link: string;
-}
+};
 type Context = FileContext;
 interface FetcherOptions {
     authorization: string;
 }
 interface InitRequest {
-    message?: string;
-    selectContext?: Context;
-    relevantContext?: Array<Context>;
-    fetcherOptions?: FetcherOptions;
+    fetcherOptions: FetcherOptions;
 }
 interface Api {
     init: (request: InitRequest) => void;
+    sendMessage: (message: ChatMessage) => void;
 }
-declare function createClient(endpoint: MessageEndpoint): _remote_ui_rpc.Endpoint<Api>;
-declare function createServer(endpoint: MessageEndpoint, api: Api): _remote_ui_rpc.Endpoint<unknown>;
+interface ChatMessage {
+    message: string;
+    selectContext?: Context;
+    relevantContext?: Array<Context>;
+}
+type CreateThreadFn = ((target: any, opts: ThreadOptions<Api>) => Record<string, any>) | ((opts: ThreadOptions<Api>) => Record<string, any>);
+declare function createClient(createFn: CreateThreadFn, target: any): Api;
+declare function createServer(createFn: CreateThreadFn, api: Api, target?: any): Record<string, any>;
 
-export { type Api, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };
+export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.mts
+++ b/clients/tabby-chat-panel/dist/index.d.mts
@@ -1,15 +1,14 @@
-import { ThreadOptions } from '@quilted/threads';
+import * as _quilted_threads from '@quilted/threads';
 
-type LineRange = {
+interface LineRange {
     start: number;
-    end: number;
-};
-type FileContext = {
+    end?: number;
+}
+interface FileContext {
     kind: 'file';
     range: LineRange;
-    filename: string;
-    link: string;
-};
+    filepath: string;
+}
 type Context = FileContext;
 interface FetcherOptions {
     authorization: string;
@@ -26,8 +25,7 @@ interface ChatMessage {
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-type CreateThreadFn = ((target: any, opts: ThreadOptions<Api>) => Record<string, any>) | ((opts: ThreadOptions<Api>) => Record<string, any>);
-declare function createClient(createFn: CreateThreadFn, target: any): Api;
-declare function createServer(createFn: CreateThreadFn, api: Api, target?: any): Record<string, any>;
+declare function createClient(target: HTMLIFrameElement): _quilted_threads.Thread<Record<string, never>>;
+declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
 
 export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.mts
+++ b/clients/tabby-chat-panel/dist/index.d.mts
@@ -1,30 +1,33 @@
-import * as _remote_ui_rpc from '@remote-ui/rpc';
-import { MessageEndpoint } from '@remote-ui/rpc';
+import { ThreadOptions } from '@quilted/threads';
 
-interface LineRange {
+type LineRange = {
     start: number;
     end: number;
-}
-interface FileContext {
+};
+type FileContext = {
     kind: 'file';
     range: LineRange;
     filename: string;
     link: string;
-}
+};
 type Context = FileContext;
 interface FetcherOptions {
     authorization: string;
 }
 interface InitRequest {
-    message?: string;
-    selectContext?: Context;
-    relevantContext?: Array<Context>;
-    fetcherOptions?: FetcherOptions;
+    fetcherOptions: FetcherOptions;
 }
 interface Api {
     init: (request: InitRequest) => void;
+    sendMessage: (message: ChatMessage) => void;
 }
-declare function createClient(endpoint: MessageEndpoint): _remote_ui_rpc.Endpoint<Api>;
-declare function createServer(endpoint: MessageEndpoint, api: Api): _remote_ui_rpc.Endpoint<unknown>;
+interface ChatMessage {
+    message: string;
+    selectContext?: Context;
+    relevantContext?: Array<Context>;
+}
+type CreateThreadFn = ((target: any, opts: ThreadOptions<Api>) => Record<string, any>) | ((opts: ThreadOptions<Api>) => Record<string, any>);
+declare function createClient(createFn: CreateThreadFn, target: any): Api;
+declare function createServer(createFn: CreateThreadFn, api: Api, target?: any): Record<string, any>;
 
-export { type Api, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };
+export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.ts
+++ b/clients/tabby-chat-panel/dist/index.d.ts
@@ -1,15 +1,14 @@
-import { ThreadOptions } from '@quilted/threads';
+import * as _quilted_threads from '@quilted/threads';
 
-type LineRange = {
+interface LineRange {
     start: number;
-    end: number;
-};
-type FileContext = {
+    end?: number;
+}
+interface FileContext {
     kind: 'file';
     range: LineRange;
-    filename: string;
-    link: string;
-};
+    filepath: string;
+}
 type Context = FileContext;
 interface FetcherOptions {
     authorization: string;
@@ -26,8 +25,7 @@ interface ChatMessage {
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-type CreateThreadFn = ((target: any, opts: ThreadOptions<Api>) => Record<string, any>) | ((opts: ThreadOptions<Api>) => Record<string, any>);
-declare function createClient(createFn: CreateThreadFn, target: any): Api;
-declare function createServer(createFn: CreateThreadFn, api: Api, target?: any): Record<string, any>;
+declare function createClient(target: HTMLIFrameElement): _quilted_threads.Thread<Record<string, never>>;
+declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
 
 export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.ts
+++ b/clients/tabby-chat-panel/dist/index.d.ts
@@ -1,30 +1,33 @@
-import * as _remote_ui_rpc from '@remote-ui/rpc';
-import { MessageEndpoint } from '@remote-ui/rpc';
+import { ThreadOptions } from '@quilted/threads';
 
-interface LineRange {
+type LineRange = {
     start: number;
     end: number;
-}
-interface FileContext {
+};
+type FileContext = {
     kind: 'file';
     range: LineRange;
     filename: string;
     link: string;
-}
+};
 type Context = FileContext;
 interface FetcherOptions {
     authorization: string;
 }
 interface InitRequest {
-    message?: string;
-    selectContext?: Context;
-    relevantContext?: Array<Context>;
-    fetcherOptions?: FetcherOptions;
+    fetcherOptions: FetcherOptions;
 }
 interface Api {
     init: (request: InitRequest) => void;
+    sendMessage: (message: ChatMessage) => void;
 }
-declare function createClient(endpoint: MessageEndpoint): _remote_ui_rpc.Endpoint<Api>;
-declare function createServer(endpoint: MessageEndpoint, api: Api): _remote_ui_rpc.Endpoint<unknown>;
+interface ChatMessage {
+    message: string;
+    selectContext?: Context;
+    relevantContext?: Array<Context>;
+}
+type CreateThreadFn = ((target: any, opts: ThreadOptions<Api>) => Record<string, any>) | ((opts: ThreadOptions<Api>) => Record<string, any>);
+declare function createClient(createFn: CreateThreadFn, target: any): Api;
+declare function createServer(createFn: CreateThreadFn, api: Api, target?: any): Record<string, any>;
 
-export { type Api, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };
+export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.mjs
+++ b/clients/tabby-chat-panel/dist/index.mjs
@@ -1,14 +1,19 @@
-import { createEndpoint } from '@remote-ui/rpc';
-
-function createClient(endpoint) {
-  return createEndpoint(endpoint);
-}
-function createServer(endpoint, api) {
-  const server = createEndpoint(endpoint);
-  server.expose({
-    init: api.init
+function createClient(createFn, target) {
+  return createFn(target, {
+    callable: ["init", "sendMessage"]
   });
-  return server;
+}
+function createServer(createFn, api, target) {
+  const opts = {
+    expose: {
+      init: api.init,
+      sendMessage: api.sendMessage
+    }
+  };
+  if (target)
+    return createFn(target, opts);
+  const createFnWithoutTarget = createFn;
+  return createFnWithoutTarget(opts);
 }
 
 export { createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.mjs
+++ b/clients/tabby-chat-panel/dist/index.mjs
@@ -1,19 +1,15 @@
-function createClient(createFn, target) {
-  return createFn(target, {
-    callable: ["init", "sendMessage"]
-  });
+import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/threads';
+
+function createClient(target) {
+  return createThreadFromIframe(target);
 }
-function createServer(createFn, api, target) {
-  const opts = {
+function createServer(api) {
+  return createThreadFromInsideIframe({
     expose: {
       init: api.init,
       sendMessage: api.sendMessage
     }
-  };
-  if (target)
-    return createFn(target, opts);
-  const createFnWithoutTarget = createFn;
-  return createFnWithoutTarget(opts);
+  });
 }
 
 export { createClient, createServer };

--- a/clients/tabby-chat-panel/dist/react.cjs
+++ b/clients/tabby-chat-panel/dist/react.cjs
@@ -1,13 +1,13 @@
 'use strict';
 
 const react = require('react');
-const threads = require('@quilted/threads');
 const index = require('./index.cjs');
+require('@quilted/threads');
 
 function useClient(iframeRef) {
   return react.useMemo(() => {
     if (iframeRef.current)
-      return index.createClient(threads.createThreadFromIframe, iframeRef.current);
+      return index.createClient(iframeRef.current);
   }, [iframeRef.current]);
 }
 function useServer(api) {
@@ -16,9 +16,8 @@ function useServer(api) {
     setIsInIframe(window.self !== window.top);
   }, []);
   return react.useMemo(() => {
-    if (isInIframe) {
-      return index.createServer(threads.createThreadFromInsideIframe, api);
-    }
+    if (isInIframe)
+      return index.createServer(api);
   }, [isInIframe]);
 }
 

--- a/clients/tabby-chat-panel/dist/react.cjs
+++ b/clients/tabby-chat-panel/dist/react.cjs
@@ -1,19 +1,25 @@
 'use strict';
 
-const rpc = require('@remote-ui/rpc');
 const react = require('react');
+const threads = require('@quilted/threads');
 const index = require('./index.cjs');
 
 function useClient(iframeRef) {
   return react.useMemo(() => {
     if (iframeRef.current)
-      return index.createClient(rpc.fromIframe(iframeRef.current));
+      return index.createClient(threads.createThreadFromIframe, iframeRef.current);
   }, [iframeRef.current]);
 }
 function useServer(api) {
-  return react.useMemo(() => {
-    return index.createServer(rpc.fromInsideIframe(), api);
+  const [isInIframe, setIsInIframe] = react.useState(false);
+  react.useEffect(() => {
+    setIsInIframe(window.self !== window.top);
   }, []);
+  return react.useMemo(() => {
+    if (isInIframe) {
+      return index.createServer(threads.createThreadFromInsideIframe, api);
+    }
+  }, [isInIframe]);
 }
 
 exports.useClient = useClient;

--- a/clients/tabby-chat-panel/dist/react.d.cts
+++ b/clients/tabby-chat-panel/dist/react.d.cts
@@ -1,8 +1,8 @@
-import * as _remote_ui_rpc from '@remote-ui/rpc';
 import { RefObject } from 'react';
 import { Api } from './index.cjs';
+import '@quilted/threads';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _remote_ui_rpc.Endpoint<Api> | undefined;
-declare function useServer(api: Api): _remote_ui_rpc.Endpoint<unknown>;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
+declare function useServer(api: Api): Record<string, any> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.cts
+++ b/clients/tabby-chat-panel/dist/react.d.cts
@@ -1,8 +1,8 @@
+import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
 import { Api } from './index.cjs';
-import '@quilted/threads';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): Record<string, any> | undefined;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.mts
+++ b/clients/tabby-chat-panel/dist/react.d.mts
@@ -1,8 +1,8 @@
+import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
 import { Api } from './index.mjs';
-import '@quilted/threads';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): Record<string, any> | undefined;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.mts
+++ b/clients/tabby-chat-panel/dist/react.d.mts
@@ -1,8 +1,8 @@
-import * as _remote_ui_rpc from '@remote-ui/rpc';
 import { RefObject } from 'react';
 import { Api } from './index.mjs';
+import '@quilted/threads';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _remote_ui_rpc.Endpoint<Api> | undefined;
-declare function useServer(api: Api): _remote_ui_rpc.Endpoint<unknown>;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
+declare function useServer(api: Api): Record<string, any> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.ts
+++ b/clients/tabby-chat-panel/dist/react.d.ts
@@ -1,8 +1,8 @@
+import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
 import { Api } from './index.js';
-import '@quilted/threads';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): Record<string, any> | undefined;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.ts
+++ b/clients/tabby-chat-panel/dist/react.d.ts
@@ -1,8 +1,8 @@
-import * as _remote_ui_rpc from '@remote-ui/rpc';
 import { RefObject } from 'react';
 import { Api } from './index.js';
+import '@quilted/threads';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _remote_ui_rpc.Endpoint<Api> | undefined;
-declare function useServer(api: Api): _remote_ui_rpc.Endpoint<unknown>;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
+declare function useServer(api: Api): Record<string, any> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.mjs
+++ b/clients/tabby-chat-panel/dist/react.mjs
@@ -1,17 +1,23 @@
-import { fromIframe, fromInsideIframe } from '@remote-ui/rpc';
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect } from 'react';
+import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/threads';
 import { createClient, createServer } from './index.mjs';
 
 function useClient(iframeRef) {
   return useMemo(() => {
     if (iframeRef.current)
-      return createClient(fromIframe(iframeRef.current));
+      return createClient(createThreadFromIframe, iframeRef.current);
   }, [iframeRef.current]);
 }
 function useServer(api) {
-  return useMemo(() => {
-    return createServer(fromInsideIframe(), api);
+  const [isInIframe, setIsInIframe] = useState(false);
+  useEffect(() => {
+    setIsInIframe(window.self !== window.top);
   }, []);
+  return useMemo(() => {
+    if (isInIframe) {
+      return createServer(createThreadFromInsideIframe, api);
+    }
+  }, [isInIframe]);
 }
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.mjs
+++ b/clients/tabby-chat-panel/dist/react.mjs
@@ -1,11 +1,11 @@
 import { useMemo, useState, useEffect } from 'react';
-import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/threads';
 import { createClient, createServer } from './index.mjs';
+import '@quilted/threads';
 
 function useClient(iframeRef) {
   return useMemo(() => {
     if (iframeRef.current)
-      return createClient(createThreadFromIframe, iframeRef.current);
+      return createClient(iframeRef.current);
   }, [iframeRef.current]);
 }
 function useServer(api) {
@@ -14,9 +14,8 @@ function useServer(api) {
     setIsInIframe(window.self !== window.top);
   }, []);
   return useMemo(() => {
-    if (isInIframe) {
-      return createServer(createThreadFromInsideIframe, api);
-    }
+    if (isInIframe)
+      return createServer(api);
   }, [isInIframe]);
 }
 

--- a/clients/tabby-chat-panel/package.json
+++ b/clients/tabby-chat-panel/package.json
@@ -45,7 +45,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@remote-ui/rpc": "^1.4.5",
+    "@quilted/threads": "^2.1.2",
     "react": "^18.3.1"
   },
   "devDependencies": {

--- a/clients/tabby-chat-panel/package.json
+++ b/clients/tabby-chat-panel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabby-chat-panel",
   "type": "module",
-  "version": "0.0.0",
+  "version": "0.0.0-dev.3",
   "packageManager": "yarn@1.22.22",
   "keywords": [],
   "sideEffects": false,

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -2,7 +2,7 @@ import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/t
 
 export interface LineRange {
   start: number
-  end?: number
+  end: number
 }
 
 export interface FileContext {

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -2,12 +2,12 @@ import type { Thread, ThreadOptions } from '@quilted/threads'
 
 export interface LineRange {
   start: number
-  end: number
+  end?: number
 }
 
 export interface FileContext {
   kind: 'file'
-  range: LineRange
+  range?: LineRange
   language?: string
   path: string
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -1,4 +1,4 @@
-import type { Thread, ThreadOptions } from '@quilted/threads'
+import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/threads'
 
 export interface LineRange {
   start: number
@@ -7,9 +7,8 @@ export interface LineRange {
 
 export interface FileContext {
   kind: 'file'
-  range?: LineRange
-  language?: string
-  path: string
+  range: LineRange
+  filepath: string
 }
 
 export type Context = FileContext
@@ -33,26 +32,15 @@ export interface ChatMessage {
   relevantContext?: Array<Context>
 }
 
-type CreateThreadFn =
-  ((target: any, opts: ThreadOptions<Api>) => Record<string, any>) |
-  ((opts: ThreadOptions<Api>) => Record<string, any>)
-
-export function createClient(createFn: CreateThreadFn, target: any) {
-  return createFn(target, {
-    callable: ['init', 'sendMessage'],
-  }) as Api
+export function createClient(target: HTMLIFrameElement) {
+  return createThreadFromIframe(target)
 }
 
-export function createServer(createFn: CreateThreadFn, api: Api, target?: any) {
-  const opts: ThreadOptions<Api> = {
+export function createServer(api: Api) {
+  return createThreadFromInsideIframe({
     expose: {
       init: api.init,
       sendMessage: api.sendMessage,
     },
-  }
-  if (target)
-    return createFn(target, opts)
-
-  const createFnWithoutTarget = createFn as (opts: ThreadOptions<Api>) => Thread<Record<string, any>>
-  return createFnWithoutTarget(opts)
+  })
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -8,8 +8,8 @@ export interface LineRange {
 export interface FileContext {
   kind: 'file'
   range: LineRange
-  filename: string
-  link: string
+  language?: string
+  path: string
 }
 
 export type Context = FileContext

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -1,18 +1,28 @@
-import { fromIframe, fromInsideIframe } from "@remote-ui/rpc"
-import { RefObject, useMemo } from "react"
-import { Api, createClient, createServer } from "./index"
+import type { RefObject } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/threads'
+
+import type { Api } from './index'
+import { createClient, createServer } from './index'
 
 function useClient(iframeRef: RefObject<HTMLIFrameElement>) {
   return useMemo(() => {
     if (iframeRef.current)
-      return createClient(fromIframe(iframeRef.current))
+      return createClient(createThreadFromIframe, iframeRef.current)
   }, [iframeRef.current])
 }
 
 function useServer(api: Api) {
-  return useMemo(() => {
-    return createServer(fromInsideIframe(), api)
+  const [isInIframe, setIsInIframe] = useState(false)
+
+  useEffect(() => {
+    setIsInIframe(window.self !== window.top)
   }, [])
+
+  return useMemo(() => {
+    if (isInIframe)
+      return createServer(createThreadFromInsideIframe, api)
+  }, [isInIframe])
 }
 
 export {

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -1,6 +1,5 @@
 import type { RefObject } from 'react'
 import { useEffect, useMemo, useState } from 'react'
-import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/threads'
 
 import type { Api } from './index'
 import { createClient, createServer } from './index'
@@ -8,7 +7,7 @@ import { createClient, createServer } from './index'
 function useClient(iframeRef: RefObject<HTMLIFrameElement>) {
   return useMemo(() => {
     if (iframeRef.current)
-      return createClient(createThreadFromIframe, iframeRef.current)
+      return createClient(iframeRef.current)
   }, [iframeRef.current])
 }
 
@@ -21,7 +20,7 @@ function useServer(api: Api) {
 
   return useMemo(() => {
     if (isInIframe)
-      return createServer(createThreadFromInsideIframe, api)
+      return createServer(api)
   }, [isInIframe])
 }
 

--- a/clients/tabby-chat-panel/yarn.lock
+++ b/clients/tabby-chat-panel/yarn.lock
@@ -661,10 +661,17 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@remote-ui/rpc@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.4.5.tgz#20328970c314374d96fdaae1cf93aca4b47fefee"
-  integrity sha512-Cr+06niG/vmE4A9YsmaKngRuuVSWKMY42NMwtZfy+gctRWGu6Wj9BWuMJg5CEp+JTkRBPToqT5rqnrg1G/Wvow==
+"@quilted/events@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@quilted/events/-/events-2.0.0.tgz#7470ec92e94be1e4628e97f1a1e7726c15cf4e2f"
+  integrity sha512-0Q5w7jgHPj3nD8sTh1o7oa7LFxATK+dH0i4p8Y6BgKBLDOkr9/m01IDUXsbZdZ98XvxQaVkxBF/HUNAFfg/KfA==
+
+"@quilted/threads@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@quilted/threads/-/threads-2.1.2.tgz#3c91d557e24cfe1edda1cd512dc0b85c3b9cf6e7"
+  integrity sha512-jkeh2K+Lbj9MkNXKsLab7Zu+kS16XcoGqBUOFXQNQerfJxMWSpVBliS4tG4chgte0YS6Ot4+fFRf19147gI0aQ==
+  dependencies:
+    "@quilted/events" "^2.0.0"
 
 "@rollup/plugin-alias@^5.0.0":
   version "5.1.0"


### PR DESCRIPTION
### Notable changes
* Using @quilted/threads to replace remote-ui/rpc
* Change FileContext
```
export interface LineRange {
  start: number
  end?: number
}

export interface FileContext {
  kind: 'file'
  range?: LineRange
  language?: string
  path: string
}
```

* Add `sendMessage` to the interface `Api`, the sendMessage is used for scenarios like `explain it`.
* In the `src/react` update method `useClient` and `useServer` (make sure the iframe is rendering)