### PR TITLE
feat: Added ollama api connection options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,6 +2110,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "futures",
+ "ollama-api-bindings",
  "reqwest 0.12.4",
  "reqwest-eventsource",
  "serde",
@@ -3333,6 +3334,33 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "url",
+]
+
+[[package]]
+name = "ollama-api-bindings"
+version = "0.12.0-dev.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "futures",
+ "ollama-rs",
+ "tabby-common",
+ "tabby-inference",
+ "tracing",
+]
+
+[[package]]
+name = "ollama-rs"
+version = "0.1.9"
+source = "git+https://github.com/pepperoni21/ollama-rs.git?rev=56e8157d98d4185bc171fe9468d3d09bc56e9dd3#56e8157d98d4185bc171fe9468d3d09bc56e9dd3"
+dependencies = [
+ "reqwest 0.12.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
  "url",
 ]
 
@@ -5989,9 +6017,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/aim-downloader",
     "crates/http-api-bindings",
     "crates/llama-cpp-server",
+    "crates/ollama-api-bindings",
 
     "ee/tabby-webserver",
     "ee/tabby-db",

--- a/crates/http-api-bindings/Cargo.toml
+++ b/crates/http-api-bindings/Cargo.toml
@@ -17,7 +17,8 @@ serde.workspace = true
 serde_json = { workspace = true }
 tabby-common = { path = "../tabby-common" }
 tabby-inference = { path = "../tabby-inference" }
+ollama-api-bindings = { path = "../ollama-api-bindings" }
 tracing.workspace = true
 
 [dev-dependencies]
-tokio ={ workspace = true, features = ["rt", "macros"]}
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -6,15 +6,15 @@ use openai_chat::OpenAIChatEngine;
 use tabby_common::config::HttpModelConfig;
 use tabby_inference::ChatCompletionStream;
 
-pub fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
-    if model.kind == "openai-chat" {
-        let engine = OpenAIChatEngine::create(
+pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
+    match model.kind.as_str() {
+        "openai-chat" => Arc::new(OpenAIChatEngine::create(
             &model.api_endpoint,
             model.model_name.as_deref().unwrap_or_default(),
             model.api_key.clone(),
-        );
-        Arc::new(engine)
-    } else {
-        panic!("Only openai-chat are supported for http chat");
+        )),
+        "ollama" => ollama_api_bindings::create_chat(model).await,
+
+        unsupported_kind => panic!("Unsupported kind for http chat: {}", unsupported_kind),
     }
 }

--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -13,7 +13,7 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
             model.model_name.as_deref().unwrap_or_default(),
             model.api_key.clone(),
         )),
-        "ollama" => ollama_api_bindings::create_chat(model).await,
+        "ollama/chat" => ollama_api_bindings::create_chat(model).await,
 
         unsupported_kind => panic!("Unsupported kind for http chat: {}", unsupported_kind),
     }

--- a/crates/http-api-bindings/src/completion/mod.rs
+++ b/crates/http-api-bindings/src/completion/mod.rs
@@ -6,11 +6,17 @@ use llama::LlamaCppEngine;
 use tabby_common::config::HttpModelConfig;
 use tabby_inference::CompletionStream;
 
