### PR TITLE
fix(ui): allow rendering chat without auth

### DIFF
--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import { usePathname } from 'next/navigation'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { Provider as UrqlProvider } from 'urql'
@@ -32,6 +33,13 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
 }
 
 function EnsureSignin() {
+  const pathname = usePathname()
+  const excludePath = ['/chat']
+
+  if (excludePath.includes(pathname)) {
+    return <></>
+  }
+
   useAuthenticatedSession()
   return <></>
 }

--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import * as React from 'react'
-import { usePathname } from 'next/navigation'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { Provider as UrqlProvider } from 'urql'
@@ -33,13 +32,6 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
 }
 
 function EnsureSignin() {
-  const pathname = usePathname()
-  const excludePath = ['/chat']
-
-  if (excludePath.includes(pathname)) {
-    return <></>
-  }
-
   useAuthenticatedSession()
   return <></>
 }

--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import { usePathname } from 'next/navigation'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { Provider as UrqlProvider } from 'urql'
@@ -12,7 +13,11 @@ import { ShowDemoBannerProvider } from '@/components/demo-banner'
 
 import { TopbarProgressProvider } from './topbar-progress-indicator'
 
+const publicPaths = ['/chat']
+
 export function Providers({ children, ...props }: ThemeProviderProps) {
+  const pathName = usePathname()
+  const isPublicPath = publicPaths.includes(pathName)
   return (
     <NextThemesProvider {...props}>
       <UrqlProvider value={client}>
@@ -20,7 +25,7 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
           <AuthProvider>
             <TopbarProgressProvider>
               <ShowDemoBannerProvider>
-                <EnsureSignin />
+                {!isPublicPath && <EnsureSignin />}
                 {children}
               </ShowDemoBannerProvider>
             </TopbarProgressProvider>

--- a/ee/tabby-ui/lib/tabby/auth.tsx
+++ b/ee/tabby-ui/lib/tabby/auth.tsx
@@ -244,10 +244,6 @@ const redirectWhitelist = [
   '/auth/reset-password'
 ]
 
-const publicPaths = [
-  '/chat'
-]
-
 function useAuthenticatedSession() {
   const isAdminInitialized = useIsAdminInitialized()
   const router = useRouter()
@@ -256,7 +252,6 @@ function useAuthenticatedSession() {
   const { data: session, status } = useSession()
 
   React.useEffect(() => {
-    if (publicPaths.includes(pathName)) return
     if (status === 'loading') return
     if (status === 'authenticated') return
     if (isAdminInitialized === undefined) return

--- a/ee/tabby-ui/lib/tabby/auth.tsx
+++ b/ee/tabby-ui/lib/tabby/auth.tsx
@@ -244,6 +244,10 @@ const redirectWhitelist = [
   '/auth/reset-password'
 ]
 
+const publicPaths = [
+  '/chat'
+]
+
 function useAuthenticatedSession() {
   const isAdminInitialized = useIsAdminInitialized()
   const router = useRouter()
@@ -252,6 +256,7 @@ function useAuthenticatedSession() {
   const { data: session, status } = useSession()
 
   React.useEffect(() => {
+    if (publicPaths.includes(pathName)) return
     if (status === 'loading') return
     if (status === 'authenticated') return
     if (isAdminInitialized === undefined) return


### PR DESCRIPTION
### Context
When I render `/chat` in the VSCode side bar, I don't wanna jump to the login page.

### To improve
Without logging in, the chat component won't display the user's avatar (the image below). Looks we need to enhance the UI for this scenario. @liangfung 

<img width="677" alt="example" src="https://github.com/TabbyML/tabby/assets/5305874/229802f2-1254-4d5e-bace-3871651ccd9c">
