### PR TITLE
feat(vscode): add commands for the chat panel

### DIFF
--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -71,7 +71,7 @@
         "title": "Tabby: Reset notifications marked as \"Don't Show Again\""
       },
       {
-        "command": "tabby.experimental.chat.explainCodeBlock",
+        "command": "tabby.chat.explainCodeBlock",
         "title": "Tabby: Explain This"
       },
       {
@@ -111,8 +111,8 @@
           "when": "!isWeb"
         },
         {
-          "command": "tabby.experimental.chat.explainCodeBlock",
-          "when": "editorHasSelection && tabby.chatEnabled && tabby.explainCodeBlockEnabled"
+          "command": "tabby.chat.explainCodeBlock",
+          "when": "editorHasSelection && tabby.chatEnabled"
         },
         {
           "command": "tabby.experimental.chat.generateCommitMessage",
@@ -129,13 +129,6 @@
         {
           "command": "tabby.experimental.chat.edit.discard",
           "when": "false"
-        }
-      ],
-      "editor/context": [
-        {
-          "command": "tabby.experimental.chat.explainCodeBlock",
-          "group": "1_close",
-          "when": "editorHasSelection && tabby.chatEnabled && tabby.explainCodeBlockEnabled"
         }
       ]
     },
@@ -221,10 +214,6 @@
           "tabby.experimental": {
             "default": {},
             "properties": {
-              "chat.explainCodeBlock": {
-                "type": "boolean",
-                "default": false
-              },
               "chat.generateCommitMessage": {
                 "type": "boolean",
                 "default": false

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -75,6 +75,18 @@
         "title": "Tabby: Explain This"
       },
       {
+        "command": "tabby.chat.fixCodeBlock",
+        "title": "Tabby: Fix This"
+      },
+      {
+        "command": "tabby.chat.generateCodeBlockDoc",
+        "title": "Tabby: Generate Docs"
+      },
+      {
+        "command": "tabby.chat.generateCodeBlockTest",
+        "title": "Tabby: Generate Tests"
+      },
+      {
         "command": "tabby.experimental.chat.generateCommitMessage",
         "title": "Generate Commit Message",
         "category": "Tabby"
@@ -112,6 +124,18 @@
         },
         {
           "command": "tabby.chat.explainCodeBlock",
+          "when": "editorHasSelection && tabby.chatEnabled"
+        },
+        {
+          "command": "tabby.chat.fixCodeBlock",
+          "when": "editorHasSelection && tabby.chatEnabled"
+        },
+        {
+          "command": "tabby.chat.generateCodeBlockDoc",
+          "when": "editorHasSelection && tabby.chatEnabled"
+        },
+        {
+          "command": "tabby.chat.generateCodeBlockTest",
           "when": "editorHasSelection && tabby.chatEnabled"
         },
         {

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -210,52 +210,53 @@ export class Commands {
         this.config.mutedNotifications = [];
       }
     },
-    "experimental.chat.explainCodeBlock": async () => {
-      const alignIndent = (text: string) => {
-        const lines = text.split("\n");
-        const subsequentLines = lines.slice(1);
-
-        // Determine the minimum indent for subsequent lines
-        const minIndent = subsequentLines.reduce((min, line) => {
-          const match = line.match(/^(\s*)/);
-          const indent = match ? match[0].length : 0;
-          return line.trim() ? Math.min(min, indent) : min;
-        }, Infinity);
-
-        // Remove the minimum indent
-        const adjustedLines = lines.slice(1).map((line) => line.slice(minIndent));
-
-        return [lines[0]?.trim(), ...adjustedLines].join("\n");
-      };
-
+    "chat.explainCodeBlock": async () => {
       const editor = window.activeTextEditor;
       if (editor) {
-        const uri = editor.document.uri;
-        const text = editor.document.getText(editor.selection);
-        const workspaceFolder = workspace.getWorkspaceFolder(uri);
-        const repo = this.gitProvider.getRepository(uri);
-        const remoteUrl = repo ? this.gitProvider.getDefaultRemoteUrl(repo) : undefined;
-        let filePath = uri.toString();
-        if (repo) {
-          filePath = filePath.replace(repo.rootUri.toString(), "");
-        } else if (workspaceFolder) {
-          filePath = filePath.replace(workspaceFolder.uri.toString(), "");
-        }
-
         commands.executeCommand("tabby.chatView.focus");
-
+        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
         this.chatViewProvider.sendMessage({
           message: "Explain the selected code:",
-          selectContext: {
-            kind: "file",
-            content: alignIndent(text),
-            range: {
-              start: editor.selection.start.line + 1,
-              end: editor.selection.end.line + 1,
-            },
-            filepath: filePath.startsWith("/") ? filePath.substring(1) : filePath,
-            git_url: remoteUrl ?? "",
-          },
+          selectContext: fileContext,
+        });
+      } else {
+        window.showInformationMessage("No active editor");
+      }
+    },
+    "chat.fixCodeBlock": async () => {
+      const editor = window.activeTextEditor;
+      if (editor) {
+        commands.executeCommand("tabby.chatView.focus");
+        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
+        this.chatViewProvider.sendMessage({
+          message: "Identify and fix potential bugs from the selected code:",
+          selectContext: fileContext,
+        });
+      } else {
+        window.showInformationMessage("No active editor");
+      }
+    },
+    "chat.generateCodeBlockDoc": async () => {
+      const editor = window.activeTextEditor;
+      if (editor) {
+        commands.executeCommand("tabby.chatView.focus");
+        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
+        this.chatViewProvider.sendMessage({
+          message: "Generate documentation for the selected code:",
+          selectContext: fileContext,
+        });
+      } else {
+        window.showInformationMessage("No active editor");
+      }
+    },
+    "chat.generateCodeBlockTest": async () => {
+      const editor = window.activeTextEditor;
+      if (editor) {
+        commands.executeCommand("tabby.chatView.focus");
+        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
+        this.chatViewProvider.sendMessage({
+          message: "Generate a unit test for the selected code:",
+          selectContext: fileContext,
         });
       } else {
         window.showInformationMessage("No active editor");

--- a/clients/vscode/src/ContextVariables.ts
+++ b/clients/vscode/src/ContextVariables.ts
@@ -4,7 +4,6 @@ import { Config } from "./Config";
 
 export class ContextVariables {
   private chatEnabledValue = false;
-  private explainCodeBlockEnabledValue = false;
   private generateCommitMessageEnabledValue = false;
   private chatEditInProgressValue = false;
   private chatEditResolvingValue = false;
@@ -36,7 +35,6 @@ export class ContextVariables {
 
   private updateExperimentalFlags() {
     const experimental = this.config.workspace.get<Record<string, unknown>>("experimental", {});
-    this.explainCodeBlockEnabled = !!experimental["chat.explainCodeBlock"];
     this.generateCommitMessageEnabled = !!experimental["chat.generateCommitMessage"];
   }
 
@@ -63,15 +61,6 @@ export class ContextVariables {
   private set chatEnabled(value: boolean) {
     commands.executeCommand("setContext", "tabby.chatEnabled", value);
     this.chatEnabledValue = value;
-  }
-
-  get explainCodeBlockEnabled(): boolean {
-    return this.explainCodeBlockEnabledValue;
-  }
-
-  private set explainCodeBlockEnabled(value: boolean) {
-    commands.executeCommand("setContext", "tabby.explainCodeBlockEnabled", value);
-    this.explainCodeBlockEnabledValue = value;
   }
 
   get generateCommitMessageEnabled(): boolean {

--- a/clients/vscode/src/chat/chatPanel.ts
+++ b/clients/vscode/src/chat/chatPanel.ts
@@ -16,7 +16,6 @@ export function createThreadFromWebview<Self = Record<string, never>, Target = R
           listen(data);
         });
 
-        // FIXME(wwayne): double check if the connection got any edge cases
         signal?.addEventListener("abort", () => {
           dispose();
         });

--- a/ee/tabby-ui/app/chat/page.css
+++ b/ee/tabby-ui/app/chat/page.css
@@ -43,3 +43,7 @@ html {
 .vscode ::-webkit-scrollbar {
   display: none;
 }
+
+.vscode .editor-bg {
+  background-color: hsl(var(--vscode-sideBar-background))
+}

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -134,7 +134,7 @@ function UserMessageCard(props: { message: UserMessage }) {
         </div>
       </div>
 
-      <div className="group flex w-full justify-between gap-x-2">
+      <div className="group flex w-full justify-between gap-x-2 relative">
         <div className="flex-1 space-y-2 overflow-hidden px-1 md:ml-4">
           <MessageMarkdown message={message.message} />
           {!!selectCodeSnippet && (
@@ -144,9 +144,8 @@ function UserMessageCard(props: { message: UserMessage }) {
             <UserMessageCardActions {...props} />
           </div>
         </div>
-
         {!data?.me.name && (
-          <div className="block opacity-0 transition-opacity group-hover:opacity-100 md:hidden">
+          <div className="block opacity-0 transition-opacity group-hover:opacity-100 md:hidden absolute top-0 right-0 -mt-0.5 editor-bg">
             <UserMessageCardActions {...props} />
           </div>
         )}

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -134,7 +134,7 @@ function UserMessageCard(props: { message: UserMessage }) {
         </div>
       </div>
 
-      <div className="group flex w-full justify-between gap-x-2 relative">
+      <div className="group relative flex w-full justify-between gap-x-2">
         <div className="flex-1 space-y-2 overflow-hidden px-1 md:ml-4">
           <MessageMarkdown message={message.message} />
           {!!selectCodeSnippet && (
@@ -145,7 +145,7 @@ function UserMessageCard(props: { message: UserMessage }) {
           </div>
         </div>
         {!data?.me.name && (
-          <div className="block opacity-0 transition-opacity group-hover:opacity-100 md:hidden absolute top-0 right-0 -mt-0.5 editor-bg">
+          <div className="editor-bg absolute right-0 top-0 -mt-0.5 block opacity-0 transition-opacity group-hover:opacity-100 md:hidden">
             <UserMessageCardActions {...props} />
           </div>
         )}


### PR DESCRIPTION
## Changes
* `tabby.experimental.chat.explainCodeBlock` -> `tabby.chat.explainCodeBlock`
* Remove `tabby.explainCodeBlockEnabled`
* Remove `right-click` menu
* Add 3 more commands to the command palette (see the below)

### Commands
<img width="324" alt="1" src="https://github.com/TabbyML/tabby/assets/5305874/689f480e-2222-4c1f-9e1d-02229dcc21d1">

### Generate Docs
<img width="520" alt="2" src="https://github.com/TabbyML/tabby/assets/5305874/752bed41-5bc0-4245-b54f-a4bd64f7fce4">

### Fix This
<img width="523" alt="3" src="https://github.com/TabbyML/tabby/assets/5305874/70f695f9-d5bc-4c38-86c2-8c151cd97052">

### Generate Tests
<img width="504" alt="5" src="https://github.com/TabbyML/tabby/assets/5305874/89d0c32b-ba05-4777-b217-3859715d7465">
