### PR TITLE
fix(ui): activity page default range

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/activities/components/activity.tsx
+++ b/ee/tabby-ui/app/(dashboard)/activities/components/activity.tsx
@@ -93,7 +93,7 @@ export const listUserEvents = graphql(/* GraphQL */ `
 `)
 
 export default function Activity() {
-  const defaultFromDate = moment().add(parseInt(DEFAULT_DATE_RANGE, 10), 'day')
+  const defaultFromDate = moment().add(parseInt(DEFAULT_DATE_RANGE, 10), 'hour')
   const defaultToDate = moment()
 
   const [members] = useAllMembers()


### PR DESCRIPTION
#### What to fix:
In the Activities page, the `Last 24 hours` is requesting the wrong range of data.

#### Before
<img width="261" alt="before" src="https://github.com/TabbyML/tabby/assets/5305874/63736d6b-b132-42d3-8b0f-91e6a1c59cb7">

#### After
<img width="267" alt="after" src="https://github.com/TabbyML/tabby/assets/5305874/9a628abb-6c35-4ca2-a85e-8165bdddc309">
