### PR TITLE
fix(ui): scroll-area display style

### DIFF
--- a/ee/tabby-ui/components/ui/scroll-area.tsx
+++ b/ee/tabby-ui/components/ui/scroll-area.tsx
@@ -14,7 +14,8 @@ const ScrollArea = React.forwardRef<
     className={cn('relative overflow-hidden', className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    {/* https://github.com/radix-ui/primitives/issues/926 */}
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />


### PR DESCRIPTION
### Context
The chat component in `/playground` is wrapped with`ScrollArea`, but after wrapping, the markdown does not adapt to the width automatically.

### Solution
Set `display: block` for ScrollArea Viewport