### PR TITLE
fix(docker): correct dockerfiles to fix build

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -39,7 +39,7 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/root/workspace/target \
     cargo build --no-default-features --features cuda,prod --release --package tabby && \
-    cp target/release/llama-server /opt/tabby/bin/ \
+    cp target/release/llama-server /opt/tabby/bin/ && \
     cp target/release/tabby /opt/tabby/bin/
 
 # For compatibility with the legacy cpu build.

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp target/release/tabby /opt/tabby/bin/
 
 # For compatibility with the legacy cpu build.
-RUN cp target/release/tabby /opt/tabby/bin/tabby-cpu
+RUN cp /opt/tabby/bin/tabby /opt/tabby/bin/tabby-cpu
 
 FROM ${BASE_CUDA_RUN_CONTAINER} as runtime
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -39,7 +39,7 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/root/workspace/target \
     cargo build --no-default-features --features rocm,prod --release --package tabby && \
-    cp target/release/llama-server /opt/tabby/bin/ \
+    cp target/release/llama-server /opt/tabby/bin/ && \
     cp target/release/tabby /opt/tabby/bin/
 
 # For compatibility with the legacy cpu build.

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp target/release/tabby /opt/tabby/bin/
 
 # For compatibility with the legacy cpu build.
-RUN cp target/release/tabby /opt/tabby/bin/tabby-cpu
+RUN cp /opt/tabby/bin/tabby /opt/tabby/bin/tabby-cpu
 
 FROM ${BASE_ROCM_RUN_CONTAINER} AS runtime
 


### PR DESCRIPTION
There was missing `&&` so `cp` commands always fails and `tabby-cpu` was copied from unmounted cache so it fails too