### PR TITLE
fix(vscode): copy function for vscode and remove codeblock download

### DIFF
--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -62,8 +62,15 @@ export class ChatViewProvider implements WebviewViewProvider {
     });
 
     webviewView.webview.onDidReceiveMessage(async (message) => {
-      if (message.action === "rendered") {
-        await this.initChatPage();
+      switch (message.action) {
+        case "rendered": {
+          await this.initChatPage();
+          return;
+        }
+        case "copy": {
+          env.clipboard.writeText(message.data);
+          return;
+        }
       }
     });
 
@@ -165,6 +172,10 @@ export class ChatViewProvider implements WebviewViewProvider {
                     syncTheme();
                     return;
                   }
+                  if (event.data.action === 'copy') {
+                    vscode.postMessage(event.data);
+                    return;
+                  }
 
                   if (event.data.data) {
                     chatIframe.contentWindow.postMessage(event.data.data[0], "${endpoint}");
@@ -180,6 +191,7 @@ export class ChatViewProvider implements WebviewViewProvider {
           <iframe
             id="chat"
             src="${endpoint}/chat?from=vscode"
+            allow="clipboard-read; clipboard-write"
             onload="iframeLoaded(this)" />
         </body>
       </html>

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -134,6 +134,16 @@ export default function ChatPage() {
     server?.navigate(context)
   }
 
+  const onCopyContent = (value: string) => {
+    parent.postMessage(
+      {
+        action: 'copy',
+        data: value
+      },
+      '*'
+    )
+  }
+
   if (!isInit || !fetcherOptions) return <></>
   const headers = {
     Authorization: `Bearer ${fetcherOptions.authorization}`
@@ -148,6 +158,7 @@ export default function ChatPage() {
       onNavigateToContext={onNavigateToContext}
       onLoaded={onChatLoaded}
       maxWidth={maxWidth}
+      onCopyContent={from === 'vscode' ? onCopyContent : undefined}
     />
   )
 }

--- a/ee/tabby-ui/components/chat/chat.tsx
+++ b/ee/tabby-ui/components/chat/chat.tsx
@@ -33,6 +33,7 @@ type ChatContextValue = {
   onNavigateToContext?: (context: Context) => void
   onClearMessages: () => void
   container?: HTMLDivElement
+  onCopyContent?: (value: string) => void
 }
 
 export const ChatContext = React.createContext<ChatContextValue>(
@@ -116,6 +117,7 @@ interface ChatProps extends React.ComponentProps<'div'> {
   maxWidth?: string
   welcomeMessage?: string
   promptFormClassname?: string
+  onCopyContent?: (value: string) => void
 }
 
 function ChatRenderer(
@@ -134,7 +136,8 @@ function ChatRenderer(
     generateRelevantQuestions,
     maxWidth,
     welcomeMessage,
-    promptFormClassname
+    promptFormClassname,
+    onCopyContent
   }: ChatProps,
   ref: React.ForwardedRef<ChatRef>
 ) {
@@ -380,7 +383,8 @@ function ChatRenderer(
         onNavigateToContext,
         handleMessageAction,
         onClearMessages,
-        container
+        container,
+        onCopyContent
       }}
     >
       <div className="flex justify-center overflow-x-hidden">

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -144,8 +144,11 @@ interface AssistantMessageCardProps {
 }
 
 function AssistantMessageCard(props: AssistantMessageCardProps) {
-  const { handleMessageAction, isLoading: isGenerating } =
-    React.useContext(ChatContext)
+  const {
+    handleMessageAction,
+    isLoading: isGenerating,
+    onCopyContent
+  } = React.useContext(ChatContext)
   const {
     message,
     selectContext,
@@ -205,7 +208,7 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
               <span className="sr-only">Regenerate message</span>
             </Button>
           )}
-          <CopyButton value={message.message} />
+          <CopyButton value={message.message} onCopyContent={onCopyContent} />
         </ChatMessageActionsWrapper>
       </div>
     </div>
@@ -213,6 +216,7 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
 }
 
 function MessageMarkdown({ message }: { message: string }) {
+  const { onCopyContent } = React.useContext(ChatContext)
   return (
     <MemoizedReactMarkdown
       className="prose max-w-none break-words dark:prose-invert prose-p:leading-relaxed prose-pre:mt-1 prose-pre:p-0"
@@ -253,6 +257,7 @@ function MessageMarkdown({ message }: { message: string }) {
               key={Math.random()}
               language={(match && match[1]) || ''}
               value={String(children).replace(/\n$/, '')}
+              onCopyContent={onCopyContent}
               {...props}
             />
           )

--- a/ee/tabby-ui/components/copy-button.tsx
+++ b/ee/tabby-ui/components/copy-button.tsx
@@ -9,10 +9,19 @@ import { IconCheck, IconCopy } from './ui/icons'
 
 interface CopyButtonProps extends ButtonProps {
   value: string
+  onCopyContent?: (value: string) => void
 }
 
-export function CopyButton({ className, value, ...props }: CopyButtonProps) {
-  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
+export function CopyButton({
+  className,
+  value,
+  onCopyContent,
+  ...props
+}: CopyButtonProps) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard({
+    timeout: 2000,
+    onCopyContent
+  })
 
   const onCopy = () => {
     if (isCopied) return

--- a/ee/tabby-ui/components/ui/codeblock.tsx
+++ b/ee/tabby-ui/components/ui/codeblock.tsx
@@ -9,7 +9,7 @@ import { coldarkDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 
 import { useCopyToClipboard } from '@/lib/hooks/use-copy-to-clipboard'
 import { Button } from '@/components/ui/button'
-import { IconCheck, IconCopy, IconDownload } from '@/components/ui/icons'
+import { IconCheck, IconCopy } from '@/components/ui/icons'
 
 interface Props {
   language: string
@@ -59,34 +59,6 @@ export const generateRandomString = (length: number, lowercase = false) => {
 const CodeBlock: FC<Props> = memo(({ language, value }) => {
   const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
 
-  const downloadAsFile = () => {
-    if (typeof window === 'undefined') {
-      return
-    }
-    const fileExtension = programmingLanguages[language] || '.file'
-    const suggestedFileName = `file-${generateRandomString(
-      3,
-      true
-    )}${fileExtension}`
-    const fileName = window.prompt('Enter file name' || '', suggestedFileName)
-
-    if (!fileName) {
-      // User pressed cancel on prompt.
-      return
-    }
-
-    const blob = new Blob([value], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.download = fileName
-    link.href = url
-    link.style.display = 'none'
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
-  }
-
   const onCopy = () => {
     if (isCopied) return
     copyToClipboard(value)
@@ -97,15 +69,6 @@ const CodeBlock: FC<Props> = memo(({ language, value }) => {
       <div className="flex w-full items-center justify-between bg-zinc-800 px-6 py-2 pr-4 text-zinc-100">
         <span className="text-xs lowercase">{language}</span>
         <div className="flex items-center space-x-1">
-          <Button
-            variant="ghost"
-            className="hover:bg-[#3C382F] hover:text-[#F4F4F5] focus-visible:ring-1 focus-visible:ring-slate-700 focus-visible:ring-offset-0"
-            onClick={downloadAsFile}
-            size="icon"
-          >
-            <IconDownload />
-            <span className="sr-only">Download</span>
-          </Button>
           <Button
             variant="ghost"
             size="icon"

--- a/ee/tabby-ui/components/ui/codeblock.tsx
+++ b/ee/tabby-ui/components/ui/codeblock.tsx
@@ -14,6 +14,7 @@ import { IconCheck, IconCopy } from '@/components/ui/icons'
 interface Props {
   language: string
   value: string
+  onCopyContent?: (value: string) => void
 }
 
 interface languageMap {
@@ -56,8 +57,11 @@ export const generateRandomString = (length: number, lowercase = false) => {
   return lowercase ? result.toLowerCase() : result
 }
 
-const CodeBlock: FC<Props> = memo(({ language, value }) => {
-  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
+const CodeBlock: FC<Props> = memo(({ language, value, onCopyContent }) => {
+  const { isCopied, copyToClipboard } = useCopyToClipboard({
+    timeout: 2000,
+    onCopyContent
+  })
 
   const onCopy = () => {
     if (isCopied) return

--- a/ee/tabby-ui/lib/hooks/use-copy-to-clipboard.tsx
+++ b/ee/tabby-ui/lib/hooks/use-copy-to-clipboard.tsx
@@ -2,13 +2,18 @@
 
 import * as React from 'react'
 import copy from 'copy-to-clipboard'
+import { toast } from 'sonner'
 
 export interface useCopyToClipboardProps {
   timeout?: number
+  onError?: (e?: any) => void
+  onCopyContent?: (value: string) => void
 }
 
 export function useCopyToClipboard({
-  timeout = 2000
+  timeout = 2000,
+  onError,
+  onCopyContent
 }: useCopyToClipboardProps) {
   const [isCopied, setIsCopied] = React.useState<Boolean>(false)
 
@@ -19,32 +24,38 @@ export function useCopyToClipboard({
     }, timeout)
   }
 
+  const onCopyError = (error?: any) => {
+    if (typeof onError === 'function') {
+      onError?.(error)
+      return
+    }
+
+    toast.error('Failed to copy.')
+  }
+
   const copyToClipboard = (value: string) => {
     if (typeof window === 'undefined') return
     if (!value) return
+
+    if (onCopyContent) {
+      onCopyContent(value)
+      onCopySuccess()
+      return
+    }
 
     if (!!navigator.clipboard?.writeText) {
       navigator.clipboard
         .writeText(value)
         .then(onCopySuccess)
-        .catch(() => {})
+        .catch(onCopyError)
     } else {
       const copyResult = copy(value)
       if (copyResult) {
         onCopySuccess()
+      } else {
+        onCopyError()
       }
     }
-
-    // When component inside an iframe sandbox(VSCode)
-    // We need to notify parent environment to handle the copy event
-    parent.postMessage(
-      {
-        action: 'copy',
-        data: value
-      },
-      '*'
-    )
-    onCopySuccess()
   }
 
   return { isCopied, copyToClipboard }


### PR DESCRIPTION
Screen record: https://jam.dev/c/815a5168-36c7-467a-8015-356454fdc93c

Changes:
* Remove the `download` on the code block
* For the `copy`, I removed the error handler to simplify the logic and make the `copy` always sending a message to its parent environment so that in VSCode, it can catch the event and use its native clipboard API. I also tested in code browser and I don't see any side effect.


