### PR TITLE
feat(ui): chat layout change to 1 col under md

### DIFF
--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -181,7 +181,7 @@ interface AssistantMessageCardProps {
 }
 
 function AssistantMessageCard(props: AssistantMessageCardProps) {
-  const { message, isLoading, onCopyContent, ...rest } = props
+  const { message, isLoading, ...rest } = props
 
   const contexts: Array<Context> = React.useMemo(() => {
     return (
@@ -243,8 +243,11 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
 }
 
 function AssistantMessageCardActions(props: AssistantMessageCardProps) {
-  const { handleMessageAction, isLoading: isGenerating } =
-    React.useContext(ChatContext)
+  const {
+    handleMessageAction,
+    isLoading: isGenerating,
+    onCopyContent
+  } = React.useContext(ChatContext)
   const { message, userMessageId } = props
   return (
     <ChatMessageActionsWrapper>
@@ -397,7 +400,7 @@ const CodeReferences = ({ contexts }: ContextReferencesProps) => {
     <Accordion
       type="single"
       collapsible
-      className="bg-background text-foreground"
+      className="bg-transparent text-foreground"
     >
       <AccordionItem value="references" className="my-0 border-0">
         <AccordionTrigger className="my-0 py-2">

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -9,6 +9,7 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import type { Context } from 'tabby-chat-panel'
 
+import { useMe } from '@/lib/hooks/use-me'
 import { filename2prism } from '@/lib/language-utils'
 import {
   AssistantMessage,
@@ -92,7 +93,7 @@ function QuestionAnswerItem({ message, isLoading }: QuestionAnswerItemProps) {
 
 function UserMessageCard(props: { message: UserMessage }) {
   const { message } = props
-  const { handleMessageAction } = React.useContext(ChatContext)
+  const [{ data }] = useMe()
   const selectContext = message.selectContext
   const selectCodeSnippet = React.useMemo(() => {
     if (!selectContext?.content) return ''
@@ -104,34 +105,70 @@ function UserMessageCard(props: { message: UserMessage }) {
 
   return (
     <div
-      className={cn('group relative mb-4 flex items-start md:-ml-4')}
+      className={cn(
+        'group relative mb-4 flex flex-col items-start gap-y-2 md:-ml-4 md:flex-row'
+      )}
       {...props}
     >
-      <div className="shrink-0 select-none rounded-full border bg-background shadow">
-        <UserAvatar
-          className="h-8 w-8"
-          fallback={
-            <div className="flex h-8 w-8 items-center justify-center">
-              <IconUser className="h-5 w-5" />
-            </div>
-          }
-        />
+      <div
+        className={cn('flex w-full items-center justify-between md:w-auto', {
+          'hidden md:flex': !data?.me.name
+        })}
+      >
+        <div className="flex items-center gap-x-2">
+          <div className="shrink-0 select-none rounded-full border bg-background shadow">
+            <UserAvatar
+              className="h-6 w-6 md:h-8 md:w-8"
+              fallback={
+                <div className="flex h-6 w-6 items-center justify-center md:h-8 md:w-8">
+                  <IconUser className="h-6 w-6" />
+                </div>
+              }
+            />
+          </div>
+          <p className="block text-xs font-bold md:hidden">{data?.me.name}</p>
+        </div>
+
+        <div className="block opacity-0 transition-opacity group-hover:opacity-100 md:hidden">
+          <UserMessageCardActions {...props} />
+        </div>
       </div>
-      <div className="ml-4 flex-1 space-y-2 overflow-hidden px-1">
-        <MessageMarkdown message={message.message} />
-        {!!selectCodeSnippet && <MessageMarkdown message={selectCodeSnippet} />}
-        <ChatMessageActionsWrapper>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={e => handleMessageAction?.(message.id, 'delete')}
-          >
-            <IconTrash />
-            <span className="sr-only">Delete message</span>
-          </Button>
-        </ChatMessageActionsWrapper>
+
+      <div className="group flex w-full justify-between gap-x-2">
+        <div className="flex-1 space-y-2 overflow-hidden px-1 md:ml-4">
+          <MessageMarkdown message={message.message} />
+          {!!selectCodeSnippet && (
+            <MessageMarkdown message={selectCodeSnippet} />
+          )}
+          <div className="hidden md:block">
+            <UserMessageCardActions {...props} />
+          </div>
+        </div>
+
+        {!data?.me.name && (
+          <div className="block opacity-0 transition-opacity group-hover:opacity-100 md:hidden">
+            <UserMessageCardActions {...props} />
+          </div>
+        )}
       </div>
     </div>
+  )
+}
+
+function UserMessageCardActions(props: { message: UserMessage }) {
+  const { message } = props
+  const { handleMessageAction } = React.useContext(ChatContext)
+  return (
+    <ChatMessageActionsWrapper>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={e => handleMessageAction?.(message.id, 'delete')}
+      >
+        <IconTrash />
+        <span className="sr-only">Delete message</span>
+      </Button>
+    </ChatMessageActionsWrapper>
   )
 }
 
@@ -144,19 +181,7 @@ interface AssistantMessageCardProps {
 }
 
 function AssistantMessageCard(props: AssistantMessageCardProps) {
-  const {
-    handleMessageAction,
-    isLoading: isGenerating,
-    onCopyContent
-  } = React.useContext(ChatContext)
-  const {
-    message,
-    selectContext,
-    relevantContext,
-    isLoading,
-    userMessageId,
-    ...rest
-  } = props
+  const { message, isLoading, onCopyContent, ...rest } = props
 
   const contexts: Array<Context> = React.useMemo(() => {
     return (
@@ -181,13 +206,25 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
 
   return (
     <div
-      className={cn('group relative mb-4 flex items-start md:-ml-4')}
+      className={cn(
+        'group relative mb-4 flex flex-col items-start gap-y-2 md:-ml-4 md:flex-row'
+      )}
       {...rest}
     >
-      <div className="shrink-0 select-none rounded-full border bg-background shadow">
-        <IconTabby className="h-8 w-8" />
+      <div className="flex w-full items-center justify-between md:w-auto">
+        <div className="flex items-center gap-x-2">
+          <div className="shrink-0 select-none rounded-full border bg-background shadow">
+            <IconTabby className="h-6 w-6 md:h-8 md:w-8" />
+          </div>
+          <p className="block text-xs font-bold md:hidden">Tabby</p>
+        </div>
+
+        <div className="block opacity-0 transition-opacity group-hover:opacity-100 md:hidden">
+          <AssistantMessageCardActions {...props} />
+        </div>
       </div>
-      <div className="ml-4 flex-1 space-y-2 overflow-hidden px-1">
+
+      <div className="w-full flex-1 space-y-2 overflow-hidden px-1 md:ml-4">
         <CodeReferences contexts={contexts} />
         {isLoading && !message?.message ? (
           <MessagePendingIndicator />
@@ -197,21 +234,32 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
             {!!message.error && <ErrorMessageBlock error={message.error} />}
           </>
         )}
-        <ChatMessageActionsWrapper>
-          {!isGenerating && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={e => handleMessageAction(userMessageId, 'regenerate')}
-            >
-              <IconRefresh />
-              <span className="sr-only">Regenerate message</span>
-            </Button>
-          )}
-          <CopyButton value={message.message} onCopyContent={onCopyContent} />
-        </ChatMessageActionsWrapper>
+        <div className="hidden md:block">
+          <AssistantMessageCardActions {...props} />
+        </div>
       </div>
     </div>
+  )
+}
+
+function AssistantMessageCardActions(props: AssistantMessageCardProps) {
+  const { handleMessageAction, isLoading: isGenerating } =
+    React.useContext(ChatContext)
+  const { message, userMessageId } = props
+  return (
+    <ChatMessageActionsWrapper>
+      {!isGenerating && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={e => handleMessageAction(userMessageId, 'regenerate')}
+        >
+          <IconRefresh />
+          <span className="sr-only">Regenerate message</span>
+        </Button>
+      )}
+      <CopyButton value={message.message} onCopyContent={onCopyContent} />
+    </ChatMessageActionsWrapper>
   )
 }
 

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -354,7 +354,7 @@ function ErrorMessageBlock({ error = 'Fail to fetch' }: { error?: string }) {
 
 function MessagePendingIndicator() {
   return (
-    <div className="space-y-2 py-2 md:py-0 md:px-1">
+    <div className="space-y-2 py-2 md:px-1 md:py-0">
       <Skeleton className="h-3 w-full" />
       <Skeleton className="h-3 w-full" />
     </div>

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -354,7 +354,7 @@ function ErrorMessageBlock({ error = 'Fail to fetch' }: { error?: string }) {
 
 function MessagePendingIndicator() {
   return (
-    <div className="space-y-2 px-1">
+    <div className="space-y-2 py-2 md:py-0 md:px-1">
       <Skeleton className="h-3 w-full" />
       <Skeleton className="h-3 w-full" />
     </div>


### PR DESCRIPTION
The following changes only take affect when width smaller than `md` 
* Avatar into one column 
* Action icons go to the top-right and only display when hover

#### VSCode
hover on the user's question, so the delete icon showed
<img width="447" alt="1" src="https://github.com/TabbyML/tabby/assets/5305874/95d17b8f-ef04-4646-b9d9-ed9de0d93ab7">

#### Code browser
<img width="664" alt="2" src="https://github.com/TabbyML/tabby/assets/5305874/309c142e-4d78-4719-bd88-a119152a03ae">

hover on the answer
<img width="672" alt="3" src="https://github.com/TabbyML/tabby/assets/5305874/6627117b-7189-420f-9426-2d5f208884b0">