-pub fn create(model: &HttpModelConfig) -> Arc<dyn CompletionStream> {
-    if model.kind == "llama.cpp/completion" {
-        let engine = LlamaCppEngine::create(&model.api_endpoint, model.api_key.clone());
-        Arc::new(engine)
-    } else {
-        panic!("Unsupported model kind: {}", model.kind);
+pub async fn create(model: &HttpModelConfig) -> Arc<dyn CompletionStream> {
+    match model.kind.as_str() {
+        "llama.cpp/completion" => {
+            let engine = LlamaCppEngine::create(&model.api_endpoint, model.api_key.clone());
+            Arc::new(engine)
+        }
+        "ollama" => ollama_api_bindings::create_completion(model).await,
+
+        unsupported_kind => panic!(
+            "Unsupported model kind for http completion: {}",
+            unsupported_kind
+        ),
     }
 }

--- a/crates/http-api-bindings/src/completion/mod.rs
+++ b/crates/http-api-bindings/src/completion/mod.rs
@@ -12,7 +12,7 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn CompletionStream> {
             let engine = LlamaCppEngine::create(&model.api_endpoint, model.api_key.clone());
             Arc::new(engine)
         }
-        "ollama" => ollama_api_bindings::create_completion(model).await,
+        "ollama/completion" => ollama_api_bindings::create_completion(model).await,
 
         unsupported_kind => panic!(
             "Unsupported model kind for http completion: {}",

--- a/crates/http-api-bindings/src/embedding/mod.rs
+++ b/crates/http-api-bindings/src/embedding/mod.rs
@@ -24,7 +24,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
             );
             Arc::new(engine)
         }
-        "ollama" => ollama_api_bindings::create_embedding(config).await,
+        "ollama/embedding" => ollama_api_bindings::create_embedding(config).await,
 
         unsupported_kind => panic!(
             "Unsupported kind for http embedding model: {}",

--- a/crates/llama-cpp-server/src/lib.rs
+++ b/crates/llama-cpp-server/src/lib.rs
@@ -35,7 +35,7 @@ impl EmbeddingServer {
 
         Self {
             server,
-            embedding: http_api_bindings::create_embedding(&config),
+            embedding: http_api_bindings::create_embedding(&config).await,
         }
     }
 }
@@ -61,7 +61,7 @@ impl CompletionServer {
             .kind("llama.cpp/completion".to_string())
             .build()
             .expect("Failed to create HttpModelConfig");
-        let completion = http_api_bindings::create(&config);
+        let completion = http_api_bindings::create(&config).await;
         Self { server, completion }
     }
 }
