### PR TITLE
fix(ui): fix the duration display on the job list

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-row.tsx
+++ b/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-row.tsx
@@ -106,6 +106,7 @@ export default function JobRow({ name }: { name: string }) {
   const lastSuccessAt = lastFinishedJob
     ? moment(lastFinishedJob.node.finishedAt).format('YYYY-MM-DD HH:mm')
     : null
+
   return (
     <LoadingWrapper
       loading={fetching}
@@ -144,7 +145,7 @@ export default function JobRow({ name }: { name: string }) {
                       .asMilliseconds(),
                     {
                       units: ['d', 'h', 'm', 's'],
-                      round: true,
+                      round: false,
                       largest: 1,
                       spacer: '',
                       language: 'shortEn'


### PR DESCRIPTION
#### Testing
finish 0s ago => 0s
finish 50s ago => 50s

finish 1m ago => 2m 
**^This seems odd; another approach could be directly using the humanizerDuration output, 1m=>1m; 1m10s=>1m; 
1m30s=>2m**

finish 1m1s ago => 2m
finish 2h40m ago => 3h