### PR TITLE
feat(ui): add chat page and integrate with files

### DIFF
--- a/clients/tabby-chat-panel/dist/index.cjs
+++ b/clients/tabby-chat-panel/dist/index.cjs
@@ -2,8 +2,12 @@
 
 const threads = require('@quilted/threads');
 
-function createClient(target) {
-  return threads.createThreadFromIframe(target);
+function createClient(target, api) {
+  return threads.createThreadFromIframe(target, {
+    expose: {
+      navigate: api.navigate
+    }
+  });
 }
 function createServer(api) {
   return threads.createThreadFromInsideIframe({

--- a/clients/tabby-chat-panel/dist/index.d.cts
+++ b/clients/tabby-chat-panel/dist/index.d.cts
@@ -2,12 +2,13 @@ import * as _quilted_threads from '@quilted/threads';
 
 interface LineRange {
     start: number;
-    end?: number;
+    end: number;
 }
 interface FileContext {
     kind: 'file';
     range: LineRange;
     filepath: string;
+    content?: string;
 }
 type Context = FileContext;
 interface FetcherOptions {
@@ -25,7 +26,7 @@ interface ChatMessage {
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-declare function createClient(target: HTMLIFrameElement): _quilted_threads.Thread<Record<string, never>>;
+declare function createClient(target: HTMLIFrameElement): Api;
 declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
 
 export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.cts
+++ b/clients/tabby-chat-panel/dist/index.d.cts
@@ -1,5 +1,3 @@
-import * as _quilted_threads from '@quilted/threads';
-
 interface LineRange {
     start: number;
     end: number;
@@ -17,16 +15,19 @@ interface FetcherOptions {
 interface InitRequest {
     fetcherOptions: FetcherOptions;
 }
-interface Api {
+interface ServerApi {
     init: (request: InitRequest) => void;
     sendMessage: (message: ChatMessage) => void;
+}
+interface ClientApi {
+    navigate: (context: Context) => void;
 }
 interface ChatMessage {
     message: string;
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-declare function createClient(target: HTMLIFrameElement): Api;
-declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
+declare function createClient(target: HTMLIFrameElement, api: ClientApi): ServerApi;
+declare function createServer(api: ServerApi): ClientApi;
 
-export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };
+export { type ChatMessage, type ClientApi, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, type ServerApi, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.mts
+++ b/clients/tabby-chat-panel/dist/index.d.mts
@@ -2,12 +2,13 @@ import * as _quilted_threads from '@quilted/threads';
 
 interface LineRange {
     start: number;
-    end?: number;
+    end: number;
 }
 interface FileContext {
     kind: 'file';
     range: LineRange;
     filepath: string;
+    content?: string;
 }
 type Context = FileContext;
 interface FetcherOptions {
@@ -25,7 +26,7 @@ interface ChatMessage {
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-declare function createClient(target: HTMLIFrameElement): _quilted_threads.Thread<Record<string, never>>;
+declare function createClient(target: HTMLIFrameElement): Api;
 declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
 
 export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.mts
+++ b/clients/tabby-chat-panel/dist/index.d.mts
@@ -1,5 +1,3 @@
-import * as _quilted_threads from '@quilted/threads';
-
 interface LineRange {
     start: number;
     end: number;
@@ -17,16 +15,19 @@ interface FetcherOptions {
 interface InitRequest {
     fetcherOptions: FetcherOptions;
 }
-interface Api {
+interface ServerApi {
     init: (request: InitRequest) => void;
     sendMessage: (message: ChatMessage) => void;
+}
+interface ClientApi {
+    navigate: (context: Context) => void;
 }
 interface ChatMessage {
     message: string;
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-declare function createClient(target: HTMLIFrameElement): Api;
-declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
+declare function createClient(target: HTMLIFrameElement, api: ClientApi): ServerApi;
+declare function createServer(api: ServerApi): ClientApi;
 
-export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };
+export { type ChatMessage, type ClientApi, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, type ServerApi, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.ts
+++ b/clients/tabby-chat-panel/dist/index.d.ts
@@ -2,12 +2,13 @@ import * as _quilted_threads from '@quilted/threads';
 
 interface LineRange {
     start: number;
-    end?: number;
+    end: number;
 }
 interface FileContext {
     kind: 'file';
     range: LineRange;
     filepath: string;
+    content?: string;
 }
 type Context = FileContext;
 interface FetcherOptions {
@@ -25,7 +26,7 @@ interface ChatMessage {
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-declare function createClient(target: HTMLIFrameElement): _quilted_threads.Thread<Record<string, never>>;
+declare function createClient(target: HTMLIFrameElement): Api;
 declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
 
 export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.d.ts
+++ b/clients/tabby-chat-panel/dist/index.d.ts
@@ -1,5 +1,3 @@
-import * as _quilted_threads from '@quilted/threads';
-
 interface LineRange {
     start: number;
     end: number;
@@ -17,16 +15,19 @@ interface FetcherOptions {
 interface InitRequest {
     fetcherOptions: FetcherOptions;
 }
-interface Api {
+interface ServerApi {
     init: (request: InitRequest) => void;
     sendMessage: (message: ChatMessage) => void;
+}
+interface ClientApi {
+    navigate: (context: Context) => void;
 }
 interface ChatMessage {
     message: string;
     selectContext?: Context;
     relevantContext?: Array<Context>;
 }
-declare function createClient(target: HTMLIFrameElement): Api;
-declare function createServer(api: Api): _quilted_threads.Thread<Record<string, never>>;
+declare function createClient(target: HTMLIFrameElement, api: ClientApi): ServerApi;
+declare function createServer(api: ServerApi): ClientApi;
 
-export { type Api, type ChatMessage, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, createClient, createServer };
+export { type ChatMessage, type ClientApi, type Context, type FetcherOptions, type FileContext, type InitRequest, type LineRange, type ServerApi, createClient, createServer };

--- a/clients/tabby-chat-panel/dist/index.mjs
+++ b/clients/tabby-chat-panel/dist/index.mjs
@@ -1,7 +1,11 @@
 import { createThreadFromIframe, createThreadFromInsideIframe } from '@quilted/threads';
 
-function createClient(target) {
-  return createThreadFromIframe(target);
+function createClient(target, api) {
+  return createThreadFromIframe(target, {
+    expose: {
+      navigate: api.navigate
+    }
+  });
 }
 function createServer(api) {
   return createThreadFromInsideIframe({

--- a/clients/tabby-chat-panel/dist/react.cjs
+++ b/clients/tabby-chat-panel/dist/react.cjs
@@ -13,15 +13,15 @@ function useClient(iframeRef) {
 }
 function useServer(api) {
   const [isInIframe, setIsInIframe] = react.useState(false);
-  let isCreated = false;
+  const serverRef = react.useRef(null);
   react.useEffect(() => {
-    setIsInIframe(window.self !== window.top);
+    const isInIframe2 = window.self !== window.top;
+    if (isInIframe2 && !serverRef.current)
+      serverRef.current = index.createServer(api);
+    setIsInIframe(isInIframe2);
   }, []);
   return react.useMemo(() => {
-    if (isInIframe && !isCreated) {
-      isCreated = true;
-      return index.createServer(api);
-    }
+    return serverRef.current;
   }, [isInIframe]);
 }
 

--- a/clients/tabby-chat-panel/dist/react.cjs
+++ b/clients/tabby-chat-panel/dist/react.cjs
@@ -4,25 +4,23 @@ const react = require('react');
 const index = require('./index.cjs');
 require('@quilted/threads');
 
-function useClient(iframeRef) {
-  return react.useMemo(() => {
-    if (iframeRef.current) {
-      return index.createClient(iframeRef.current);
+function useClient(iframeRef, api) {
+  const clientRef = react.useRef(null);
+  react.useEffect(() => {
+    if (iframeRef.current && !clientRef.current) {
+      clientRef.current = index.createClient(iframeRef.current, api);
     }
   }, [iframeRef.current]);
+  return react.useMemo(() => clientRef.current, [clientRef.current]);
 }
 function useServer(api) {
-  const [isInIframe, setIsInIframe] = react.useState(false);
   const serverRef = react.useRef(null);
   react.useEffect(() => {
-    const isInIframe2 = window.self !== window.top;
-    if (isInIframe2 && !serverRef.current)
+    const isInIframe = window.self !== window.top;
+    if (isInIframe && !serverRef.current)
       serverRef.current = index.createServer(api);
-    setIsInIframe(isInIframe2);
   }, []);
-  return react.useMemo(() => {
-    return serverRef.current;
-  }, [isInIframe]);
+  return react.useMemo(() => serverRef.current, [serverRef.current]);
 }
 
 exports.useClient = useClient;

--- a/clients/tabby-chat-panel/dist/react.cjs
+++ b/clients/tabby-chat-panel/dist/react.cjs
@@ -11,7 +11,7 @@ function useClient(iframeRef, api) {
       clientRef.current = index.createClient(iframeRef.current, api);
     }
   }, [iframeRef.current]);
-  return react.useMemo(() => clientRef.current, [clientRef.current]);
+  return clientRef.current;
 }
 function useServer(api) {
   const serverRef = react.useRef(null);
@@ -20,7 +20,7 @@ function useServer(api) {
     if (isInIframe && !serverRef.current)
       serverRef.current = index.createServer(api);
   }, []);
-  return react.useMemo(() => serverRef.current, [serverRef.current]);
+  return serverRef.current;
 }
 
 exports.useClient = useClient;

--- a/clients/tabby-chat-panel/dist/react.cjs
+++ b/clients/tabby-chat-panel/dist/react.cjs
@@ -6,18 +6,22 @@ require('@quilted/threads');
 
 function useClient(iframeRef) {
   return react.useMemo(() => {
-    if (iframeRef.current)
+    if (iframeRef.current) {
       return index.createClient(iframeRef.current);
+    }
   }, [iframeRef.current]);
 }
 function useServer(api) {
   const [isInIframe, setIsInIframe] = react.useState(false);
+  let isCreated = false;
   react.useEffect(() => {
     setIsInIframe(window.self !== window.top);
   }, []);
   return react.useMemo(() => {
-    if (isInIframe)
+    if (isInIframe && !isCreated) {
+      isCreated = true;
       return index.createServer(api);
+    }
   }, [isInIframe]);
 }
 

--- a/clients/tabby-chat-panel/dist/react.d.cts
+++ b/clients/tabby-chat-panel/dist/react.d.cts
@@ -1,8 +1,7 @@
 import { RefObject } from 'react';
-import { Thread } from '@quilted/threads';
-import { Api } from './index.cjs';
+import { ClientApi, ServerApi } from './index.cjs';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): Thread<Record<string, never>> | null;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi): ServerApi | null;
+declare function useServer(api: ServerApi): ClientApi | null;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.cts
+++ b/clients/tabby-chat-panel/dist/react.d.cts
@@ -2,7 +2,7 @@ import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
 import { Api } from './index.cjs';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
 declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.cts
+++ b/clients/tabby-chat-panel/dist/react.d.cts
@@ -1,8 +1,8 @@
-import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
+import { Thread } from '@quilted/threads';
 import { Api } from './index.cjs';
 
 declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useServer(api: Api): Thread<Record<string, never>> | null;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.mts
+++ b/clients/tabby-chat-panel/dist/react.d.mts
@@ -1,8 +1,7 @@
 import { RefObject } from 'react';
-import { Thread } from '@quilted/threads';
-import { Api } from './index.mjs';
+import { ClientApi, ServerApi } from './index.mjs';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): Thread<Record<string, never>> | null;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi): ServerApi | null;
+declare function useServer(api: ServerApi): ClientApi | null;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.mts
+++ b/clients/tabby-chat-panel/dist/react.d.mts
@@ -1,8 +1,8 @@
-import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
+import { Thread } from '@quilted/threads';
 import { Api } from './index.mjs';
 
 declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useServer(api: Api): Thread<Record<string, never>> | null;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.mts
+++ b/clients/tabby-chat-panel/dist/react.d.mts
@@ -2,7 +2,7 @@ import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
 import { Api } from './index.mjs';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
 declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.ts
+++ b/clients/tabby-chat-panel/dist/react.d.ts
@@ -1,8 +1,7 @@
 import { RefObject } from 'react';
-import { Thread } from '@quilted/threads';
-import { Api } from './index.js';
+import { ClientApi, ServerApi } from './index.js';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): Thread<Record<string, never>> | null;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi): ServerApi | null;
+declare function useServer(api: ServerApi): ClientApi | null;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.ts
+++ b/clients/tabby-chat-panel/dist/react.d.ts
@@ -1,8 +1,8 @@
-import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
+import { Thread } from '@quilted/threads';
 import { Api } from './index.js';
 
 declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
-declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useServer(api: Api): Thread<Record<string, never>> | null;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.d.ts
+++ b/clients/tabby-chat-panel/dist/react.d.ts
@@ -2,7 +2,7 @@ import * as _quilted_threads from '@quilted/threads';
 import { RefObject } from 'react';
 import { Api } from './index.js';
 
-declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): _quilted_threads.Thread<Record<string, never>> | undefined;
+declare function useClient(iframeRef: RefObject<HTMLIFrameElement>): Api | undefined;
 declare function useServer(api: Api): _quilted_threads.Thread<Record<string, never>> | undefined;
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.mjs
+++ b/clients/tabby-chat-panel/dist/react.mjs
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useRef, useEffect } from 'react';
 import { createClient, createServer } from './index.mjs';
 import '@quilted/threads';
 
@@ -11,15 +11,15 @@ function useClient(iframeRef) {
 }
 function useServer(api) {
   const [isInIframe, setIsInIframe] = useState(false);
-  let isCreated = false;
+  const serverRef = useRef(null);
   useEffect(() => {
-    setIsInIframe(window.self !== window.top);
+    const isInIframe2 = window.self !== window.top;
+    if (isInIframe2 && !serverRef.current)
+      serverRef.current = createServer(api);
+    setIsInIframe(isInIframe2);
   }, []);
   return useMemo(() => {
-    if (isInIframe && !isCreated) {
-      isCreated = true;
-      return createServer(api);
-    }
+    return serverRef.current;
   }, [isInIframe]);
 }
 

--- a/clients/tabby-chat-panel/dist/react.mjs
+++ b/clients/tabby-chat-panel/dist/react.mjs
@@ -4,18 +4,22 @@ import '@quilted/threads';
 
 function useClient(iframeRef) {
   return useMemo(() => {
-    if (iframeRef.current)
+    if (iframeRef.current) {
       return createClient(iframeRef.current);
+    }
   }, [iframeRef.current]);
 }
 function useServer(api) {
   const [isInIframe, setIsInIframe] = useState(false);
+  let isCreated = false;
   useEffect(() => {
     setIsInIframe(window.self !== window.top);
   }, []);
   return useMemo(() => {
-    if (isInIframe)
+    if (isInIframe && !isCreated) {
+      isCreated = true;
       return createServer(api);
+    }
   }, [isInIframe]);
 }
 

--- a/clients/tabby-chat-panel/dist/react.mjs
+++ b/clients/tabby-chat-panel/dist/react.mjs
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo } from 'react';
+import { useRef, useEffect } from 'react';
 import { createClient, createServer } from './index.mjs';
 import '@quilted/threads';
 
@@ -9,7 +9,7 @@ function useClient(iframeRef, api) {
       clientRef.current = createClient(iframeRef.current, api);
     }
   }, [iframeRef.current]);
-  return useMemo(() => clientRef.current, [clientRef.current]);
+  return clientRef.current;
 }
 function useServer(api) {
   const serverRef = useRef(null);
@@ -18,7 +18,7 @@ function useServer(api) {
     if (isInIframe && !serverRef.current)
       serverRef.current = createServer(api);
   }, []);
-  return useMemo(() => serverRef.current, [serverRef.current]);
+  return serverRef.current;
 }
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/dist/react.mjs
+++ b/clients/tabby-chat-panel/dist/react.mjs
@@ -1,26 +1,24 @@
-import { useMemo, useState, useRef, useEffect } from 'react';
+import { useRef, useEffect, useMemo } from 'react';
 import { createClient, createServer } from './index.mjs';
 import '@quilted/threads';
 
-function useClient(iframeRef) {
-  return useMemo(() => {
-    if (iframeRef.current) {
-      return createClient(iframeRef.current);
+function useClient(iframeRef, api) {
+  const clientRef = useRef(null);
+  useEffect(() => {
+    if (iframeRef.current && !clientRef.current) {
+      clientRef.current = createClient(iframeRef.current, api);
     }
   }, [iframeRef.current]);
+  return useMemo(() => clientRef.current, [clientRef.current]);
 }
 function useServer(api) {
-  const [isInIframe, setIsInIframe] = useState(false);
   const serverRef = useRef(null);
   useEffect(() => {
-    const isInIframe2 = window.self !== window.top;
-    if (isInIframe2 && !serverRef.current)
+    const isInIframe = window.self !== window.top;
+    if (isInIframe && !serverRef.current)
       serverRef.current = createServer(api);
-    setIsInIframe(isInIframe2);
   }, []);
-  return useMemo(() => {
-    return serverRef.current;
-  }, [isInIframe]);
+  return useMemo(() => serverRef.current, [serverRef.current]);
 }
 
 export { useClient, useServer };

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -22,9 +22,14 @@ export interface InitRequest {
   fetcherOptions: FetcherOptions
 }
 
-export interface Api {
+export interface ServerApi {
   init: (request: InitRequest) => void
   sendMessage: (message: ChatMessage) => void
+  
+}
+
+export interface ClientApi {
+  navigate: (context: Context) => void
 }
 
 export interface ChatMessage {
@@ -33,11 +38,15 @@ export interface ChatMessage {
   relevantContext?: Array<Context>
 }
 
-export function createClient(target: HTMLIFrameElement): Api {
-  return createThreadFromIframe(target)
+export function createClient(target: HTMLIFrameElement, api: ClientApi): ServerApi {
+  return createThreadFromIframe(target, {
+    expose: {
+      navigate: api.navigate
+    }
+  })
 }
 
-export function createServer(api: Api) {
+export function createServer(api: ServerApi): ClientApi {
   return createThreadFromInsideIframe({
     expose: {
       init: api.init,

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -33,8 +33,8 @@ export interface ChatMessage {
   relevantContext?: Array<Context>
 }
 
-export function createClient(target: HTMLIFrameElement) {
-  return createThreadFromIframe(target) as Api
+export function createClient(target: HTMLIFrameElement): Api {
+  return createThreadFromIframe(target)
 }
 
 export function createServer(api: Api) {

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -9,6 +9,7 @@ export interface FileContext {
   kind: 'file'
   range: LineRange
   filepath: string
+  content?: string
 }
 
 export type Context = FileContext
@@ -33,7 +34,7 @@ export interface ChatMessage {
 }
 
 export function createClient(target: HTMLIFrameElement) {
-  return createThreadFromIframe(target)
+  return createThreadFromIframe(target) as Api
 }
 
 export function createServer(api: Api) {

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react'
-import { useEffect, useMemo, useState, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 import type { ServerApi, ClientApi } from './index'
 import { createClient, createServer } from './index'
@@ -13,7 +13,7 @@ function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
     }
   }, [iframeRef.current])
 
-  return useMemo(() => clientRef.current, [clientRef.current])
+  return clientRef.current
 }
 
 function useServer(api: ServerApi) {
@@ -24,7 +24,7 @@ function useServer(api: ServerApi) {
     if (isInIframe && !serverRef.current) serverRef.current = createServer(api)
   }, [])
 
-  return useMemo(() => serverRef.current, [serverRef.current])
+  return serverRef.current
 }
 
 export {

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -6,21 +6,25 @@ import { createClient, createServer } from './index'
 
 function useClient(iframeRef: RefObject<HTMLIFrameElement>) {
   return useMemo(() => {
-    if (iframeRef.current)
+    if (iframeRef.current) {
       return createClient(iframeRef.current)
+    }
   }, [iframeRef.current])
 }
 
 function useServer(api: Api) {
   const [isInIframe, setIsInIframe] = useState(false)
+  let isCreated = false
 
   useEffect(() => {
     setIsInIframe(window.self !== window.top)
   }, [])
 
   return useMemo(() => {
-    if (isInIframe)
+    if (isInIframe && !isCreated) {
+      isCreated = true
       return createServer(api)
+    }
   }, [isInIframe])
 }
 

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -1,33 +1,30 @@
 import type { RefObject } from 'react'
 import { useEffect, useMemo, useState, useRef } from 'react'
-import { Thread } from '@quilted/threads'
 
-import type { Api } from './index'
+import type { ServerApi, ClientApi } from './index'
 import { createClient, createServer } from './index'
 
-function useClient(iframeRef: RefObject<HTMLIFrameElement>) {
-  return useMemo(() => {
-    if (iframeRef.current) {
-      return createClient(iframeRef.current)
+function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
+  const clientRef = useRef<ServerApi | null>(null)
+
+  useEffect(() => {
+    if (iframeRef.current && !clientRef.current) {
+      clientRef.current = createClient(iframeRef.current, api)
     }
   }, [iframeRef.current])
+
+  return useMemo(() => clientRef.current, [clientRef.current])
 }
 
-function useServer(api: Api) {
-  const [isInIframe, setIsInIframe] = useState(false)
-  const serverRef = useRef<Thread<Record<string, never>> | null>(null)
+function useServer(api: ServerApi) {
+  const serverRef = useRef<ClientApi | null>(null)
 
   useEffect(() => {
     const isInIframe = window.self !== window.top
-    if (isInIframe && !serverRef.current) {
-      serverRef.current = createServer(api)
-    }
-    setIsInIframe(isInIframe)
+    if (isInIframe && !serverRef.current) serverRef.current = createServer(api)
   }, [])
 
-  return useMemo(() => {
-    return serverRef.current
-  }, [isInIframe])
+  return useMemo(() => serverRef.current, [serverRef.current])
 }
 
 export {

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -1,5 +1,6 @@
 import type { RefObject } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useRef } from 'react'
+import { Thread } from '@quilted/threads'
 
 import type { Api } from './index'
 import { createClient, createServer } from './index'
@@ -14,17 +15,18 @@ function useClient(iframeRef: RefObject<HTMLIFrameElement>) {
 
 function useServer(api: Api) {
   const [isInIframe, setIsInIframe] = useState(false)
-  let isCreated = false
+  const serverRef = useRef<Thread<Record<string, never>> | null>(null)
 
   useEffect(() => {
-    setIsInIframe(window.self !== window.top)
+    const isInIframe = window.self !== window.top
+    if (isInIframe && !serverRef.current) {
+      serverRef.current = createServer(api)
+    }
+    setIsInIframe(isInIframe)
   }, [])
 
   return useMemo(() => {
-    if (isInIframe && !isCreated) {
-      isCreated = true
-      return createServer(api)
-    }
+    return serverRef.current
   }, [isInIframe])
 }
 

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -1,29 +1,31 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useRef, useState } from 'react'
+import type { ChatMessage, FetcherOptions } from 'tabby-chat-panel'
 import { useServer } from 'tabby-chat-panel/react'
-import type { FetcherOptions, ChatMessage } from 'tabby-chat-panel'
 
 import { nanoid } from '@/lib/utils'
 import { Chat, ChatRef } from '@/components/chat/chat'
 
-export default function ChatPage () {
+export default function ChatPage() {
   const [isInit, setIsInit] = useState(false)
-  const [fetcherOptions, setFetcherOptions] = useState<FetcherOptions | null>(null)
-  const chatRef = useRef<ChatRef>(null);
+  const [fetcherOptions, setFetcherOptions] = useState<FetcherOptions | null>(
+    null
+  )
+  const chatRef = useRef<ChatRef>(null)
   const activeChatId = nanoid()
-  let messageQueueBeforeInit: ChatMessage[] = [];
+  let messageQueueBeforeInit: ChatMessage[] = []
 
   const sendMessage = (message: ChatMessage) => {
     if (chatRef.current) {
-      chatRef.current.sendUserChat(message);
+      chatRef.current.sendUserChat(message)
     } else {
       messageQueueBeforeInit.push(message)
     }
   }
 
   useServer({
-    init: (request) => {
+    init: request => {
       if (chatRef.current) return
       setIsInit(true)
       setFetcherOptions(request.fetcherOptions)
@@ -38,7 +40,7 @@ export default function ChatPage () {
 
   if (!isInit || !fetcherOptions) return <></>
   const headers = {
-    'Authorization': `Bearer ${fetcherOptions.authorization}`
+    Authorization: `Bearer ${fetcherOptions.authorization}`
   }
   return (
     <Chat

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -24,7 +24,7 @@ export default function ChatPage() {
     }
   }
 
-  useServer({
+  const server = useServer({
     init: request => {
       if (chatRef.current) return
       setActiveChatId(nanoid())
@@ -40,12 +40,7 @@ export default function ChatPage() {
   })
 
   const onNavigateToContext = (context: Context) => {
-    if (window.top !== window.self) {
-      window.top?.postMessage({
-        action: 'onNavigateToContext',
-        context
-      })
-    }
+    server?.navigate(context)
   }
 
   if (!isInit || !fetcherOptions) return <></>

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -12,7 +12,7 @@ export default function ChatPage() {
   const [fetcherOptions, setFetcherOptions] = useState<FetcherOptions | null>(
     null
   )
-  const [activeChatId, setActiveChatId] = useState("")
+  const [activeChatId, setActiveChatId] = useState('')
   const chatRef = useRef<ChatRef>(null)
   let messageQueueBeforeInit: ChatMessage[] = []
 

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -12,8 +12,8 @@ export default function ChatPage() {
   const [fetcherOptions, setFetcherOptions] = useState<FetcherOptions | null>(
     null
   )
+  const [activeChatId, setActiveChatId] = useState("")
   const chatRef = useRef<ChatRef>(null)
-  const activeChatId = nanoid()
   let messageQueueBeforeInit: ChatMessage[] = []
 
   const sendMessage = (message: ChatMessage) => {
@@ -27,6 +27,7 @@ export default function ChatPage() {
   useServer({
     init: request => {
       if (chatRef.current) return
+      setActiveChatId(nanoid())
       setIsInit(true)
       setFetcherOptions(request.fetcherOptions)
 

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
-import type { ChatMessage, FetcherOptions } from 'tabby-chat-panel'
+import type { ChatMessage, Context, FetcherOptions } from 'tabby-chat-panel'
 import { useServer } from 'tabby-chat-panel/react'
 
 import { nanoid } from '@/lib/utils'
@@ -39,6 +39,15 @@ export default function ChatPage() {
     }
   })
 
+  const onNavigateToContext = (context: Context) => {
+    if (window.top !== window.self) {
+      window.top?.postMessage({
+        action: 'onNavigateToContext',
+        context
+      })
+    }
+  }
+
   if (!isInit || !fetcherOptions) return <></>
   const headers = {
     Authorization: `Bearer ${fetcherOptions.authorization}`
@@ -50,7 +59,7 @@ export default function ChatPage() {
       ref={chatRef}
       headers={headers}
       onThreadUpdates={() => {}}
-      onNavigateToContext={() => {}}
+      onNavigateToContext={onNavigateToContext}
     />
   )
 }

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { useServer } from 'tabby-chat-panel/react'
+import type { FetcherOptions, ChatMessage } from 'tabby-chat-panel'
+
+import { nanoid } from '@/lib/utils'
+import { Chat, ChatRef } from '@/components/chat/chat'
+
+export default function ChatPage () {
+  const [isInit, setIsInit] = useState(false)
+  const [fetcherOptions, setFetcherOptions] = useState<FetcherOptions | null>(null)
+  const chatRef = useRef<ChatRef>(null);
+  const activeChatId = nanoid()
+  let messageQueueBeforeInit: ChatMessage[] = [];
+
+  const sendMessage = (message: ChatMessage) => {
+    if (chatRef.current) {
+      chatRef.current.sendUserChat(message);
+    } else {
+      messageQueueBeforeInit.push(message)
+    }
+  }
+
+  useServer({
+    init: (request) => {
+      if (chatRef.current) return
+      setIsInit(true)
+      setFetcherOptions(request.fetcherOptions)
+
+      messageQueueBeforeInit.forEach(sendMessage)
+      messageQueueBeforeInit = []
+    },
+    sendMessage: (message: ChatMessage) => {
+      return sendMessage(message)
+    }
+  })
+
+  if (!isInit || !fetcherOptions) return <></>
+  const headers = {
+    'Authorization': `Bearer ${fetcherOptions.authorization}`
+  }
+  return (
+    <Chat
+      chatId={activeChatId}
+      key={activeChatId}
+      ref={chatRef}
+      headers={headers}
+      onThreadUpdates={() => {}}
+      onNavigateToContext={() => {}}
+    />
+  )
+}

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type { Context } from 'tabby-chat-panel'
 import { useClient } from 'tabby-chat-panel/react'
 
 import { useMe } from '@/lib/hooks/use-me'
@@ -25,7 +26,11 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
   )
   const activeChatId = useStore(useChatStore, state => state.activeChatId)
   const iframeRef = React.useRef<HTMLIFrameElement>(null)
-  const client = useClient(iframeRef)
+  const client = useClient(iframeRef, {
+    navigate: (context: Context) => {
+      console.log('todo: ', context)
+    }
+  })
 
   const getPrompt = ({ action }: QuickActionEventPayload) => {
     let builtInPrompt = ''

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import type { ChatMessage } from 'tabby-chat-panel'
 import { useClient } from 'tabby-chat-panel/react'
 
-import { useStore } from '@/lib/hooks/use-store'
 import { useMe } from '@/lib/hooks/use-me'
+import { useStore } from '@/lib/hooks/use-store'
 import { useChatStore } from '@/lib/stores/chat-store'
 import { UserMessage } from '@/lib/types'
 import { cn } from '@/lib/utils'
@@ -96,7 +95,7 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
             start: lineFrom,
             end: lineTo
           },
-          filePath: path,
+          filePath: path
         }
       })
     }

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -3,6 +3,7 @@ import type { Context } from 'tabby-chat-panel'
 import { useClient } from 'tabby-chat-panel/react'
 
 import { useMe } from '@/lib/hooks/use-me'
+import useRouterStuff from '@/lib/hooks/use-router-stuff'
 import { useStore } from '@/lib/hooks/use-store'
 import { useChatStore } from '@/lib/stores/chat-store'
 import { UserMessage } from '@/lib/types'
@@ -20,6 +21,7 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
   className,
   ...props
 }) => {
+  const { updateSearchParams } = useRouterStuff()
   const [{ data }] = useMe()
   const { pendingEvent, setPendingEvent } = React.useContext(
     SourceCodeBrowserContext
@@ -28,7 +30,15 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
   const iframeRef = React.useRef<HTMLIFrameElement>(null)
   const client = useClient(iframeRef, {
     navigate: (context: Context) => {
-      console.log('todo: ', context)
+      if (context?.filepath) {
+        updateSearchParams({
+          set: {
+            path: context.filepath,
+            line: String(context.range.start ?? '')
+          },
+          del: 'plain'
+        })
+      }
     }
   })
 
@@ -55,7 +65,7 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
     const contentWindow = iframeRef.current?.contentWindow
 
     if (pendingEvent) {
-      const { lineFrom, lineTo, language, code, path } = pendingEvent
+      const { lineFrom, lineTo, code, path } = pendingEvent
       contentWindow?.postMessage({
         action: 'sendUserChat',
         payload: {

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -61,11 +61,7 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
               start: lineFrom,
               end: lineTo
             },
-            language,
-            filePath: path,
-            link: `/files?path=${encodeURIComponent(path ?? '')}&line=${
-              lineFrom ?? ''
-            }`
+            filepath: path
           }
         } as UserMessage
       })
@@ -93,9 +89,9 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
           content: code,
           range: {
             start: lineFrom,
-            end: lineTo
+            end: lineTo ?? lineFrom
           },
-          filePath: path
+          filepath: path
         }
       })
     }

--- a/ee/tabby-ui/app/files/lib/event-emitter.ts
+++ b/ee/tabby-ui/app/files/lib/event-emitter.ts
@@ -7,8 +7,8 @@ type QuickActionEventPayload = {
   action: CodeBrowserQuickAction
   code: string
   language?: string
-  path?: string
-  lineFrom?: number
+  path: string
+  lineFrom: number
   lineTo?: number
 }
 

--- a/ee/tabby-ui/app/playground/components/chats.tsx
+++ b/ee/tabby-ui/app/playground/components/chats.tsx
@@ -86,18 +86,7 @@ export default function Chats() {
 
   const onNavigateToContext = (context: ChatContext) => {
     if (!context.filepath) return
-
-    // const isInIframe = window.self !== window.top
-    // if embed
-    // if (isInIframe) {
-    //   window.top?.postMessage({
-    //     action: 'navigateToContext',
-    //     path: context.filepath,
-    //     line: context.range.start
-    //   })
-    // } else {
-    //   window.open(context.link)
-    // }
+    
     const url = `/files?path=${encodeURIComponent(context.filepath)}&line=${
       context.range.start ?? ''
     }`

--- a/ee/tabby-ui/app/playground/components/chats.tsx
+++ b/ee/tabby-ui/app/playground/components/chats.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { Context as ChatContext } from 'tabby-chat-panel'
 
 import { useDebounceCallback } from '@/lib/hooks/use-debounce'
 import useRouterStuff from '@/lib/hooks/use-router-stuff'
@@ -9,7 +10,7 @@ import { addChat, updateMessages } from '@/lib/stores/chat-actions'
 import { useChatStore } from '@/lib/stores/chat-store'
 import { getChatById } from '@/lib/stores/utils'
 import fetcher from '@/lib/tabby/fetcher'
-import { Context as ChatContext, QuestionAnswerPair } from '@/lib/types/chat'
+import { QuestionAnswerPair } from '@/lib/types/chat'
 import { truncateText } from '@/lib/utils'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Chat, ChatRef } from '@/components/chat/chat'
@@ -84,18 +85,23 @@ export default function Chats() {
   }
 
   const onNavigateToContext = (context: ChatContext) => {
-    // todo check if is embed
-    if (!context.filePath || !context.link) return
-    const isInIframe = window.self !== window.top
-    if (isInIframe) {
-      window.top?.postMessage({
-        action: 'navigateToContext',
-        path: context.filePath,
-        line: context.range.start
-      })
-    } else {
-      window.open(context.link)
-    }
+    if (!context.filepath) return
+
+    // const isInIframe = window.self !== window.top
+    // if embed
+    // if (isInIframe) {
+    //   window.top?.postMessage({
+    //     action: 'navigateToContext',
+    //     path: context.filepath,
+    //     line: context.range.start
+    //   })
+    // } else {
+    //   window.open(context.link)
+    // }
+    const url = `/files?path=${encodeURIComponent(context.filepath)}&line=${
+      context.range.start ?? ''
+    }`
+    window.open(url)
   }
 
   const onChatLoaded = () => {

--- a/ee/tabby-ui/app/playground/components/chats.tsx
+++ b/ee/tabby-ui/app/playground/components/chats.tsx
@@ -86,7 +86,7 @@ export default function Chats() {
 
   const onNavigateToContext = (context: ChatContext) => {
     if (!context.filepath) return
-    
+
     const url = `/files?path=${encodeURIComponent(context.filepath)}&line=${
       context.range.start ?? ''
     }`

--- a/ee/tabby-ui/components/chat/chat.tsx
+++ b/ee/tabby-ui/components/chat/chat.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import { Message } from 'ai'
 import { useChat, type UseChatHelpers } from 'ai/react'
 import { findIndex, omit } from 'lodash-es'
+import type { Context, FileContext } from 'tabby-chat-panel'
 
+import { filename2prism } from '@/lib/language-utils'
 import {
   AssistantMessage,
-  Context,
-  FileContext,
   MessageActionType,
   QuestionAnswerPair,
   UserMessage,
@@ -63,9 +63,12 @@ function userMessageToMessage(userMessage: UserMessage): Message {
 }
 
 function fileContextToMessageContent(context: FileContext | undefined): string {
-  if (!context) return ''
-  const { content, language } = context
-  return `\n${'```'}${language ?? ''} is_reference=1\n ${content} \n${'```'}\n`
+  if (!context || !context.content) return ''
+  const { content, filepath } = context
+  const language = filename2prism(filepath)?.[0]
+  return `\n${'```'}${language ?? ''} is_reference=1\n ${
+    content ?? ''
+  } \n${'```'}\n`
 }
 
 export interface ChatRef extends Omit<UseChatHelpers, 'append' | 'messages'> {

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -7,10 +7,10 @@ import tabbyLogo from '@/assets/tabby.png'
 import { compact, isNil } from 'lodash-es'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
+import type { Context } from 'tabby-chat-panel'
 
 import {
   AssistantMessage,
-  Context,
   QuestionAnswerPair,
   UserMessage
 } from '@/lib/types/chat'
@@ -316,8 +316,10 @@ const CodeReferences = ({ contexts }: ContextReferencesProps) => {
         <AccordionContent className="space-y-2">
           {contexts?.map(item => {
             const isMultiLine =
-              !isNil(item.range?.start) && item.range.start < item.range.end
-            const pathSegments = item.filePath.split('/')
+              !isNil(item.range?.start) &&
+              !isNil(item.range?.end) &&
+              item.range.start < item.range.end
+            const pathSegments = item.filepath.split('/')
             const fileName = pathSegments[pathSegments.length - 1]
             const path = pathSegments
               .slice(0, pathSegments.length - 1)
@@ -325,7 +327,7 @@ const CodeReferences = ({ contexts }: ContextReferencesProps) => {
             return (
               <div
                 className="cursor-pointer rounded-md border p-2 hover:bg-accent"
-                key={item.filePath}
+                key={item.filepath}
                 onClick={e => onNavigateToContext?.(item)}
               >
                 <div className="flex items-center gap-1 overflow-x-auto">

--- a/ee/tabby-ui/lib/types/chat.ts
+++ b/ee/tabby-ui/lib/types/chat.ts
@@ -1,5 +1,3 @@
-import type { ChatMessage } from 'tabby-chat-panel'
-
 interface LineRange {
   start: number
   end: number

--- a/ee/tabby-ui/lib/types/chat.ts
+++ b/ee/tabby-ui/lib/types/chat.ts
@@ -1,3 +1,5 @@
+import type { ChatMessage } from 'tabby-chat-panel'
+
 interface LineRange {
   start: number
   end: number

--- a/ee/tabby-ui/lib/types/chat.ts
+++ b/ee/tabby-ui/lib/types/chat.ts
@@ -1,25 +1,7 @@
-interface LineRange {
-  start: number
-  end: number
-}
+import type { ChatMessage } from 'tabby-chat-panel'
 
-export interface FileContext {
-  kind: 'file'
-  range: LineRange
-  filePath: string
-  link: string
-  language?: string
-  // FIXME(jueliang): add code snippet here for client side mock
-  content: string
-}
-
-export type Context = FileContext
-
-export interface UserMessage {
+export interface UserMessage extends ChatMessage {
   id: string
-  message: string
-  selectContext?: Context
-  relevantContext?: Array<Context>
 }
 
 export type UserMessageWithOptionalId = Omit<UserMessage, 'id'> & {


### PR DESCRIPTION
## Screen record
https://jam.dev/c/84eb9ae8-8a7b-477f-bc38-9a44b7d2cf6d

## Notable changes
* `tabby-chat-panel`: New client-side API `navigate`. One use case for invoking `navigate` is when a user clicks on a reference link in the chat.
* `tabby-chat-panel/react`: Enhance the initialization of useServer and useClient. Prevent duplicate rendering in React development mode.
* `ee/tabby-ui/chat`: New page which embed the Chat component, it owner userServer
* `ee/tabby-ui/files/components/chat-side-bar.tsx`: Embed /chat iframe with useClient