@@ -83,7 +83,7 @@ pub async fn create_completion(
 
 pub async fn create_embedding(config: &ModelConfig) -> Arc<dyn Embedding> {
     match config {
-        ModelConfig::Http(http) => http_api_bindings::create_embedding(http),
+        ModelConfig::Http(http) => http_api_bindings::create_embedding(http).await,
         ModelConfig::Local(llama) => {
             if fs::metadata(&llama.model_id).is_ok() {
                 let path = PathBuf::from(&llama.model_id);

--- a/crates/ollama-api-bindings/Cargo.toml
+++ b/crates/ollama-api-bindings/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ollama-api-bindings"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tabby-common = { path = "../tabby-common" }
+tabby-inference = { path = "../tabby-inference" }
+
+anyhow.workspace = true
+async-stream.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+tracing.workspace = true
+
+# Use git version for now: https://github.com/pepperoni21/ollama-rs/issues/44 is required to correct work with normal URLs
+[dependencies.ollama-rs]
+git = "https://github.com/pepperoni21/ollama-rs.git"
+rev = "56e8157d98d4185bc171fe9468d3d09bc56e9dd3"
+features = ["stream"]

--- a/crates/ollama-api-bindings/src/chat.rs
+++ b/crates/ollama-api-bindings/src/chat.rs
@@ -89,7 +89,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
         .expect("Failed to create connection to Ollama, URL invalid");
 
     let model = connection
-        .select_model_or_default(config.model_name.to_owned(), true)
+        .select_model_or_default(config.model_name.to_owned())
         .await
         .unwrap();
 

--- a/crates/ollama-api-bindings/src/chat.rs
+++ b/crates/ollama-api-bindings/src/chat.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+
+use ollama_rs::generation::chat::request::ChatMessageRequest;
+use ollama_rs::generation::chat::{ChatMessage, MessageRole};
+use ollama_rs::generation::options::GenerationOptions;
+use ollama_rs::Ollama;
+
+use tabby_common::api::chat::Message;
+use tabby_common::config::HttpModelConfig;
+use tabby_inference::{ChatCompletionOptions, ChatCompletionStream};
+
+use crate::model::OllamaModelExt;
+
+/// A special adapter to convert Tabby messages to ollama-rs messages
+struct ChatMessageAdapter(ChatMessage);
+
+impl TryFrom<Message> for ChatMessageAdapter {
+    type Error = anyhow::Error;
+    fn try_from(value: Message) -> Result<ChatMessageAdapter> {
+        let role = match value.role.as_str() {
+            "system" => MessageRole::System,
+            "assistant" => MessageRole::Assistant,
+            "user" => MessageRole::User,
+            other => bail!("Unsupported chat message role: {other}"),
+        };
+
+        Ok(ChatMessageAdapter(ChatMessage::new(role, value.content)))
+    }
+}
+
+impl From<ChatMessageAdapter> for ChatMessage {
+    fn from(val: ChatMessageAdapter) -> Self {
+        val.0
+    }
+}
+
+/// Ollama chat completions
+pub struct OllamaChat {
+    /// Connection to Ollama API
+    connection: Ollama,
+    /// Model name, <model>
+    model: String,
+}
+
+#[async_trait]
+impl ChatCompletionStream for OllamaChat {
+    async fn chat_completion(
+        &self,
+        messages: &[Message],
+        options: ChatCompletionOptions,
+    ) -> Result<BoxStream<String>> {
+        let messages = messages
+            .iter()
+            .map(|m| ChatMessageAdapter::try_from(m.to_owned()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let messages = messages.into_iter().map(|m| m.into()).collect::<Vec<_>>();
+
+        let options = GenerationOptions::default()
+            .seed(options.seed as i32)
+            .temperature(options.sampling_temperature)
+            .num_predict(options.max_decoding_tokens);
+
+        let request = ChatMessageRequest::new(self.model.to_owned(), messages).options(options);
+
+        let stream = self.connection.send_chat_messages_stream(request).await?;
+
+        let stream = stream
+            .map(|x| match x {
+                Ok(response) => response.message,
+                Err(_) => None,
+            })
+            .map(|x| match x {
+                Some(e) => e.content,
+                None => "".to_owned(),
+            });
+
+        Ok(stream.boxed())
+    }
+}
+
+pub async fn create(config: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
+    let connection = Ollama::try_new(config.api_endpoint.to_owned())
+        .expect("Failed to create connection to Ollama, URL invalid");
+
+    let model = connection
+        .select_model_or_default(config.model_name.to_owned(), true)
+        .await
+        .unwrap();
+
+    Arc::new(OllamaChat { connection, model })
+}

--- a/crates/ollama-api-bindings/src/chat.rs
+++ b/crates/ollama-api-bindings/src/chat.rs
@@ -2,16 +2,15 @@ use std::sync::Arc;
 
 use anyhow::{bail, Result};
 use async_trait::async_trait;
-use futures::stream::BoxStream;
-use futures::StreamExt;
-
-use ollama_rs::generation::chat::request::ChatMessageRequest;
-use ollama_rs::generation::chat::{ChatMessage, MessageRole};
-use ollama_rs::generation::options::GenerationOptions;
-use ollama_rs::Ollama;
-
-use tabby_common::api::chat::Message;
-use tabby_common::config::HttpModelConfig;
+use futures::{stream::BoxStream, StreamExt};
+use ollama_rs::{
+    generation::{
+        chat::{request::ChatMessageRequest, ChatMessage, MessageRole},
+        options::GenerationOptions,
+    },
+    Ollama,
+};
+use tabby_common::{api::chat::Message, config::HttpModelConfig};
 use tabby_inference::{ChatCompletionOptions, ChatCompletionStream};
 
 use crate::model::OllamaModelExt;

--- a/crates/ollama-api-bindings/src/chat.rs
+++ b/crates/ollama-api-bindings/src/chat.rs
@@ -88,10 +88,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
     let connection = Ollama::try_new(config.api_endpoint.to_owned())
         .expect("Failed to create connection to Ollama, URL invalid");
 
-    let model = connection
-        .select_model_or_default(config.model_name.to_owned())
-        .await
-        .unwrap();
+    let model = connection.select_model_or_default(config).await.unwrap();
 
     Arc::new(OllamaChat { connection, model })
 }

--- a/crates/ollama-api-bindings/src/completion.rs
+++ b/crates/ollama-api-bindings/src/completion.rs
@@ -3,14 +3,13 @@ use std::sync::Arc;
 use async_stream::stream;
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt};
-use tracing::error;
-
-use ollama_rs::generation::completion::request::GenerationRequest;
-use ollama_rs::generation::options::GenerationOptions;
-use ollama_rs::Ollama;
-
+use ollama_rs::{
+    generation::{completion::request::GenerationRequest, options::GenerationOptions},
+    Ollama,
+};
 use tabby_common::config::HttpModelConfig;
 use tabby_inference::{CompletionOptions, CompletionStream};
+use tracing::error;
 
 use crate::model::OllamaModelExt;
 

--- a/crates/ollama-api-bindings/src/completion.rs
+++ b/crates/ollama-api-bindings/src/completion.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use async_stream::stream;
+use async_trait::async_trait;
+use futures::{stream::BoxStream, StreamExt};
+
+use ollama_rs::{
+    generation::{completion::request::GenerationRequest, options::GenerationOptions},
+    Ollama,
+};
+
+use tabby_common::config::HttpModelConfig;
+use tabby_inference::{CompletionOptions, CompletionStream};
+
+use crate::model::OllamaModelExt;
+
+pub struct OllamaCompletion {
+    /// Connection to Ollama API
+    connection: Ollama,
+    /// Model name, <model>
+    model: String,
+}
+
+#[async_trait]
+impl CompletionStream for OllamaCompletion {
+    async fn generate(&self, prompt: &str, options: CompletionOptions) -> BoxStream<String> {
+        let ollama_options = GenerationOptions::default()
+            .num_ctx(options.max_input_length as u32)
+            .num_predict(options.max_decoding_tokens)
+            .seed(options.seed as i32)
+            .temperature(options.sampling_temperature);
+        let request = GenerationRequest::new(self.model.to_owned(), prompt.to_owned())
+            .template("{{ .Prompt }}".to_string())
+            .options(ollama_options);
+
+        // Why this function returns not Result?
+        let stream = self.connection.generate_stream(request).await.unwrap();
+
+        let tabby_stream = stream! {
+
+            for await response in stream {
+                let parts = response.unwrap();
+                for part in parts {
+                    yield part.response
+                }
+            }
+
+        };
+
+        tabby_stream.boxed()
+    }
+}
+
+pub async fn create(config: &HttpModelConfig) -> Arc<dyn CompletionStream> {
+    let connection = Ollama::try_new(config.api_endpoint.to_owned())
+        .expect("Failed to create connection to Ollama, URL invalid");
+
+    let model = connection
+        .select_model_or_default(config.model_name.to_owned(), true)
+        .await
+        .unwrap();
+
+    Arc::new(OllamaCompletion { connection, model })
+}

--- a/crates/ollama-api-bindings/src/completion.rs
+++ b/crates/ollama-api-bindings/src/completion.rs
@@ -62,7 +62,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn CompletionStream> {
         .expect("Failed to create connection to Ollama, URL invalid");
 
     let model = connection
-        .select_model_or_default(config.model_name.to_owned(), true)
+        .select_model_or_default(config.model_name.to_owned())
         .await
         .unwrap();
 

--- a/crates/ollama-api-bindings/src/completion.rs
+++ b/crates/ollama-api-bindings/src/completion.rs
@@ -61,10 +61,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn CompletionStream> {
     let connection = Ollama::try_new(config.api_endpoint.to_owned())
         .expect("Failed to create connection to Ollama, URL invalid");
 
-    let model = connection
-        .select_model_or_default(config.model_name.to_owned())
-        .await
-        .unwrap();
+    let model = connection.select_model_or_default(config).await.unwrap();
 
     Arc::new(OllamaCompletion { connection, model })
 }

--- a/crates/ollama-api-bindings/src/embedding.rs
+++ b/crates/ollama-api-bindings/src/embedding.rs
@@ -32,10 +32,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
     let connection = Ollama::try_new(config.api_endpoint.to_owned())
         .expect("Failed to create connection to Ollama, URL invalid");
 
-    let model = connection
-        .select_model_or_default(config.model_name.to_owned())
-        .await
-        .unwrap();
+    let model = connection.select_model_or_default(config).await.unwrap();
 
     Arc::new(OllamaCompletion { connection, model })
 }

--- a/crates/ollama-api-bindings/src/embedding.rs
+++ b/crates/ollama-api-bindings/src/embedding.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use ollama_rs::Ollama;
+
+use tabby_common::config::HttpModelConfig;
+use tabby_inference::Embedding;
+
+use crate::model::OllamaModelExt;
+
+pub struct OllamaCompletion {
+    /// Connection to Ollama API
+    connection: Ollama,
+    /// Model name, <model>
+    model: String,
+}
+
+#[async_trait]
+impl Embedding for OllamaCompletion {
+    async fn embed(&self, prompt: &str) -> anyhow::Result<Vec<f32>> {
+        self.connection
+            .generate_embeddings(self.model.to_owned(), prompt.to_owned(), None)
+            .await
+            .map(|x| x.embeddings)
+            .map(|e| e.iter().map(|v| *v as f32).collect())
+            .map_err(|err| err.into())
+    }
+}
+
+pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
+    let connection = Ollama::try_new(config.api_endpoint.to_owned())
+        .expect("Failed to create connection to Ollama, URL invalid");
+
+    let model = connection
+        .select_model_or_default(config.model_name.to_owned(), true)
+        .await
+        .unwrap();
+
+    Arc::new(OllamaCompletion { connection, model })
+}

--- a/crates/ollama-api-bindings/src/embedding.rs
+++ b/crates/ollama-api-bindings/src/embedding.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
 use ollama_rs::Ollama;
-
 use tabby_common::config::HttpModelConfig;
 use tabby_inference::Embedding;
 

--- a/crates/ollama-api-bindings/src/embedding.rs
+++ b/crates/ollama-api-bindings/src/embedding.rs
@@ -33,7 +33,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
         .expect("Failed to create connection to Ollama, URL invalid");
 
     let model = connection
-        .select_model_or_default(config.model_name.to_owned(), true)
+        .select_model_or_default(config.model_name.to_owned())
         .await
         .unwrap();
 

--- a/crates/ollama-api-bindings/src/lib.rs
+++ b/crates/ollama-api-bindings/src/lib.rs
@@ -1,0 +1,10 @@
+mod model;
+
+mod chat;
+pub use chat::create as create_chat;
+
+mod completion;
+pub use completion::create as create_completion;
+
+mod embedding;
+pub use embedding::create as create_embedding;

--- a/crates/ollama-api-bindings/src/model.rs
+++ b/crates/ollama-api-bindings/src/model.rs
@@ -1,0 +1,117 @@
+//!
+//! Ollama model management utils
+//!
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+use ollama_rs::Ollama;
+use tracing::{info, warn};
+
+#[async_trait]
+pub trait OllamaModelExt {
+    /// Check if a model is available in remote Ollama instance
+    async fn model_available(&self, name: impl AsRef<str> + Send) -> Result<bool>;
+
+    /// Get the first available model in remote Ollama instance
+    async fn get_first_available_model(&self) -> Result<Option<String>>;
+
+    /// For input model specification:
+    /// - If model is specified, check if it is available in remote Ollama instance and returns its name
+    /// - If model is not specified, get the first available model in remote Ollama instance and returns its name
+    /// - If no model is available, returns error
+    /// - If model is specified and not available, returns error if `allow_pull=false` and tries to pull it otherwise
+    ///
+    /// # Parameters
+    /// - `model`: model name
+    /// - `allow_pull`: if true, try to pull the model if it is not available
+    ///
+    /// # Returns
+    /// - model name to use
+    async fn select_model_or_default(
+        &self,
+        model: Option<String>,
+        allow_pull: bool,
+    ) -> Result<String>;
+
+    /// Pull model and puts progress in tracing
+    async fn pull_model_with_tracing(&self, model: &str) -> Result<()>;
+}
+
+#[async_trait]
+impl OllamaModelExt for Ollama {
+    async fn model_available(&self, name: impl AsRef<str> + Send) -> Result<bool> {
+        let name = name.as_ref();
+
+        let models_available = self.list_local_models().await?;
+
+        Ok(models_available.into_iter().any(|model| model.name == name))
+    }
+
+    async fn get_first_available_model(&self) -> Result<Option<String>> {
+        let models_available = self.list_local_models().await?;
+
+        Ok(models_available.first().map(|x| x.name.to_owned()))
+    }
+
+    async fn select_model_or_default(
+        &self,
+        model: Option<String>,
+        allow_pull: bool,
+    ) -> Result<String> {
+        let model = match model {
+            Some(ref model) => model.to_owned(),
+            None => {
+                let model = self
+                    .get_first_available_model()
+                    .await?
+                    .ok_or(anyhow!("Ollama instances does not have any models"))?;
+
+                warn!("No model name provided, using first available: {}", model);
+                model
+            }
+        };
+
+        let available = self.model_available(&model).await?;
+
+        match (available, allow_pull) {
+            (true, _) => Ok(model),
+            (false, true) => {
+                info!("Model not available, pulling it");
+                self.pull_model_with_tracing(model.as_str()).await?;
+                Ok(model)
+            }
+            (false, false) => {
+                bail!("Model not available, and pulling is disabled")
+            }
+        }
+    }
+
+    async fn pull_model_with_tracing(&self, model: &str) -> Result<()> {
+        let mut stream = self.pull_model_stream(model.to_owned(), false).await?;
+
+        let mut last_status = "".to_string();
+        let mut last_progress = 0.0;
+
+        while let Some(result) = stream.next().await {
+            let response = result?;
+            let status = response.message;
+            if last_status != status {
+                info!("Status: {}", status);
+                last_status = status;
+                last_progress = 0.0;
+            }
+
+            // Show progress only if 1% gain happened
+            if let (Some(completed), Some(total)) = (response.completed, response.total) {
+                let progress = completed as f64 / total as f64;
+                if progress - last_progress > 0.01 {
+                    info!("Progress: {:.2}%", progress * 100.0);
+                    last_progress = progress;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/tabby/src/services/model/mod.rs
+++ b/crates/tabby/src/services/model/mod.rs
@@ -15,7 +15,7 @@ use crate::fatal;
 
 pub async fn load_chat_completion(chat: &ModelConfig) -> Arc<dyn ChatCompletionStream> {
     match chat {
-        ModelConfig::Http(http) => http_api_bindings::create_chat(http),
+        ModelConfig::Http(http) => http_api_bindings::create_chat(http).await,
 
         ModelConfig::Local(_) => {
             let (engine, PromptInfo { chat_template, .. }) = load_completion(chat).await;
@@ -41,7 +41,7 @@ pub async fn load_code_generation(model: &ModelConfig) -> (Arc<CodeGeneration>, 
 async fn load_completion(model: &ModelConfig) -> (Arc<dyn CompletionStream>, PromptInfo) {
     match model {
         ModelConfig::Http(http) => {
-            let engine = http_api_bindings::create(http);
+            let engine = http_api_bindings::create(http).await;
             (
                 engine,
                 PromptInfo {


### PR DESCRIPTION
# Brief
A full-featured completion, chat, embedding ollama api binding. Currently, tries to pull model automatically on Ollama side if cannot find it.

### TODO
- [x] ~~Completion looks bad with repository context~~ (Model was too small for handing additional context)
- [ ] Embedding, I don't know how to test it
- [x] Avoid panic in CompletionStream::generate impl for OllamaCompletion
- [x] Output model pulling status with println or add "ollama-http-bindings=info" to log sources. Leaving as is. If anyone want to get some status when downloading or just troubleshoot a ollama binding. Add to RUST_LOG env `ollama-http-bindings=info`

---
Closes #2176 
