### PR TITLE
fix(chat-panel): react rendering

### DIFF
--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -44,7 +44,7 @@ export function createClient(target: HTMLIFrameElement, api: ClientApi, signal?:
     expose: {
       navigate: api.navigate,
     },
-    signal
+    signal,
   })
 }
 
@@ -54,6 +54,6 @@ export function createServer(api: ServerApi, signal?: AbortSignal): ClientApi {
       init: api.init,
       sendMessage: api.sendMessage,
     },
-    signal
+    signal,
   })
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -39,21 +39,19 @@ export interface ChatMessage {
   relevantContext?: Array<Context>
 }
 
-export function createClient(target: HTMLIFrameElement, api: ClientApi, signal?: AbortSignal): ServerApi {
+export function createClient(target: HTMLIFrameElement, api: ClientApi): ServerApi {
   return createThreadFromIframe(target, {
     expose: {
       navigate: api.navigate,
-    },
-    signal,
+    }
   })
 }
 
-export function createServer(api: ServerApi, signal?: AbortSignal): ClientApi {
+export function createServer(api: ServerApi): ClientApi {
   return createThreadFromInsideIframe({
     expose: {
       init: api.init,
       sendMessage: api.sendMessage,
-    },
-    signal,
+    }
   })
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -43,7 +43,7 @@ export function createClient(target: HTMLIFrameElement, api: ClientApi): ServerA
   return createThreadFromIframe(target, {
     expose: {
       navigate: api.navigate,
-    }
+    },
   })
 }
 
@@ -52,6 +52,6 @@ export function createServer(api: ServerApi): ClientApi {
     expose: {
       init: api.init,
       sendMessage: api.sendMessage,
-    }
+    },
   })
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -39,19 +39,21 @@ export interface ChatMessage {
   relevantContext?: Array<Context>
 }
 
-export function createClient(target: HTMLIFrameElement, api: ClientApi): ServerApi {
+export function createClient(target: HTMLIFrameElement, api: ClientApi, signal?: AbortSignal): ServerApi {
   return createThreadFromIframe(target, {
     expose: {
       navigate: api.navigate,
     },
+    signal
   })
 }
 
-export function createServer(api: ServerApi): ClientApi {
+export function createServer(api: ServerApi, signal?: AbortSignal): ClientApi {
   return createThreadFromInsideIframe({
     expose: {
       init: api.init,
       sendMessage: api.sendMessage,
     },
+    signal
   })
 }

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -1,32 +1,36 @@
 import type { RefObject } from 'react'
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 
 import type { ClientApi, ServerApi } from './index'
 import { createClient, createServer } from './index'
 
 function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
-  const clientRef = useRef<ServerApi | null>(null)
+  const [client, setClient] = useState<ServerApi | null>(null)
+  let isCreated = false
 
   useEffect(() => {
-    if (iframeRef.current && !clientRef.current) {
-      clientRef.current = createClient(iframeRef.current, api)
+    if (iframeRef.current && !isCreated) {
+      isCreated = true
+      setClient(createClient(iframeRef.current, api))
     }
   }, [iframeRef.current])
 
-  return clientRef.current
+  return client
 }
 
 function useServer(api: ServerApi) {
-  const serverRef = useRef<ClientApi | null>(null)
+  const [server, setServer] = useState<ClientApi | null>(null)
+  let isCreated = false
 
   useEffect(() => {
     const isInIframe = window.self !== window.top
-    if (isInIframe && !serverRef.current) {
-      serverRef.current = createServer(api)
+    if (isInIframe && !isCreated) {
+      isCreated = true
+      setServer(createServer(api))
     }
   }, [])
 
-  return serverRef.current
+  return server
 }
 
 export {

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -10,7 +10,6 @@ function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
 
   useEffect(() => {
     if (iframeRef.current) {
-      console.log('client abortController', abortController)
       abortController?.abort()
       setClient(createClient(iframeRef.current, api, abortController?.signal))
       abortController = new AbortController()
@@ -27,7 +26,6 @@ function useServer(api: ServerApi) {
   useEffect(() => {
     const isInIframe = window.self !== window.top
     if (isInIframe) {
-      console.log('server abortController', abortController)
       abortController?.abort()
       setServer(createServer(api, abortController?.signal))
       abortController = new AbortController()

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -6,13 +6,12 @@ import { createClient, createServer } from './index'
 
 function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
   const [client, setClient] = useState<ServerApi | null>(null)
-  let abortController: AbortController
+  let isCreated = false
 
   useEffect(() => {
-    if (iframeRef.current) {
-      abortController?.abort()
-      setClient(createClient(iframeRef.current, api, abortController?.signal))
-      abortController = new AbortController()
+    if (iframeRef.current && !isCreated) {
+      isCreated = true
+      setClient(createClient(iframeRef.current!, api))
     }
   }, [iframeRef.current])
 
@@ -21,14 +20,13 @@ function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
 
 function useServer(api: ServerApi) {
   const [server, setServer] = useState<ClientApi | null>(null)
-  let abortController: AbortController
+  let isCreated = false
 
   useEffect(() => {
     const isInIframe = window.self !== window.top
-    if (isInIframe) {
-      abortController?.abort()
-      setServer(createServer(api, abortController?.signal))
-      abortController = new AbortController()
+    if (isInIframe && !isCreated) {
+      isCreated = true
+      setServer(createServer(api))
     }
   }, [])
 

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -6,12 +6,14 @@ import { createClient, createServer } from './index'
 
 function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
   const [client, setClient] = useState<ServerApi | null>(null)
-  let isCreated = false
+  let abortController: AbortController
 
   useEffect(() => {
-    if (iframeRef.current && !isCreated) {
-      isCreated = true
-      setClient(createClient(iframeRef.current, api))
+    if (iframeRef.current) {
+      console.log('client abortController', abortController)
+      abortController?.abort()
+      setClient(createClient(iframeRef.current, api, abortController?.signal))
+      abortController = new AbortController()
     }
   }, [iframeRef.current])
 
@@ -20,13 +22,15 @@ function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApi) {
 
 function useServer(api: ServerApi) {
   const [server, setServer] = useState<ClientApi | null>(null)
-  let isCreated = false
+  let abortController: AbortController
 
   useEffect(() => {
     const isInIframe = window.self !== window.top
-    if (isInIframe && !isCreated) {
-      isCreated = true
-      setServer(createServer(api))
+    if (isInIframe) {
+      console.log('server abortController', abortController)
+      abortController?.abort()
+      setServer(createServer(api, abortController?.signal))
+      abortController = new AbortController()
     }
   }, [])
 


### PR DESCRIPTION
I tried another way - destroying previous instance and create a new one
```
function useServer(api: ServerApi) {
  const [server, setServer] = useState<ClientApi | null>(null)
  let abortController:AbortController

  useEffect(() => {
    const isInIframe = window.self !== window.top
    if (isInIframe) {
      abortController?.abort()
      abortController = new AbortController()
      setServer(createServer(api, abortController.signal))
    }
  }, [])

  return server
}
```

But in this way, the thread lib will throw error, so I keep using `isCreated` for simplify

<img width="521" alt="1" src="https://github.com/TabbyML/tabby/assets/5305874/6ac720fb-42a7-4c67-8362-5535485c4140">


<img width="714" alt="111" src="https://github.com/TabbyML/tabby/assets/5305874/afe703fd-427d-445e-a015-a913bb1aecaf">

