### PR TITLE
feat(ui): register with name

### DIFF
--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -363,7 +363,7 @@ type Mutation {
   updateUserRole(id: ID!, isAdmin: Boolean!): Boolean!
   uploadUserAvatarBase64(id: ID!, avatarBase64: String): Boolean!
   updateUserName(id: ID!, name: String!): Boolean!
-  register(email: String!, password1: String!, password2: String!, invitationCode: String): RegisterResponse!
+  register(name: String, email: String!, password1: String!, password2: String!, invitationCode: String): RegisterResponse!
   tokenAuth(email: String!, password: String!): TokenAuthResponse!
   verifyToken(token: String!): Boolean!
   refreshToken(refreshToken: String!): RefreshTokenResponse!

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -363,7 +363,7 @@ type Mutation {
   updateUserRole(id: ID!, isAdmin: Boolean!): Boolean!
   uploadUserAvatarBase64(id: ID!, avatarBase64: String): Boolean!
   updateUserName(id: ID!, name: String!): Boolean!
-  register(name: String, email: String!, password1: String!, password2: String!, invitationCode: String): RegisterResponse!
+  register(name: String!, email: String!, password1: String!, password2: String!, invitationCode: String): RegisterResponse!
   tokenAuth(email: String!, password: String!): TokenAuthResponse!
   verifyToken(token: String!): Boolean!
   refreshToken(refreshToken: String!): RefreshTokenResponse!

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -363,7 +363,7 @@ type Mutation {
   updateUserRole(id: ID!, isAdmin: Boolean!): Boolean!
   uploadUserAvatarBase64(id: ID!, avatarBase64: String): Boolean!
   updateUserName(id: ID!, name: String!): Boolean!
-  register(name: String!, email: String!, password1: String!, password2: String!, invitationCode: String): RegisterResponse!
+  register(email: String!, password1: String!, password2: String!, invitationCode: String, name: String!): RegisterResponse!
   tokenAuth(email: String!, password: String!): TokenAuthResponse!
   verifyToken(token: String!): Boolean!
   refreshToken(refreshToken: String!): RefreshTokenResponse!

--- a/ee/tabby-schema/src/schema/auth.rs
+++ b/ee/tabby-schema/src/schema/auth.rs
@@ -363,7 +363,7 @@ pub trait AuthenticationService: Send + Sync {
         email: String,
         password1: String,
         invitation_code: Option<String>,
-        name: Option<String>
+        name: Option<String>,
     ) -> Result<RegisterResponse>;
     async fn allow_self_signup(&self) -> Result<bool>;
 

--- a/ee/tabby-schema/src/schema/auth.rs
+++ b/ee/tabby-schema/src/schema/auth.rs
@@ -363,6 +363,7 @@ pub trait AuthenticationService: Send + Sync {
         email: String,
         password1: String,
         invitation_code: Option<String>,
+        name: Option<String>
     ) -> Result<RegisterResponse>;
     async fn allow_self_signup(&self) -> Result<bool>;
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -834,7 +834,7 @@ impl Mutation {
         password1: String,
         password2: String,
         invitation_code: Option<String>,
-        name: String
+        name: String,
     ) -> Result<RegisterResponse> {
         let input = auth::RegisterInput {
             email,

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -834,6 +834,7 @@ impl Mutation {
         password1: String,
         password2: String,
         invitation_code: Option<String>,
+        name: Option<String>
     ) -> Result<RegisterResponse> {
         let input = auth::RegisterInput {
             email,
@@ -844,7 +845,7 @@ impl Mutation {
 
         ctx.locator
             .auth()
-            .register(input.email, input.password1, invitation_code)
+            .register(input.email, input.password1, invitation_code, name)
             .await
     }
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -834,7 +834,7 @@ impl Mutation {
         password1: String,
         password2: String,
         invitation_code: Option<String>,
-        name: Option<String>
+        name: String
     ) -> Result<RegisterResponse> {
         let input = auth::RegisterInput {
             email,
@@ -845,7 +845,7 @@ impl Mutation {
 
         ctx.locator
             .auth()
-            .register(input.email, input.password1, invitation_code, name)
+            .register(input.email, input.password1, invitation_code, Some(name))
             .await
     }
 

--- a/ee/tabby-ui/app/auth/signup/components/user-register-form.tsx
+++ b/ee/tabby-ui/app/auth/signup/components/user-register-form.tsx
@@ -30,12 +30,14 @@ import {
 
 export const registerUser = graphql(/* GraphQL */ `
   mutation register(
+    $name: String
     $email: String!
     $password1: String!
     $password2: String!
     $invitationCode: String
   ) {
     register(
+      name: $name
       email: $email
       password1: $password1
       password2: $password2
@@ -48,6 +50,7 @@ export const registerUser = graphql(/* GraphQL */ `
 `)
 
 const formSchema = z.object({
+  name: z.string().optional(),
   email: z.string().email('Invalid email address'),
   password1: z.string(),
   password2: z.string(),
@@ -104,6 +107,19 @@ export function UserAuthForm({
     <Form {...form}>
       <div className={cn('grid gap-2', className)} {...props}>
         <form className="grid gap-4" onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input {...field} value={field.value} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
           <FormField
             control={form.control}
             name="email"

--- a/ee/tabby-ui/app/auth/signup/components/user-register-form.tsx
+++ b/ee/tabby-ui/app/auth/signup/components/user-register-form.tsx
@@ -30,7 +30,7 @@ import {
 
 export const registerUser = graphql(/* GraphQL */ `
   mutation register(
-    $name: String
+    $name: String!
     $email: String!
     $password1: String!
     $password2: String!
@@ -50,7 +50,7 @@ export const registerUser = graphql(/* GraphQL */ `
 `)
 
 const formSchema = z.object({
-  name: z.string().optional(),
+  name: z.string(),
   email: z.string().email('Invalid email address'),
   password1: z.string(),
   password2: z.string(),

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -61,6 +61,7 @@ impl AuthenticationService for AuthenticationServiceImpl {
         email: String,
         password: String,
         invitation_code: Option<String>,
+        name: Option<String>
     ) -> Result<RegisterResponse> {
         let is_admin_initialized = self.is_admin_initialized().await?;
         if is_admin_initialized && is_demo_mode() {
@@ -85,12 +86,12 @@ impl AuthenticationService for AuthenticationServiceImpl {
                     Some(pwd_hash),
                     !is_admin_initialized,
                     invitation.id,
-                    None,
+                    name.clone(),
                 )
                 .await?
         } else {
             self.db
-                .create_user(email.clone(), Some(pwd_hash), !is_admin_initialized, None)
+                .create_user(email.clone(), Some(pwd_hash), !is_admin_initialized, name.clone())
                 .await?
         };
 

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -61,7 +61,7 @@ impl AuthenticationService for AuthenticationServiceImpl {
         email: String,
         password: String,
         invitation_code: Option<String>,
-        name: Option<String>
+        name: Option<String>,
     ) -> Result<RegisterResponse> {
         let is_admin_initialized = self.is_admin_initialized().await?;
         if is_admin_initialized && is_demo_mode() {
@@ -91,7 +91,12 @@ impl AuthenticationService for AuthenticationServiceImpl {
                 .await?
         } else {
             self.db
-                .create_user(email.clone(), Some(pwd_hash), !is_admin_initialized, name.clone())
+                .create_user(
+                    email.clone(),
+                    Some(pwd_hash),
+                    !is_admin_initialized,
+                    name.clone(),
+                )
                 .await?
         };
 
@@ -737,7 +742,12 @@ mod tests {
 
     async fn register_admin_user(service: &AuthenticationServiceImpl) -> RegisterResponse {
         service
-            .register(ADMIN_EMAIL.to_owned(), ADMIN_PASSWORD.to_owned(), None, None)
+            .register(
+                ADMIN_EMAIL.to_owned(),
+                ADMIN_PASSWORD.to_owned(),
+                None,
+                None,
+            )
             .await
             .unwrap()
     }

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -737,7 +737,7 @@ mod tests {
 
     async fn register_admin_user(service: &AuthenticationServiceImpl) -> RegisterResponse {
         service
-            .register(ADMIN_EMAIL.to_owned(), ADMIN_PASSWORD.to_owned(), None)
+            .register(ADMIN_EMAIL.to_owned(), ADMIN_PASSWORD.to_owned(), None, None)
             .await
             .unwrap()
     }
@@ -792,7 +792,7 @@ mod tests {
         // Admin initialized, registeration requires a invitation code;
         assert_matches!(
             service
-                .register(email.to_owned(), password.to_owned(), None)
+                .register(email.to_owned(), password.to_owned(), None, None)
                 .await,
             Err(_)
         );
@@ -803,7 +803,8 @@ mod tests {
                 .register(
                     email.to_owned(),
                     password.to_owned(),
-                    Some("abc".to_owned())
+                    Some("abc".to_owned()),
+                    None
                 )
                 .await,
             Err(_)
@@ -815,6 +816,7 @@ mod tests {
                 email.to_owned(),
                 password.to_owned(),
                 Some(invitation.code.clone()),
+                None
             )
             .await
             .is_ok());
@@ -825,7 +827,8 @@ mod tests {
                 .register(
                     email.to_owned(),
                     password.to_owned(),
-                    Some(invitation.code.clone())
+                    Some(invitation.code.clone()),
+                    None
                 )
                 .await,
             Err(_)
@@ -1018,7 +1021,7 @@ mod tests {
             .unwrap();
 
         service
-            .register("test@example.com".into(), "".into(), Some(code.code))
+            .register("test@example.com".into(), "".into(), Some(code.code), None)
             .await
             .unwrap();
 
@@ -1304,7 +1307,7 @@ mod tests {
 
         // Create owner user.
         service
-            .register("a@example.com".into(), "pass".into(), None)
+            .register("a@example.com".into(), "pass".into(), None, None)
             .await
             .unwrap();
 


### PR DESCRIPTION
Register with name
* The `name` field is required

<img width="1281" alt="123" src="https://github.com/TabbyML/tabby/assets/5305874/56cd3920-1cf0-4c4f-ba62-3c290d448743">

<img width="951" alt="2" src="https://github.com/TabbyML/tabby/assets/5305874/f0b0a6e0-a517-4683-be66-6df0a2c4e456">


### Testing
* Admin register with name
* Member register with invitationCode & name