### PR TITLE
core: fix building rocm version with modern ROCm

### DIFF
--- a/crates/llama-cpp-bindings/build.rs
+++ b/crates/llama-cpp-bindings/build.rs
@@ -85,6 +85,7 @@ fn build_llama_cpp() {
         println!("cargo:rustc-link-search=native={}/hip/lib", rocm_root);
         println!("cargo:rustc-link-search=native={}/rocblas/lib", rocm_root);
         println!("cargo:rustc-link-search=native={}/hipblas/lib", rocm_root);
+        println!("cargo:rustc-link-search=native={}/lib", rocm_root);
         println!("cargo:rustc-link-lib=amdhip64");
         println!("cargo:rustc-link-lib=rocblas");
         println!("cargo:rustc-link-lib=hipblas");


### PR DESCRIPTION
Even in currently used version (5.7.1) all lib symlinks are available in /opt/rocm-xxx/lib/.

Sin ROCm 6.0.0 there is no separate folders with dev libs for each lib.