### PR TITLE
feat: fill user's name when register by oauth

### DIFF
--- a/ee/tabby-db/src/lib.rs
+++ b/ee/tabby-db/src/lib.rs
@@ -471,7 +471,7 @@ pub mod testutils {
     pub async fn create_user(conn: &DbConn) -> i64 {
         let email: &str = "test@example.com";
         let password: &str = "123456789";
-        conn.create_user(email.to_string(), Some(password.to_string()), true)
+        conn.create_user(email.to_string(), Some(password.to_string()), true, None)
             .await
             .unwrap()
     }

--- a/ee/tabby-db/src/refresh_tokens.rs
+++ b/ee/tabby-db/src/refresh_tokens.rs
@@ -111,7 +111,7 @@ mod tests {
     async fn test_create_refresh_token() {
         let conn = DbConn::new_in_memory().await.unwrap();
         let user_id = conn
-            .create_user("email@email".into(), None, true)
+            .create_user("email@email".into(), None, true, None)
             .await
             .unwrap();
         let token = conn.create_refresh_token(user_id).await.unwrap();
@@ -129,7 +129,7 @@ mod tests {
         let conn = DbConn::new_in_memory().await.unwrap();
 
         let user_id = conn
-            .create_user("email@email".into(), None, true)
+            .create_user("email@email".into(), None, true, None)
             .await
             .unwrap();
         let old = conn.create_refresh_token(user_id).await.unwrap();

--- a/ee/tabby-db/src/users.rs
+++ b/ee/tabby-db/src/users.rs
@@ -62,8 +62,14 @@ impl DbConn {
         invitation_id: i64,
         name: Option<String>,
     ) -> Result<i64> {
-        self.create_user_impl(email, password_encrypted, is_admin, Some(invitation_id), name)
-            .await
+        self.create_user_impl(
+            email,
+            password_encrypted,
+            is_admin,
+            Some(invitation_id),
+            name,
+        )
+        .await
     }
 
     async fn create_user_impl(
@@ -295,7 +301,12 @@ mod tests {
         let conn = DbConn::new_in_memory().await.unwrap();
 
         let id = conn
-            .create_user("use1@example.com".into(), Some("123456".into()), false, Some("name1".into()))
+            .create_user(
+                "use1@example.com".into(),
+                Some("123456".into()),
+                false,
+                Some("name1".into()),
+            )
             .await
             .unwrap();
         let user = conn.get_user(id).await.unwrap().unwrap();
@@ -447,7 +458,12 @@ mod tests {
         );
 
         let id1 = conn
-            .create_user("use1@example.com".into(), Some("123456".into()), false, None)
+            .create_user(
+                "use1@example.com".into(),
+                Some("123456".into()),
+                false,
+                None,
+            )
             .await
             .unwrap();
 
@@ -516,19 +532,39 @@ mod tests {
         );
 
         let id2 = conn
-            .create_user("use2@example.com".into(), Some("123456".into()), false, None)
+            .create_user(
+                "use2@example.com".into(),
+                Some("123456".into()),
+                false,
+                None,
+            )
             .await
             .unwrap();
         let id3 = conn
-            .create_user("use3@example.com".into(), Some("123456".into()), false, None)
+            .create_user(
+                "use3@example.com".into(),
+                Some("123456".into()),
+                false,
+                None,
+            )
             .await
             .unwrap();
         let id4 = conn
-            .create_user("use4@example.com".into(), Some("123456".into()), false, None)
+            .create_user(
+                "use4@example.com".into(),
+                Some("123456".into()),
+                false,
+                None,
+            )
             .await
             .unwrap();
         let id5 = conn
-            .create_user("use5@example.com".into(), Some("123456".into()), false, None)
+            .create_user(
+                "use5@example.com".into(),
+                Some("123456".into()),
+                false,
+                None,
+            )
             .await
             .unwrap();
 

--- a/ee/tabby-webserver/src/oauth/google.rs
+++ b/ee/tabby-webserver/src/oauth/google.rs
@@ -178,6 +178,10 @@ mod tests {
     #[test]
     fn test_create_authorization_url() {
         let url = create_authorization_url("client_id", "localhost").unwrap();
-        assert_eq!(url, "https://accounts.google.com/o/oauth2/v2/auth?client_id=client_id&redirect_uri=localhost&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email&access_type=offline");
+        assert_eq!(url, "https://accounts.google.com/o/oauth2/v2/auth?client_id=client_id\
+        &redirect_uri=localhost\
+        &response_type=code\
+        &scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile\
+        &access_type=offline");
     }
 }

--- a/ee/tabby-webserver/src/oauth/google.rs
+++ b/ee/tabby-webserver/src/oauth/google.rs
@@ -36,6 +36,13 @@ struct GoogleUserEmail {
     error: Option<GoogleOAuthError>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GoogleUserName {
+    #[serde(default)]
+    name: String,
+    error: Option<GoogleOAuthError>,
+}
+
 pub struct GoogleClient {
     client: reqwest::Client,
     auth: Arc<dyn AuthenticationService>,
@@ -91,7 +98,7 @@ impl GoogleClient {
 
 #[async_trait]
 impl OAuthClient for GoogleClient {
-    async fn fetch_user_email(&self, code: String) -> Result<String> {
+    async fn exchange_code_for_token(&self, code: String) -> Result<String> {
         let credential = self.read_credential().await?;
         let redirect_uri = self.auth.oauth_callback_url(OAuthProvider::Google).await?;
         let token_resp = self
@@ -101,12 +108,16 @@ impl OAuthClient for GoogleClient {
             bail!("Empty access token from Google OAuth");
         }
 
+        Ok(token_resp.access_token)
+    }
+
+    async fn fetch_user_email(&self, access_token: &str) -> Result<String> {
         let resp = self
             .client
             .get("https://www.googleapis.com/oauth2/v2/userinfo?alt=json&fields=email")
             .header(
                 reqwest::header::AUTHORIZATION,
-                format!("Bearer {}", token_resp.access_token),
+                format!("Bearer {}", access_token),
             )
             .send()
             .await?
@@ -117,6 +128,25 @@ impl OAuthClient for GoogleClient {
             bail!(err.message);
         }
         Ok(resp.email)
+    }
+
+    async fn fetch_user_full_name(&self, access_token: &str) -> Result<String> {
+        let resp = self
+            .client
+            .get("https://www.googleapis.com/oauth2/v2/userinfo?alt=json&fields=name")
+            .header(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {}", access_token),
+            )
+            .send()
+            .await?
+            .json::<GoogleUserName>()
+            .await?;
+
+        if let Some(err) = resp.error {
+            bail!(err.message);
+        }
+        Ok(resp.name)
     }
 
     async fn get_authorization_url(&self) -> Result<String> {

--- a/ee/tabby-webserver/src/oauth/google.rs
+++ b/ee/tabby-webserver/src/oauth/google.rs
@@ -162,7 +162,7 @@ fn create_authorization_url(client_id: &str, redirect_uri: &str) -> Result<Strin
         ("client_id", client_id),
         ("redirect_uri", redirect_uri),
         ("response_type", "code"),
-        ("scope", "https://www.googleapis.com/auth/userinfo.email"),
+        ("scope", "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"),
         ("access_type", "offline"),
     ];
     for (k, v) in params {

--- a/ee/tabby-webserver/src/oauth/mod.rs
+++ b/ee/tabby-webserver/src/oauth/mod.rs
@@ -14,7 +14,9 @@ use self::gitlab::GitlabClient;
 
 #[async_trait]
 pub trait OAuthClient: Send + Sync {
-    async fn fetch_user_email(&self, code: String) -> Result<String>;
+    async fn exchange_code_for_token(&self, code: String) -> Result<String>;
+    async fn fetch_user_email(&self, access_token: &str) -> Result<String>;
+    async fn fetch_user_full_name(&self, access_token: &str) -> Result<String>;
     async fn get_authorization_url(&self) -> Result<String>;
 }
 

--- a/ee/tabby-webserver/src/service/analytic.rs
+++ b/ee/tabby-webserver/src/service/analytic.rs
@@ -139,7 +139,7 @@ mod tests {
     async fn test_daily_stats_in_past_year() {
         let db = DbConn::new_in_memory().await.unwrap();
         let user_id = db
-            .create_user("test@example.com".into(), Some("pass".into()), true)
+            .create_user("test@example.com".into(), Some("pass".into()), true, None)
             .await
             .unwrap();
 
@@ -158,7 +158,7 @@ mod tests {
             .unwrap();
 
         let user_id2 = db
-            .create_user("test2@example.com".into(), Some("pass".into()), false)
+            .create_user("test2@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
 
@@ -212,7 +212,7 @@ mod tests {
     async fn test_daily_stats() {
         let db = DbConn::new_in_memory().await.unwrap();
         let user_id = db
-            .create_user("test@example.com".into(), Some("pass".into()), true)
+            .create_user("test@example.com".into(), Some("pass".into()), true, None)
             .await
             .unwrap();
 
@@ -256,7 +256,7 @@ mod tests {
         let db = DbConn::new_in_memory().await.unwrap();
 
         let user_id = db
-            .create_user("test@example.com".into(), Some("pass".into()), true)
+            .create_user("test@example.com".into(), Some("pass".into()), true, None)
             .await
             .unwrap();
 
@@ -303,7 +303,7 @@ mod tests {
         let service = new_analytic_service(db.clone());
 
         let id = db
-            .create_user("testuser".into(), None, false)
+            .create_user("testuser".into(), None, false, None)
             .await
             .unwrap();
 

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -944,7 +944,7 @@ mod tests {
             &setting,
             &service.mail,
             "test@example.com",
-            ""
+            "",
         )
         .await;
         assert_matches!(res, Err(OAuthError::UserDisabled));
@@ -984,7 +984,11 @@ mod tests {
         .await;
         assert_matches!(res, Err(OAuthError::UserNotInvited));
 
-        service.db.create_invitation("example@gmail.com".into()).await.unwrap();
+        service
+            .db
+            .create_invitation("example@gmail.com".into())
+            .await
+            .unwrap();
 
         let res = get_or_create_oauth_user(
             &license,

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -430,7 +430,8 @@ impl AuthenticationService for AuthenticationServiceImpl {
             .await
             .context("Failed to read license info")?;
         let user_id =
-            get_or_create_oauth_user(&license, &self.db, &self.setting, &self.mail, &email, &name).await?;
+            get_or_create_oauth_user(&license, &self.db, &self.setting, &self.mail, &email, &name)
+                .await?;
 
         let refresh_token = self.db.create_refresh_token(user_id).await?;
 
@@ -1362,7 +1363,12 @@ mod tests {
         let (service, _mail) = test_authentication_service_with_mail().await;
         let id = service
             .db
-            .create_user("test@example.com".into(), password_hash("pass").ok(), true, None)
+            .create_user(
+                "test@example.com".into(),
+                password_hash("pass").ok(),
+                true,
+                None,
+            )
             .await
             .unwrap();
 
@@ -1390,7 +1396,12 @@ mod tests {
 
         let id = service
             .db
-            .create_user("test@example.com".into(), password_hash("pass").ok(), true, None)
+            .create_user(
+                "test@example.com".into(),
+                password_hash("pass").ok(),
+                true,
+                None,
+            )
             .await
             .unwrap();
 

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -85,11 +85,12 @@ impl AuthenticationService for AuthenticationServiceImpl {
                     Some(pwd_hash),
                     !is_admin_initialized,
                     invitation.id,
+                    None,
                 )
                 .await?
         } else {
             self.db
-                .create_user(email.clone(), Some(pwd_hash), !is_admin_initialized)
+                .create_user(email.clone(), Some(pwd_hash), !is_admin_initialized, None)
                 .await?
         };
 
@@ -420,14 +421,16 @@ impl AuthenticationService for AuthenticationServiceImpl {
         provider: OAuthProvider,
     ) -> std::result::Result<OAuthResponse, OAuthError> {
         let client = oauth::new_oauth_client(provider, Arc::new(self.clone()));
-        let email = client.fetch_user_email(code).await?;
+        let access_token = client.exchange_code_for_token(code).await?;
+        let email = client.fetch_user_email(&access_token).await?;
+        let name = client.fetch_user_full_name(&access_token).await?;
         let license = self
             .license
             .read()
             .await
             .context("Failed to read license info")?;
         let user_id =
-            get_or_create_oauth_user(&license, &self.db, &self.setting, &self.mail, &email).await?;
+            get_or_create_oauth_user(&license, &self.db, &self.setting, &self.mail, &email, &name).await?;
 
         let refresh_token = self.db.create_refresh_token(user_id).await?;
 
@@ -517,6 +520,7 @@ async fn get_or_create_oauth_user(
     setting: &Arc<dyn SettingService>,
     mail: &Arc<dyn EmailService>,
     email: &str,
+    name: &str,
 ) -> Result<i64, OAuthError> {
     if let Some(user) = db.get_user_by_email(email).await? {
         return user
@@ -529,6 +533,8 @@ async fn get_or_create_oauth_user(
     if license.ensure_available_seats(1).is_err() {
         return Err(OAuthError::InsufficientSeats);
     }
+
+    let name = (!name.is_empty()).then_some(name.to_owned());
 
     if setting
         .read_security_setting()
@@ -543,7 +549,8 @@ async fn get_or_create_oauth_user(
         // 1. both `register` & `token_auth` mutation will do input validation, so empty password won't be accepted
         // 2. `password_verify` will always return false for empty password hash read from user table
         // so user created here is only able to login by github oauth, normal login won't work
-        let res = db.create_user(email.to_owned(), None, false).await?;
+
+        let res = db.create_user(email.to_owned(), None, false, name).await?;
         if let Err(e) = mail.send_signup(email.to_string()).await {
             warn!("Failed to send signup email: {e}");
         }
@@ -554,7 +561,7 @@ async fn get_or_create_oauth_user(
         };
         // safe to create with empty password for same reasons above
         let id = db
-            .create_user_with_invitation(email.to_owned(), None, false, invitation.id)
+            .create_user_with_invitation(email.to_owned(), None, false, invitation.id, name)
             .await?;
         let user = db.get_user(id).await?.unwrap();
         Ok(user.id)
@@ -924,7 +931,7 @@ mod tests {
         let license = service.license.read().await.unwrap();
         let id = service
             .db
-            .create_user("test@example.com".into(), None, false)
+            .create_user("test@example.com".into(), None, false, None)
             .await
             .unwrap();
         service.db.update_user_active(id, false).await.unwrap();
@@ -935,7 +942,8 @@ mod tests {
             &service.db,
             &setting,
             &service.mail,
-            "test@example.com"
+            "test@example.com",
+            ""
         )
         .await
         .is_err());
@@ -951,7 +959,8 @@ mod tests {
             &service.db,
             &setting,
             &service.mail,
-            "example@example.com"
+            "example@example.com",
+            "",
         )
         .await
         .is_ok());
@@ -965,7 +974,8 @@ mod tests {
             &service.db,
             &setting,
             &service.mail,
-            "example@gmail.com"
+            "example@gmail.com",
+            "",
         )
         .await
         .is_err());
@@ -996,13 +1006,13 @@ mod tests {
         let service = test_authentication_service().await;
         let _ = service
             .db
-            .create_user("admin@example.com".into(), None, true)
+            .create_user("admin@example.com".into(), None, true, None)
             .await
             .unwrap();
 
         let user_id = service
             .db
-            .create_user("user@example.com".into(), None, false)
+            .create_user("user@example.com".into(), None, false, None)
             .await
             .unwrap();
 
@@ -1027,7 +1037,7 @@ mod tests {
         let service = test_authentication_service().await;
         let admin_id = service
             .db
-            .create_user("admin@example.com".into(), None, true)
+            .create_user("admin@example.com".into(), None, true, None)
             .await
             .unwrap();
 
@@ -1050,7 +1060,7 @@ mod tests {
         // Test first reset, ensure wrong code fails
         service
             .db
-            .create_user("user@example.com".into(), Some("pass".into()), true)
+            .create_user("user@example.com".into(), Some("pass".into()), true, None)
             .await
             .unwrap();
         let user = service.get_user_by_email("user@example.com").await.unwrap();
@@ -1109,7 +1119,7 @@ mod tests {
         // Test third reset, ensure inactive users cannot reset their password
         let user_id_2 = service
             .db
-            .create_user("user2@example.com".into(), Some("pass".into()), false)
+            .create_user("user2@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
 
@@ -1141,17 +1151,17 @@ mod tests {
         let service = test_authentication_service().await;
         service
             .db
-            .create_user("a@example.com".into(), Some("pass".into()), false)
+            .create_user("a@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
         service
             .db
-            .create_user("b@example.com".into(), Some("pass".into()), false)
+            .create_user("b@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
         service
             .db
-            .create_user("c@example.com".into(), Some("pass".into()), false)
+            .create_user("c@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
 
@@ -1274,17 +1284,17 @@ mod tests {
 
         let user1 = service
             .db
-            .create_user("b@example.com".into(), Some("pass".into()), false)
+            .create_user("b@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
         let user2 = service
             .db
-            .create_user("c@example.com".into(), Some("pass".into()), false)
+            .create_user("c@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
         let user3 = service
             .db
-            .create_user("d@example.com".into(), Some("pass".into()), false)
+            .create_user("d@example.com".into(), Some("pass".into()), false, None)
             .await
             .unwrap();
 
@@ -1325,7 +1335,7 @@ mod tests {
         let service = test_authentication_service().await;
         let id = service
             .db
-            .create_user("test@example.com".into(), None, true)
+            .create_user("test@example.com".into(), None, true, None)
             .await
             .unwrap();
 
@@ -1352,7 +1362,7 @@ mod tests {
         let (service, _mail) = test_authentication_service_with_mail().await;
         let id = service
             .db
-            .create_user("test@example.com".into(), password_hash("pass").ok(), true)
+            .create_user("test@example.com".into(), password_hash("pass").ok(), true, None)
             .await
             .unwrap();
 
@@ -1380,7 +1390,7 @@ mod tests {
 
         let id = service
             .db
-            .create_user("test@example.com".into(), password_hash("pass").ok(), true)
+            .create_user("test@example.com".into(), password_hash("pass").ok(), true, None)
             .await
             .unwrap();
 

--- a/ee/tabby-webserver/src/service/event_logger.rs
+++ b/ee/tabby-webserver/src/service/event_logger.rs
@@ -151,7 +151,7 @@ mod tests {
         let db = DbConn::new_in_memory().await.unwrap();
         let logger = create_event_logger(db.clone());
         let user_id = db
-            .create_user("testuser".into(), Some("pass".into()), true)
+            .create_user("testuser".into(), Some("pass".into()), true, None)
             .await
             .unwrap();
 

--- a/ee/tabby-webserver/src/service/user_event.rs
+++ b/ee/tabby-webserver/src/service/user_event.rs
@@ -76,7 +76,7 @@ mod tests {
     async fn test_list_user_events() {
         let db = DbConn::new_in_memory().await.unwrap();
         let user1 = db
-            .create_user("test@example.com".into(), Some("pass".into()), true)
+            .create_user("test@example.com".into(), Some("pass".into()), true, None)
             .await
             .unwrap();
 
@@ -85,7 +85,7 @@ mod tests {
             .unwrap();
 
         let user2 = db
-            .create_user("test2@example.com".into(), Some("pass".into()), true)
+            .create_user("test2@example.com".into(), Some("pass".into()), true, None)
             .await
             .unwrap();
 


### PR DESCRIPTION
Follow up of https://github.com/TabbyML/tabby/pull/2100#pullrequestreview-2053445842

~~This PR is almost done, so I want to raise it for review, to make sure I'm on the correct direction.~~

The core changes in this PR resides in following places

- Add extra `name: Option<String>,` parameters for `create_user` & `create_user_with_invitation` methods inside of `tabby-db` crate
  - A lot of unit tests depend on this 2 methods, so update all of them accordingly.
- Extract token exchange logic from `fetch_user_email` method, added new `fetch_user_full_name` method, pass in access token to fetch user email & user name
- Update google oauth scope to request user's profile info
- Update gitlab integration
- Improve unit test for `get_or_create_oauth_user`

Tested registration by invitation branch locally that user's name info can be fetched and inserted into db for both `google` & `github` provider.

Kindly help review, thanks.