### PR TITLE
feat(ui): support browsing different git tree in code browser

### DIFF
--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -5,22 +5,15 @@ import { useClient } from 'tabby-chat-panel/react'
 
 import { useLatest } from '@/lib/hooks/use-latest'
 import { useMe } from '@/lib/hooks/use-me'
-import useRouterStuff from '@/lib/hooks/use-router-stuff'
 import { useStore } from '@/lib/hooks/use-store'
 import { useChatStore } from '@/lib/stores/chat-store'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { IconClose } from '@/components/ui/icons'
-import { useTopbarProgress } from '@/components/topbar-progress-indicator'
 
 import { QuickActionEventPayload } from '../lib/event-emitter'
-import { SourceCodeBrowserContext, TFileMap } from './source-code-browser'
-import {
-  fetchEntriesFromPath,
-  getDirectoriesFromBasename,
-  resolveFileNameFromPath,
-  resolveRepoSpecifierFromRepoInfo
-} from './utils'
+import { SourceCodeBrowserContext } from './source-code-browser'
+import { resolveRepoSpecifierFromRepoInfo } from './utils'
 
 interface ChatSideBarProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {}
@@ -29,20 +22,18 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
   className,
   ...props
 }) => {
-  const { setProgress } = useTopbarProgress()
-  const { updateSearchParams, updatePathnameAndSearch } = useRouterStuff()
   const [{ data }] = useMe()
   const {
     pendingEvent,
     setPendingEvent,
     repoMap,
-    setExpandedKeys,
-    updateFileMap,
-    activeRepoRef
+    activeRepoRef,
+    updateActivePath
   } = React.useContext(SourceCodeBrowserContext)
   const activeChatId = useStore(useChatStore, state => state.activeChatId)
   const iframeRef = React.useRef<HTMLIFrameElement>(null)
   const repoMapRef = useLatest(repoMap)
+  const latestRepoRef = useLatest(activeRepoRef)
   const onNavigate = async (context: Context) => {
     if (context?.filepath && context?.git_url) {
       const repoMap = repoMapRef.current
@@ -53,61 +44,16 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
       if (matchedRepositoryKey) {
         const repository = repoMap[matchedRepositoryKey]
         const repositorySpecifier = resolveRepoSpecifierFromRepoInfo(repository)
-        const rev = activeRepoRef?.name
+        const rev = latestRepoRef?.current?.name ?? 'main'
 
         const fullPath = `${repositorySpecifier}/${rev}/${context.filepath}`
         if (!fullPath) return
-        try {
-          setProgress(true)
-          const entries = await fetchEntriesFromPath(
-            fullPath,
-            repositorySpecifier
-              ? repoMap?.[`${repositorySpecifier}/${rev}`]
-              : undefined
-          )
-          const initialExpandedDirs = getDirectoriesFromBasename(
-            context.filepath
-          )
-
-          const patchMap: TFileMap = {}
-          // fetch dirs
-          for (const entry of entries) {
-            const path = `${repositorySpecifier}/${entry.basename}`
-            patchMap[path] = {
-              file: entry,
-              name: resolveFileNameFromPath(path),
-              fullPath: path,
-              treeExpanded: initialExpandedDirs.includes(entry.basename)
-            }
+        updateActivePath(fullPath, {
+          shouldFetchAllEntries: true,
+          params: {
+            line: String(context.range.start)
           }
-          const expandedKeys = initialExpandedDirs.map(dir =>
-            [repositorySpecifier, dir].filter(Boolean).join('/')
-          )
-          if (patchMap) {
-            updateFileMap(patchMap)
-          }
-          if (expandedKeys?.length) {
-            setExpandedKeys(prevKeys => {
-              const newSet = new Set(prevKeys)
-              for (const k of expandedKeys) {
-                newSet.add(k)
-              }
-              return newSet
-            })
-          }
-        } catch (e) {
-        } finally {
-          updatePathnameAndSearch(
-            `${repositorySpecifier ?? ''}/${context.filepath}`,
-            {
-              set: {
-                line: String(context.range.start ?? '')
-              },
-              del: 'plain'
-            }
-          )
-          setProgress(false)
-        }
+        })
       }
     }
   }

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -37,7 +37,8 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
     setPendingEvent,
     repoMap,
     setExpandedKeys,
-    updateFileMap
+    updateFileMap,
+    activeRepoRef
   } = React.useContext(SourceCodeBrowserContext)
   const activeChatId = useStore(useChatStore, state => state.activeChatId)
   const iframeRef = React.useRef<HTMLIFrameElement>(null)
@@ -52,8 +53,8 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
       if (matchedRepositoryKey) {
         const repository = repoMap[matchedRepositoryKey]
         const repositorySpecifier = resolveRepoSpecifierFromRepoInfo(repository)
-        // todo should contain rev or get default rev
-        const rev = 'main'
+        const rev = activeRepoRef?.name
+
         const fullPath = `${repositorySpecifier}/${rev}/${context.filepath}`
         if (!fullPath) return
         try {

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -30,7 +30,7 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
   ...props
 }) => {
   const { setProgress } = useTopbarProgress()
-  const { updateSearchParams } = useRouterStuff()
+  const { updateSearchParams, updatePathnameAndSearch } = useRouterStuff()
   const [{ data }] = useMe()
   const {
     pendingEvent,
@@ -52,13 +52,17 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
       if (matchedRepositoryKey) {
         const repository = repoMap[matchedRepositoryKey]
         const repositorySpecifier = resolveRepoSpecifierFromRepoInfo(repository)
-        const fullPath = `${repositorySpecifier}/${context.filepath}`
+        // todo should contain rev or get default rev
+        const rev = 'main'
+        const fullPath = `${repositorySpecifier}/${rev}/${context.filepath}`
         if (!fullPath) return
         try {
           setProgress(true)
           const entries = await fetchEntriesFromPath(
             fullPath,
-            repositorySpecifier ? repoMap?.[repositorySpecifier] : undefined
+            repositorySpecifier
+              ? repoMap?.[`${repositorySpecifier}/${rev}`]
+              : undefined
           )
           const initialExpandedDirs = getDirectoriesFromBasename(
             context.filepath
@@ -92,13 +96,15 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
           }
         } catch (e) {
         } finally {
-          updateSearchParams({
-            set: {
-              path: `${repositorySpecifier ?? ''}/${context.filepath}`,
-              line: String(context.range.start ?? '')
-            },
-            del: 'plain'
-          })
+          updatePathnameAndSearch(
+            `${repositorySpecifier ?? ''}/${context.filepath}`,
+            {
+              set: {
+                line: String(context.range.start ?? '')
+              },
+              del: 'plain'
+            }
+          )
           setProgress(false)
         }
       }

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -49,7 +49,6 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
         const fullPath = `${repositorySpecifier}/${rev}/${context.filepath}`
         if (!fullPath) return
         updateActivePath(fullPath, {
-          shouldFetchAllEntries: true,
           params: {
             line: String(context.range.start)
           }

--- a/ee/tabby-ui/app/files/components/chat-side-bar.tsx
+++ b/ee/tabby-ui/app/files/components/chat-side-bar.tsx
@@ -45,8 +45,11 @@ export const ChatSideBar: React.FC<ChatSideBarProps> = ({
         const repository = repoMap[matchedRepositoryKey]
         const repositorySpecifier = resolveRepoSpecifierFromRepoInfo(repository)
         const rev = latestRepoRef?.current?.name ?? 'main'
+        const isFile = context.kind === 'file'
 
-        const fullPath = `${repositorySpecifier}/${rev}/${context.filepath}`
+        const fullPath = `${repositorySpecifier}/-/${
+          isFile ? 'blob' : 'tree'
+        }/${rev}/${context.filepath}`
         if (!fullPath) return
         updateActivePath(fullPath, {
           params: {

--- a/ee/tabby-ui/app/files/components/code-editor-view.tsx
+++ b/ee/tabby-ui/app/files/components/code-editor-view.tsx
@@ -46,10 +46,10 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
   const { isChatEnabled, activePath, fileMap } = React.useContext(
     SourceCodeBrowserContext
   )
-  const { repositorySpecifier, basename } =
+  const { repositorySpecifier, rev, basename } =
     resolveRepositoryInfoFromPath(activePath)
   const gitUrl = repositorySpecifier
-    ? fileMap[repositorySpecifier]?.repository?.gitUrl ?? ''
+    ? fileMap[`${repositorySpecifier}/${rev}`]?.repository?.gitUrl ?? ''
     : ''
 
   const extensions = React.useMemo(() => {

--- a/ee/tabby-ui/app/files/components/code-editor-view.tsx
+++ b/ee/tabby-ui/app/files/components/code-editor-view.tsx
@@ -26,7 +26,6 @@ import { useCopyToClipboard } from '@/lib/hooks/use-copy-to-clipboard'
 import useRouterStuff from '@/lib/hooks/use-router-stuff'
 
 import { emitter, LineMenuActionEventPayload } from '../lib/event-emitter'
-import { resolveRepositoryInfoFromPath } from './utils'
 
 interface CodeEditorViewProps {
   value: string
@@ -43,11 +42,9 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
   const line = searchParams.get('line')?.toString()
   const [editorView, setEditorView] = React.useState<EditorView | null>(null)
 
-  const { isChatEnabled, activePath, fileMap } = React.useContext(
-    SourceCodeBrowserContext
-  )
-  const { repositorySpecifier, rev, basename } =
-    resolveRepositoryInfoFromPath(activePath)
+  const { isChatEnabled, activePath, fileMap, activeEntryInfo } =
+    React.useContext(SourceCodeBrowserContext)
+  const { repositorySpecifier, rev, basename } = activeEntryInfo
   const gitUrl = repositorySpecifier
     ? fileMap[`${repositorySpecifier}/${rev}`]?.repository?.gitUrl ?? ''
     : ''

--- a/ee/tabby-ui/app/files/components/error-view.tsx
+++ b/ee/tabby-ui/app/files/components/error-view.tsx
@@ -3,23 +3,14 @@ import React from 'react'
 import { cn } from '@/lib/utils'
 import { IconFileSearch } from '@/components/ui/icons'
 
-import { SourceCodeBrowserContext } from './source-code-browser'
 import { Errors } from './utils'
-
-// import { Errors } from "./utils";
 
 interface ErrorViewProps extends React.HTMLAttributes<HTMLDivElement> {
   error: Error | undefined
 }
 
 export const ErrorView: React.FC<ErrorViewProps> = ({ className, error }) => {
-  const { activeEntryInfo, activeRepo, activeRepoRef } = React.useContext(
-    SourceCodeBrowserContext
-  )
-  const basename = activeEntryInfo?.basename
-  const isNotFound = error?.message === Errors.NOT_FOUND
   const isEmptyRepository = error?.message === Errors?.EMPTY_REPOSITORY
-  // const isEmptyRepository = !!basename && (!activeRepo || !activeRepoRef?.name)
 
   let errorMessge = 'Not found'
   if (isEmptyRepository) {

--- a/ee/tabby-ui/app/files/components/error-view.tsx
+++ b/ee/tabby-ui/app/files/components/error-view.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { cn } from '@/lib/utils'
+import { IconFileSearch } from '@/components/ui/icons'
+
+import { SourceCodeBrowserContext } from './source-code-browser'
+import { Errors } from './utils'
+
+// import { Errors } from "./utils";
+
+interface ErrorViewProps extends React.HTMLAttributes<HTMLDivElement> {
+  error: Error | undefined
+}
+
+export const ErrorView: React.FC<ErrorViewProps> = ({ className, error }) => {
+  const { activeEntryInfo, activeRepo, activeRepoRef } = React.useContext(
+    SourceCodeBrowserContext
+  )
+  const basename = activeEntryInfo?.basename
+  const isNotFound = error?.message === Errors.NOT_FOUND
+  const isEmptyRepository = error?.message === Errors?.EMPTY_REPOSITORY
+  // const isEmptyRepository = !!basename && (!activeRepo || !activeRepoRef?.name)
+
+  let errorMessge = 'Not found'
+  if (isEmptyRepository) {
+    errorMessge = 'Empty repository'
+  }
+
+  return (
+    <div
+      className={cn('min-h-[30vh] flex items-center justify-center', className)}
+    >
+      <div className="flex flex-col items-center">
+        <IconFileSearch className="mb-2 h-10 w-10" />
+        <div className="font-semibold text-2xl">{errorMessge}</div>
+      </div>
+    </div>
+  )
+}

--- a/ee/tabby-ui/app/files/components/error-view.tsx
+++ b/ee/tabby-ui/app/files/components/error-view.tsx
@@ -28,11 +28,11 @@ export const ErrorView: React.FC<ErrorViewProps> = ({ className, error }) => {
 
   return (
     <div
-      className={cn('min-h-[30vh] flex items-center justify-center', className)}
+      className={cn('flex min-h-[30vh] items-center justify-center', className)}
     >
       <div className="flex flex-col items-center">
         <IconFileSearch className="mb-2 h-10 w-10" />
-        <div className="font-semibold text-2xl">{errorMessge}</div>
+        <div className="text-2xl font-semibold">{errorMessge}</div>
       </div>
     </div>
   )

--- a/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
@@ -12,7 +12,7 @@ interface FileDirectoryBreadcrumbProps
 const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
   className
 }) => {
-  const { currentFileRoutes, setActivePath, activePath } = React.useContext(
+  const { currentFileRoutes, updateActivePath, activePath } = React.useContext(
     SourceCodeBrowserContext
   )
   const basename = React.useMemo(
@@ -25,7 +25,7 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
       <div className="flex items-center gap-1 overflow-x-auto leading-8">
         <div
           className="cursor-pointer font-medium text-primary hover:underline"
-          onClick={e => setActivePath(undefined)}
+          onClick={e => updateActivePath(undefined)}
         >
           Repositories
         </div>
@@ -45,7 +45,7 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
                     : 'cursor-pointer text-primary hover:underline',
                   isRepo ? 'hover:underline' : undefined
                 )}
-                onClick={e => setActivePath(route.fullPath)}
+                onClick={e => updateActivePath(route.fullPath)}
               >
                 {route.name}
               </div>

--- a/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
@@ -49,7 +49,7 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
     <div className={cn('flex flex-nowrap items-center gap-1', className)}>
       <div className="flex items-center gap-1 overflow-x-auto leading-8">
         <Link
-          className="text-primary cursor-pointer font-medium hover:underline"
+          className="cursor-pointer font-medium text-primary hover:underline"
           href="/files"
         >
           Repositories
@@ -61,7 +61,7 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
           const classname = cn(
             'whitespace-nowrap',
             isRepo || isActiveFile ? 'font-bold' : 'font-medium',
-            isActiveFile ? '' : 'text-primary cursor-pointer hover:underline',
+            isActiveFile ? '' : 'cursor-pointer text-primary hover:underline',
             isRepo ? 'hover:underline' : undefined
           )
 

--- a/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
@@ -38,7 +38,7 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
     const basename = activeEntryInfo?.basename
     let result = [
       {
-        name: activeRepo?.name ?? '',
+        name: activeEntryInfo?.repositoryName ?? '',
         href: generateEntryPath(activeRepo, activeRepoRef?.name, '', 'dir')
       }
     ]

--- a/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
 
+import { RepositoryKind } from '@/lib/gql/generates/graphql'
 import { cn } from '@/lib/utils'
 import { CopyButton } from '@/components/copy-button'
 
 import { SourceCodeBrowserContext } from './source-code-browser'
-import { resolveRepositoryInfoFromPath } from './utils'
+import {
+  generateEntryPath,
+  resolveFileNameFromPath,
+  resolveRepositoryInfoFromPath
+} from './utils'
 
 interface FileDirectoryBreadcrumbProps
   extends React.HTMLAttributes<HTMLDivElement> {}
@@ -12,13 +17,46 @@ interface FileDirectoryBreadcrumbProps
 const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
   className
 }) => {
-  const { currentFileRoutes, updateActivePath, activePath } = React.useContext(
-    SourceCodeBrowserContext
-  )
+  const {
+    currentFileRoutes,
+    updateActivePath,
+    activePath,
+    activeRepo,
+    activeRepoRef,
+    activeEntryInfo
+  } = React.useContext(SourceCodeBrowserContext)
   const basename = React.useMemo(
     () => resolveRepositoryInfoFromPath(activePath)?.basename,
     [activePath]
   )
+
+  const routes: Array<{
+    name: string
+    href: string
+    kind?: RepositoryKind
+  }> = React.useMemo(() => {
+    const basename = activeEntryInfo?.basename
+    let result = [
+      {
+        name: activeRepo?.name ?? '',
+        href: generateEntryPath(activeRepo, activeRepoRef?.name, '', 'dir')
+      }
+    ]
+
+    if (basename) {
+      const pathSegments = basename?.split('/') || []
+      for (let i = 0; i < pathSegments.length; i++) {
+        const p = pathSegments.slice(0, i + 1).join('/')
+        const name = resolveFileNameFromPath(p)
+        result.push({
+          name,
+          href: generateEntryPath(activeRepo, activeRepoRef?.name, p, 'dir')
+        })
+      }
+    }
+
+    return result
+  }, [activeEntryInfo, activeRepo, activeRepoRef])
 
   return (
     <div className={cn('flex flex-nowrap items-center gap-1', className)}>
@@ -30,12 +68,13 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
           Repositories
         </div>
         <div>/</div>
-        {currentFileRoutes?.map((route, idx) => {
-          const isRepo = idx === 0 && currentFileRoutes?.length > 1
-          const isActiveFile = idx === currentFileRoutes.length - 1
+        {routes?.map((route, idx) => {
+          const isRepo = idx === 0 && routes?.length > 1
+          const isActiveFile = idx === routes.length - 1
 
+          // todo use link
           return (
-            <React.Fragment key={route.fullPath}>
+            <React.Fragment key={route.href}>
               <div
                 className={cn(
                   'whitespace-nowrap',
@@ -45,11 +84,14 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
                     : 'cursor-pointer text-primary hover:underline',
                   isRepo ? 'hover:underline' : undefined
                 )}
-                onClick={e => updateActivePath(route.fullPath)}
+                onClick={e => {
+                  if (isActiveFile) return
+                  updateActivePath(route.href)
+                }}
               >
                 {route.name}
               </div>
-              {route.file.kind !== 'file' && <div>/</div>}
+              {!isActiveFile && <div>/</div>}
             </React.Fragment>
           )
         })}

--- a/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
@@ -6,11 +6,7 @@ import { cn } from '@/lib/utils'
 import { CopyButton } from '@/components/copy-button'
 
 import { SourceCodeBrowserContext } from './source-code-browser'
-import {
-  generateEntryPath,
-  resolveFileNameFromPath,
-  resolveRepositoryInfoFromPath
-} from './utils'
+import { generateEntryPath, resolveFileNameFromPath } from './utils'
 
 interface FileDirectoryBreadcrumbProps
   extends React.HTMLAttributes<HTMLDivElement> {}
@@ -18,18 +14,9 @@ interface FileDirectoryBreadcrumbProps
 const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
   className
 }) => {
-  const {
-    currentFileRoutes,
-    activePath,
-    activeRepo,
-    activeRepoRef,
-    activeEntryInfo
-  } = React.useContext(SourceCodeBrowserContext)
-  const basename = React.useMemo(
-    () => resolveRepositoryInfoFromPath(activePath)?.basename,
-    [activePath]
-  )
-
+  const { currentFileRoutes, activeRepo, activeRepoRef, activeEntryInfo } =
+    React.useContext(SourceCodeBrowserContext)
+  const basename = activeEntryInfo?.basename
   const routes: Array<{
     name: string
     href: string

--- a/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 
 import { RepositoryKind } from '@/lib/gql/generates/graphql'
 import { cn } from '@/lib/utils'
@@ -19,7 +20,6 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
 }) => {
   const {
     currentFileRoutes,
-    updateActivePath,
     activePath,
     activeRepo,
     activeRepoRef,
@@ -61,36 +61,32 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
   return (
     <div className={cn('flex flex-nowrap items-center gap-1', className)}>
       <div className="flex items-center gap-1 overflow-x-auto leading-8">
-        <div
-          className="cursor-pointer font-medium text-primary hover:underline"
-          onClick={e => updateActivePath(undefined)}
+        <Link
+          className="text-primary cursor-pointer font-medium hover:underline"
+          href="/files"
         >
           Repositories
-        </div>
+        </Link>
         <div>/</div>
         {routes?.map((route, idx) => {
           const isRepo = idx === 0 && routes?.length > 1
           const isActiveFile = idx === routes.length - 1
+          const classname = cn(
+            'whitespace-nowrap',
+            isRepo || isActiveFile ? 'font-bold' : 'font-medium',
+            isActiveFile ? '' : 'text-primary cursor-pointer hover:underline',
+            isRepo ? 'hover:underline' : undefined
+          )
 
-          // todo use link
           return (
             <React.Fragment key={route.href}>
-              <div
-                className={cn(
-                  'whitespace-nowrap',
-                  isRepo || isActiveFile ? 'font-bold' : 'font-medium',
-                  isActiveFile
-                    ? ''
-                    : 'cursor-pointer text-primary hover:underline',
-                  isRepo ? 'hover:underline' : undefined
-                )}
-                onClick={e => {
-                  if (isActiveFile) return
-                  updateActivePath(route.href)
-                }}
-              >
-                {route.name}
-              </div>
+              {isActiveFile ? (
+                <div className={classname}>{route.name}</div>
+              ) : (
+                <Link className={classname} href={`/files/${route.href}`}>
+                  {route.name}
+                </Link>
+              )}
               {!isActiveFile && <div>/</div>}
             </React.Fragment>
           )

--- a/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-breadcrumb.tsx
@@ -36,7 +36,7 @@ const FileDirectoryBreadcrumb: React.FC<FileDirectoryBreadcrumbProps> = ({
         const p = pathSegments.slice(0, i + 1).join('/')
         const name = resolveFileNameFromPath(p)
         result.push({
-          name,
+          name: decodeURIComponent(name),
           href: generateEntryPath(activeRepo, activeRepoRef?.name, p, 'dir')
         })
       }

--- a/ee/tabby-ui/app/files/components/file-directory-view.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-view.tsx
@@ -23,7 +23,7 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
   loading: propsLoading,
   initialized
 }) => {
-  const { activePath, currentFileRoutes, setActivePath, fileTreeData } =
+  const { activePath, currentFileRoutes, updateActivePath, fileTreeData } =
     React.useContext(SourceCodeBrowserContext)
 
   const files = React.useMemo(() => {
@@ -37,11 +37,11 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
   const onClickParent = () => {
     const parentPath =
       currentFileRoutes[currentFileRoutes?.length - 2]?.fullPath
-    setActivePath(parentPath)
+    updateActivePath(parentPath)
   }
 
   const onClickFile = (file: TFileMapItem) => {
-    setActivePath(file.fullPath)
+    updateActivePath(file.fullPath)
   }
 
   return (
@@ -138,11 +138,15 @@ function getCurrentDirFromTree(
     const repos = treeData.map(x => omit(x, 'children')) || []
     return repos
   } else {
-    let { repositorySpecifier = '', basename = '' } =
-      resolveRepositoryInfoFromPath(path)
-    let pathSegments = [repositorySpecifier, ...basename.split('/')].filter(
-      Boolean
-    )
+    let {
+      repositorySpecifier = '',
+      basename = '',
+      rev = ''
+    } = resolveRepositoryInfoFromPath(path)
+    let pathSegments = [
+      `${repositorySpecifier}/${rev}`,
+      ...basename.split('/')
+    ].filter(Boolean)
     let currentNodes: TFileTreeNode[] = treeData
     for (let i = 0; i < pathSegments.length; i++) {
       const path = pathSegments.slice(0, i + 1).join('/')

--- a/ee/tabby-ui/app/files/components/file-directory-view.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-view.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { find, omit } from 'lodash-es'
+import Link from 'next/link'
+import { find, isEmpty, omit } from 'lodash-es'
 
 import { useDebounceValue } from '@/lib/hooks/use-debounce'
 import { cn } from '@/lib/utils'
@@ -10,8 +11,14 @@ import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table'
 import { BlobHeader } from './blob-header'
 import { TFileTreeNode } from './file-tree'
 import { RepositoryKindIcon } from './repository-kind-icon'
-import { SourceCodeBrowserContext, TFileMapItem } from './source-code-browser'
-import { resolveRepositoryInfoFromPath } from './utils'
+import { SourceCodeBrowserContext } from './source-code-browser'
+import {
+  generateEntryPath,
+  getDefaultRepoRef,
+  repositoryMap2List,
+  resolveRepoRef,
+  resolveRepositoryInfoFromPath
+} from './utils'
 
 interface DirectoryViewProps extends React.HTMLAttributes<HTMLDivElement> {
   loading: boolean
@@ -23,50 +30,74 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
   loading: propsLoading,
   initialized
 }) => {
-  const { activePath, currentFileRoutes, updateActivePath, fileTreeData } =
-    React.useContext(SourceCodeBrowserContext)
+  const {
+    activePath,
+    currentFileRoutes,
+    fileTreeData,
+    activeRepo,
+    activeRepoRef,
+    repoMap
+  } = React.useContext(SourceCodeBrowserContext)
 
-  const files = React.useMemo(() => {
+  const files: TFileTreeNode[] = React.useMemo(() => {
+    if (!isEmpty(repoMap) && !activeRepo) {
+      return repositoryMap2List(repoMap).map(repo => {
+        return {
+          file: {
+            basename: repo.name,
+            kind: 'dir'
+          },
+          isRepository: true,
+          repository: repo,
+          fullPath: generateEntryPath(
+            repo,
+            resolveRepoRef(getDefaultRepoRef(repo.refs) ?? 'refs/heads/main')
+              ?.name,
+            '',
+            'dir'
+          ),
+          name: repo.name
+        }
+      })
+    }
+
     return getCurrentDirFromTree(fileTreeData, activePath)
-  }, [fileTreeData, activePath])
+  }, [fileTreeData, activePath, activeRepo, repoMap])
 
   const [loading] = useDebounceValue(propsLoading, 300)
 
   const showParentEntry = currentFileRoutes?.length > 0
-
-  const onClickParent = () => {
-    const parentPath =
-      currentFileRoutes[currentFileRoutes?.length - 2]?.fullPath
-    updateActivePath(parentPath)
-  }
-
-  const onClickFile = (file: TFileMapItem) => {
-    updateActivePath(file.fullPath)
-  }
+  const parentNode = currentFileRoutes[currentFileRoutes?.length - 2]
 
   return (
     <div className={cn('text-base', className)}>
       <BlobHeader blob={undefined} hideBlobActions className="border-0" />
       {loading || !initialized ? (
         <FileTreeSkeleton />
-      ) : fileTreeData?.length ? (
+      ) : files?.length ? (
         <Table>
           <TableBody>
             {showParentEntry && (
-              <TableRow
-                className="cursor-pointer"
-                onClick={e => onClickParent()}
-              >
-                <TableCell className="p-1 px-4">
-                  <div className="flex items-center gap-2">
-                    <div className="shrink-0">
-                      <IconDirectorySolid
-                        style={{ color: 'rgb(84, 174, 255)' }}
-                      />
+              <TableRow className="cursor-pointer">
+                <Link
+                  href={`/files/${generateEntryPath(
+                    activeRepo,
+                    activeRepoRef?.name as string,
+                    parentNode?.file?.basename,
+                    parentNode?.file?.kind
+                  )}`}
+                >
+                  <TableCell className="p-1 px-4">
+                    <div className="flex items-center gap-2">
+                      <div className="shrink-0">
+                        <IconDirectorySolid
+                          style={{ color: 'rgb(84, 174, 255)' }}
+                        />
+                      </div>
+                      <span className="px-1 py-2">..</span>
                     </div>
-                    <span className="px-1 py-2">..</span>
-                  </div>
-                </TableCell>
+                  </TableCell>
+                </Link>
               </TableRow>
             )}
             <>
@@ -95,12 +126,21 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
                             <IconFile />
                           )}
                         </div>
-                        <span
-                          onClick={e => onClickFile(file)}
+                        <Link
+                          href={
+                            isRepository
+                              ? `/files/${file.fullPath}`
+                              : `/files/${generateEntryPath(
+                                  activeRepo ?? file.repository,
+                                  activeRepoRef?.name as string,
+                                  file.file.basename,
+                                  file.file.kind
+                                )}`
+                          }
                           className="cursor-pointer px-1 py-2 hover:text-primary hover:underline"
                         >
                           {file.name}
-                        </span>
+                        </Link>
                       </div>
                     </TableCell>
                   </TableRow>
@@ -138,15 +178,10 @@ function getCurrentDirFromTree(
     const repos = treeData.map(x => omit(x, 'children')) || []
     return repos
   } else {
-    let {
-      repositorySpecifier = '',
-      basename = '',
-      rev = ''
-    } = resolveRepositoryInfoFromPath(path)
-    let pathSegments = [
-      `${repositorySpecifier}/${rev}`,
-      ...basename.split('/')
-    ].filter(Boolean)
+    let { basename = '' } = resolveRepositoryInfoFromPath(path)
+
+    if (!basename) return treeData
+    let pathSegments = basename.split('/')
     let currentNodes: TFileTreeNode[] = treeData
     for (let i = 0; i < pathSegments.length; i++) {
       const path = pathSegments.slice(0, i + 1).join('/')

--- a/ee/tabby-ui/app/files/components/file-directory-view.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-view.tsx
@@ -36,7 +36,8 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
     fileTreeData,
     activeRepo,
     activeRepoRef,
-    repoMap
+    repoMap,
+    activeEntryInfo
   } = React.useContext(SourceCodeBrowserContext)
 
   const files: TFileTreeNode[] = React.useMemo(() => {
@@ -66,28 +67,28 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
 
   const [loading] = useDebounceValue(propsLoading, 300)
 
-  const showParentEntry = currentFileRoutes?.length > 0
+  const showParentEntry = !!activeEntryInfo?.basename
   const parentNode = currentFileRoutes[currentFileRoutes?.length - 2]
 
   return (
     <div className={cn('text-base', className)}>
       <BlobHeader blob={undefined} hideBlobActions className="border-0" />
-      {loading || !initialized ? (
+      {(loading && !files?.length) || !initialized ? (
         <FileTreeSkeleton />
       ) : files?.length ? (
         <Table>
           <TableBody>
             {showParentEntry && (
               <TableRow className="cursor-pointer">
-                <Link
-                  href={`/files/${generateEntryPath(
-                    activeRepo,
-                    activeRepoRef?.name as string,
-                    parentNode?.file?.basename,
-                    parentNode?.file?.kind
-                  )}`}
-                >
-                  <TableCell className="p-1 px-4">
+                <TableCell className="p-1 px-4">
+                  <Link
+                    href={`/files/${generateEntryPath(
+                      activeRepo,
+                      activeRepoRef?.name as string,
+                      parentNode?.file?.basename,
+                      parentNode?.file?.kind
+                    )}`}
+                  >
                     <div className="flex items-center gap-2">
                       <div className="shrink-0">
                         <IconDirectorySolid
@@ -96,8 +97,8 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
                       </div>
                       <span className="px-1 py-2">..</span>
                     </div>
-                  </TableCell>
-                </Link>
+                  </Link>
+                </TableCell>
               </TableRow>
             )}
             <>
@@ -153,8 +154,7 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
         <div className="flex justify-center py-8">
           No indexed repository yet
         </div>
-      ) : // <div>404</div>
-      null}
+      ) : null}
     </div>
   )
 }

--- a/ee/tabby-ui/app/files/components/file-directory-view.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-view.tsx
@@ -153,10 +153,8 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
         <div className="flex justify-center py-8">
           No indexed repository yet
         </div>
-      ) : (
-        // <div>404</div>
-        null
-      )}
+      ) : // <div>404</div>
+      null}
     </div>
   )
 }

--- a/ee/tabby-ui/app/files/components/file-directory-view.tsx
+++ b/ee/tabby-ui/app/files/components/file-directory-view.tsx
@@ -149,10 +149,13 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({
             </>
           </TableBody>
         </Table>
-      ) : (
+      ) : isEmpty(repoMap) ? (
         <div className="flex justify-center py-8">
           No indexed repository yet
         </div>
+      ) : (
+        // <div>404</div>
+        null
       )}
     </div>
   )

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -457,7 +457,7 @@ const HighlightMatches = ({
     <p className="text-muted-foreground">
       {text.split('').map((char, index) => {
         return indicesSet.has(index) ? (
-          <span className="font-semibold text-foreground">{char}</span>
+          <span className="font-semibold text-foreground" key={`${char}_${index}`}>{char}</span>
         ) : (
           char
         )

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -63,8 +63,8 @@ type SearchOption = {
 type RepositoryRefKind = 'branch' | 'tag'
 
 const repositorySearch = graphql(/* GraphQL */ `
-  query RepositorySearch($kind: RepositoryKind!, $id: ID!, $pattern: String!) {
-    repositorySearch(kind: $kind, id: $id, pattern: $pattern) {
+  query RepositorySearch($kind: RepositoryKind!, $id: ID!, $rev: String, $pattern: String!) {
+    repositorySearch(kind: $kind, id: $id, rev: $rev, pattern: $pattern) {
       type
       path
       indices
@@ -114,7 +114,8 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
     variables: {
       kind: repositoryKind as RepositoryKind,
       id: repoId as string,
-      pattern: repositorySearchPattern ?? ''
+      pattern: repositorySearchPattern ?? '',
+      rev: activeRepoRef?.name ? decodeURIComponent(activeRepoRef.name) : undefined
     },
     pause: !repoId || !repositoryKind || !repositorySearchPattern
   })

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -63,7 +63,12 @@ type SearchOption = {
 type RepositoryRefKind = 'branch' | 'tag'
 
 const repositorySearch = graphql(/* GraphQL */ `
-  query RepositorySearch($kind: RepositoryKind!, $id: ID!, $rev: String, $pattern: String!) {
+  query RepositorySearch(
+    $kind: RepositoryKind!
+    $id: ID!
+    $rev: String
+    $pattern: String!
+  ) {
     repositorySearch(kind: $kind, id: $id, rev: $rev, pattern: $pattern) {
       type
       path
@@ -115,7 +120,9 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
       kind: repositoryKind as RepositoryKind,
       id: repoId as string,
       pattern: repositorySearchPattern ?? '',
-      rev: activeRepoRef?.name ? decodeURIComponent(activeRepoRef.name) : undefined
+      rev: activeRepoRef?.name
+        ? decodeURIComponent(activeRepoRef.name)
+        : undefined
     },
     pause: !repoId || !repositoryKind || !repositorySearchPattern
   })
@@ -457,7 +464,12 @@ const HighlightMatches = ({
     <p className="text-muted-foreground">
       {text.split('').map((char, index) => {
         return indicesSet.has(index) ? (
-          <span className="font-semibold text-foreground" key={`${char}_${index}`}>{char}</span>
+          <span
+            className="font-semibold text-foreground"
+            key={`${char}_${index}`}
+          >
+            {char}
+          </span>
         ) : (
           char
         )

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useContext } from 'react'
+import { isNil } from 'lodash-es'
 import { useQuery } from 'urql'
 
 import { graphql } from '@/lib/gql/generates'
@@ -128,6 +129,16 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
     },
     pause: !repoId || !repositoryKind || !repositorySearchPattern
   })
+
+  const onSelectRef = (ref: string) => {
+    if (isNil(ref)) return
+    const nextRev = resolveRepoRef(ref)?.name
+    const { basename, repositorySpecifier } =
+      resolveRepositoryInfoFromPath(activePath)
+    // todo double check
+    // todo fetch
+    updateActivePath(`${repositorySpecifier}/${nextRev}/${basename}`)
+  }
 
   React.useEffect(() => {
     const _options =
@@ -308,7 +319,6 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
             align="start"
             side="bottom"
           >
-            {/* <div className='px-2 py-1'>Switch branches/tags</div> */}
             <Command className="transition-all">
               <CommandInput
                 placeholder={
@@ -334,17 +344,17 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
                       key={ref.ref ?? refIndex}
                       onSelect={() => {
                         setRefSelectVisible(false)
-                        // todo
+                        onSelectRef(ref.ref)
                       }}
                     >
-                      {/* <IconCheck
-                          className={cn(
-                            'mr-2',
-                            ref.node.id === field.value
-                              ? 'opacity-100'
-                              : 'opacity-0'
-                          )}
-                        /> */}
+                      <IconCheck
+                        className={cn(
+                          'mr-2',
+                          !!ref?.name && ref.name === activeRepoRef?.name
+                            ? 'opacity-100'
+                            : 'opacity-0'
+                        )}
+                      />
                       {ref.name}
                     </CommandItem>
                   ))}

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -137,13 +137,8 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
     const nextRev = resolveRepoRef(ref)?.name ?? 'main'
     const { basename = '' } = resolveRepositoryInfoFromPath(activePath)
     const kind = fileMap?.[basename]?.file?.kind ?? 'dir'
-    // updateActivePath(`${repositorySpecifier}/${nextRev}/${basename}`, {
-    //   shouldFetchAllEntries: true
-    // })
-    updateActivePath(generateEntryPath(activeRepo, nextRev, basename, kind), {
-      // todo
-      shouldFetchAllEntries: true
-    })
+
+    updateActivePath(generateEntryPath(activeRepo, nextRev, basename, kind))
   }
 
   React.useEffect(() => {
@@ -157,7 +152,7 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
   }, [repositorySearchData?.repositorySearch])
 
   const onSelectRepo = (path: string) => {
-    updateActivePath(path, { shouldFetchAllEntries: true })
+    updateActivePath(path)
   }
 
   const onInputValueChange = useDebounceCallback((v: string | undefined) => {
@@ -179,10 +174,11 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
     const path = value.path
     if (!path) return
 
+    // todo generate entry path
     const fullPath = `${repositorySpecifier}/${
       activeRepoRef?.name ?? ''
     }/${path}`
-    await updateActivePath(fullPath, { shouldFetchAllEntries: true })
+    await updateActivePath(fullPath)
   }
 
   // shortcut 't'

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -54,7 +54,6 @@ import {
   getDefaultRepoRef,
   repositoryMap2List,
   resolveRepoRef,
-  resolveRepositoryInfoFromPath,
   resolveRepoSpecifierFromRepoInfo
 } from './utils'
 
@@ -95,7 +94,8 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
     activeRepo,
     activeRepoRef,
     fileMap,
-    repoMap
+    repoMap,
+    activeEntryInfo
   } = useContext(SourceCodeBrowserContext)
   const repoList = React.useMemo(() => {
     return repositoryMap2List(repoMap).map(repo => {
@@ -111,7 +111,7 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
     activeRepoRef?.kind ?? 'branch'
   )
   const { repositoryKind, repositoryName, repositorySpecifier } =
-    resolveRepositoryInfoFromPath(activePath)
+    activeEntryInfo
   const repoId = activeRepo?.id
   const refs = activeRepo?.refs
   const formattedRefs = React.useMemo(() => {
@@ -147,7 +147,7 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
   const onSelectRef = (ref: string) => {
     if (isNil(ref)) return
     const nextRev = resolveRepoRef(ref)?.name ?? 'main'
-    const { basename = '' } = resolveRepositoryInfoFromPath(activePath)
+    const { basename = '' } = activeEntryInfo
     const kind = fileMap?.[basename]?.file?.kind ?? 'dir'
 
     // clear repository search
@@ -168,7 +168,7 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
   const onSelectRepo = (repoSpecifier: string) => {
     const repo = repoList.find(o => o.repoSpecifier === repoSpecifier)?.repo
     if (repo) {
-      const path = `${repoSpecifier}/tree/${
+      const path = `${repoSpecifier}/-/tree/${
         resolveRepoRef(getDefaultRepoRef(repo.refs)).name
       }`
       // clear repository search

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -49,7 +49,11 @@ import {
 
 import { RepositoryKindIcon } from './repository-kind-icon'
 import { SourceCodeBrowserContext } from './source-code-browser'
-import { resolveRepoRef, resolveRepositoryInfoFromPath } from './utils'
+import {
+  generateEntryPath,
+  resolveRepoRef,
+  resolveRepositoryInfoFromPath
+} from './utils'
 
 interface FileTreeHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 
@@ -87,7 +91,8 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
     updateActivePath,
     initialized,
     activeRepo,
-    activeRepoRef
+    activeRepoRef,
+    fileMap
   } = useContext(SourceCodeBrowserContext)
   const [refSelectVisible, setRefSelectVisible] = React.useState(false)
   const [activeRefKind, setActiveRefKind] = React.useState<RepositoryRefKind>(
@@ -129,10 +134,14 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
 
   const onSelectRef = (ref: string) => {
     if (isNil(ref)) return
-    const nextRev = resolveRepoRef(ref)?.name
-    const { basename, repositorySpecifier } =
-      resolveRepositoryInfoFromPath(activePath)
-    updateActivePath(`${repositorySpecifier}/${nextRev}/${basename}`, {
+    const nextRev = resolveRepoRef(ref)?.name ?? 'main'
+    const { basename = '' } = resolveRepositoryInfoFromPath(activePath)
+    const kind = fileMap?.[basename]?.file?.kind ?? 'dir'
+    // updateActivePath(`${repositorySpecifier}/${nextRev}/${basename}`, {
+    //   shouldFetchAllEntries: true
+    // })
+    updateActivePath(generateEntryPath(activeRepo, nextRev, basename, kind), {
+      // todo
       shouldFetchAllEntries: true
     })
   }

--- a/ee/tabby-ui/app/files/components/file-tree-panel.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-panel.tsx
@@ -14,7 +14,7 @@ interface FileTreePanelProps extends React.HTMLAttributes<HTMLDivElement> {}
 export const FileTreePanel: React.FC<FileTreePanelProps> = () => {
   const {
     activePath,
-    setActivePath,
+    updateActivePath,
     expandedKeys,
     updateFileMap,
     toggleExpandedKey,
@@ -25,13 +25,14 @@ export const FileTreePanel: React.FC<FileTreePanelProps> = () => {
   const containerRef = React.useRef<HTMLDivElement>(null)
   const scrollTop = useScrollTop(containerRef, 200)
   const onSelectTreeNode = (treeNode: TFileTreeNode) => {
-    setActivePath(treeNode.fullPath)
+    updateActivePath(treeNode.fullPath)
   }
 
   const currentFileTreeData = React.useMemo(() => {
-    const { repositorySpecifier } = resolveRepositoryInfoFromPath(activePath)
+    const { repositorySpecifier, rev } =
+      resolveRepositoryInfoFromPath(activePath)
     const repo = fileTreeData.find(
-      treeNode => treeNode.fullPath === repositorySpecifier
+      treeNode => treeNode.fullPath === `${repositorySpecifier}/${rev}`
     )
     return repo?.children ?? []
   }, [activePath, fileTreeData])

--- a/ee/tabby-ui/app/files/components/file-tree-panel.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-panel.tsx
@@ -9,9 +9,13 @@ import { FileTreeHeader } from './file-tree-header'
 import { SourceCodeBrowserContext } from './source-code-browser'
 import { generateEntryPath } from './utils'
 
-interface FileTreePanelProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface FileTreePanelProps extends React.HTMLAttributes<HTMLDivElement> {
+  fetchingTreeEntries: boolean
+}
 
-export const FileTreePanel: React.FC<FileTreePanelProps> = () => {
+export const FileTreePanel: React.FC<FileTreePanelProps> = ({
+  fetchingTreeEntries
+}) => {
   const {
     activePath,
     updateActivePath,
@@ -36,18 +40,6 @@ export const FileTreePanel: React.FC<FileTreePanelProps> = () => {
     updateActivePath(nextPath)
   }
 
-  // const currentFileTreeData = React.useMemo(() => {
-  //   const { repositorySpecifier, rev, basename } =
-  //     resolveRepositoryInfoFromPath(activePath)
-
-  //   if (!basename) return fileTreeData
-
-  //   const repo = fileTreeData.find(
-  //     treeNode => treeNode.fullPath === basename
-  //   )
-  //   return repo?.children ?? []
-  // }, [activePath, fileTreeData])
-
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <FileTreeHeader className="shrink-0 px-4 pb-3" />
@@ -64,6 +56,7 @@ export const FileTreePanel: React.FC<FileTreePanelProps> = () => {
           toggleExpandedKey={toggleExpandedKey}
           initialized={initialized}
           fileTreeData={fileTreeData}
+          fetchingTreeEntries={fetchingTreeEntries}
         />
       </div>
     </div>

--- a/ee/tabby-ui/app/files/components/file-tree-panel.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-panel.tsx
@@ -7,7 +7,7 @@ import { useScrollTop } from '@/lib/hooks/use-scroll-top'
 import { FileTree, TFileTreeNode } from './file-tree'
 import { FileTreeHeader } from './file-tree-header'
 import { SourceCodeBrowserContext } from './source-code-browser'
-import { resolveRepositoryInfoFromPath } from './utils'
+import { generateEntryPath } from './utils'
 
 interface FileTreePanelProps extends React.HTMLAttributes<HTMLDivElement> {}
 
@@ -20,22 +20,33 @@ export const FileTreePanel: React.FC<FileTreePanelProps> = () => {
     toggleExpandedKey,
     initialized,
     fileTreeData,
-    fileMap
+    fileMap,
+    activeRepo,
+    activeRepoRef
   } = React.useContext(SourceCodeBrowserContext)
   const containerRef = React.useRef<HTMLDivElement>(null)
   const scrollTop = useScrollTop(containerRef, 200)
   const onSelectTreeNode = (treeNode: TFileTreeNode) => {
-    updateActivePath(treeNode.fullPath)
+    const nextPath = generateEntryPath(
+      activeRepo,
+      activeRepoRef?.name as string,
+      treeNode.file.basename,
+      treeNode.file.kind
+    )
+    updateActivePath(nextPath)
   }
 
-  const currentFileTreeData = React.useMemo(() => {
-    const { repositorySpecifier, rev } =
-      resolveRepositoryInfoFromPath(activePath)
-    const repo = fileTreeData.find(
-      treeNode => treeNode.fullPath === `${repositorySpecifier}/${rev}`
-    )
-    return repo?.children ?? []
-  }, [activePath, fileTreeData])
+  // const currentFileTreeData = React.useMemo(() => {
+  //   const { repositorySpecifier, rev, basename } =
+  //     resolveRepositoryInfoFromPath(activePath)
+
+  //   if (!basename) return fileTreeData
+
+  //   const repo = fileTreeData.find(
+  //     treeNode => treeNode.fullPath === basename
+  //   )
+  //   return repo?.children ?? []
+  // }, [activePath, fileTreeData])
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -52,7 +63,7 @@ export const FileTreePanel: React.FC<FileTreePanelProps> = () => {
           expandedKeys={expandedKeys}
           toggleExpandedKey={toggleExpandedKey}
           initialized={initialized}
-          fileTreeData={currentFileTreeData}
+          fileTreeData={fileTreeData}
         />
       </div>
     </div>

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -264,9 +264,9 @@ const DirectoryTreeNode: React.FC<DirectoryTreeNodeProps> = ({
   const { data, isLoading }: SWRResponse<ResolveEntriesResponse> =
     useSWRImmutable(
       shouldFetchChildren
-        ? `/repositories/${activeRepoIdentity}/rev/${encodeURIComponent(
-            rev ?? ''
-          )}/${encodeURIComponentIgnoringSlash(basename)}`
+        ? `/repositories/${activeRepoIdentity}/rev/${
+            rev ?? 'main'
+          }/${encodeURIComponentIgnoringSlash(basename)}`
         : null,
       fetcher,
       {

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -230,9 +230,7 @@ const DirectoryTreeNode: React.FC<DirectoryTreeNodeProps> = ({
   level,
   root
 }) => {
-  const { activeRepo, activeRepoRef } = React.useContext(
-    SourceCodeBrowserContext
-  )
+  const { activeRepo } = React.useContext(SourceCodeBrowserContext)
   const {
     fileMap,
     updateFileMap,

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -264,11 +264,9 @@ const DirectoryTreeNode: React.FC<DirectoryTreeNodeProps> = ({
   const { data, isLoading }: SWRResponse<ResolveEntriesResponse> =
     useSWRImmutable(
       shouldFetchChildren
-        ? encodeURIComponentIgnoringSlash(
-            `/repositories/${activeRepoIdentity}/rev/${encodeURIComponent(
-              rev ?? ''
-            )}/${basename}`
-          )
+        ? `/repositories/${activeRepoIdentity}/rev/${encodeURIComponent(
+            rev ?? ''
+          )}/${encodeURIComponentIgnoringSlash(basename)}`
         : null,
       fetcher,
       {

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -46,6 +46,7 @@ interface FileTreeProps extends React.HTMLAttributes<HTMLDivElement> {
   toggleExpandedKey: (key: string) => void
   initialized: boolean
   fileTreeData: TFileTreeNode[]
+  fetchingTreeEntries: boolean
 }
 
 interface FileTreeProviderProps extends FileTreeProps {}
@@ -59,6 +60,7 @@ type FileTreeContextValue = {
   toggleExpandedKey: (key: string) => void
   activePath: string | undefined
   initialized: boolean
+  fetchingTreeEntries: boolean
 }
 
 type DirectoryTreeNodeProps = {
@@ -97,7 +99,8 @@ const FileTreeProvider: React.FC<
   expandedKeys,
   toggleExpandedKey,
   initialized,
-  fileTreeData
+  fileTreeData,
+  fetchingTreeEntries
 }) => {
   return (
     <FileTreeContext.Provider
@@ -109,7 +112,8 @@ const FileTreeProvider: React.FC<
         activePath,
         fileMap,
         updateFileMap,
-        initialized
+        initialized,
+        fetchingTreeEntries
       }}
     >
       {children}
@@ -340,25 +344,13 @@ const DirectoryTreeNode: React.FC<DirectoryTreeNodeProps> = ({
 }
 
 const FileTreeRenderer: React.FC = () => {
-  const { activeEntryInfo, repoMap } = React.useContext(
-    SourceCodeBrowserContext
-  )
-  const { initialized, activePath, fileMap, fileTreeData } =
+  const { repoMap } = React.useContext(SourceCodeBrowserContext)
+  const { initialized, activePath, fileTreeData, fetchingTreeEntries } =
     React.useContext(FileTreeContext)
   const { repositorySpecifier } = resolveRepositoryInfoFromPath(activePath)
 
-  // todo
   const hasSelectedRepo = !!repositorySpecifier
   const hasNoRepoEntries = hasSelectedRepo && !fileTreeData?.length
-  const activeEntryPath = activeEntryInfo?.basename
-  // const fetchingRepoEntries =
-  //   activeEntryPath &&
-  //   fileMap?.[activeEntryPath]?.isRepository &&
-  //   !fileMap?.[activeEntryPath]?.treeExpanded
-  const fetchingRepoEntries =
-    activeEntryPath &&
-    fileMap?.[activeEntryPath]?.isRepository &&
-    !fileMap?.[activeEntryPath]?.treeExpanded
 
   if (!initialized) return <FileTreeSkeleton />
 
@@ -374,7 +366,7 @@ const FileTreeRenderer: React.FC = () => {
   }
 
   if (hasNoRepoEntries) {
-    if (fetchingRepoEntries) {
+    if (fetchingTreeEntries) {
       return <FileTreeSkeleton />
     }
 

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -48,7 +48,7 @@ interface FileTreeProps extends React.HTMLAttributes<HTMLDivElement> {
   fileTreeData: TFileTreeNode[]
 }
 
-interface FileTreeProviderProps extends FileTreeProps { }
+interface FileTreeProviderProps extends FileTreeProps {}
 
 type FileTreeContextValue = {
   fileMap: TFileMap
@@ -99,23 +99,23 @@ const FileTreeProvider: React.FC<
   initialized,
   fileTreeData
 }) => {
-    return (
-      <FileTreeContext.Provider
-        value={{
-          onSelectTreeNode,
-          fileTreeData,
-          expandedKeys,
-          toggleExpandedKey,
-          activePath,
-          fileMap,
-          updateFileMap,
-          initialized
-        }}
-      >
-        {children}
-      </FileTreeContext.Provider>
-    )
-  }
+  return (
+    <FileTreeContext.Provider
+      value={{
+        onSelectTreeNode,
+        fileTreeData,
+        expandedKeys,
+        toggleExpandedKey,
+        activePath,
+        fileMap,
+        updateFileMap,
+        initialized
+      }}
+    >
+      {children}
+    </FileTreeContext.Provider>
+  )
+}
 
 const GridArea: React.FC<{ level: number }> = ({ level }) => {
   const items = React.useMemo(() => {

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -48,7 +48,7 @@ interface FileTreeProps extends React.HTMLAttributes<HTMLDivElement> {
   fileTreeData: TFileTreeNode[]
 }
 
-interface FileTreeProviderProps extends FileTreeProps {}
+interface FileTreeProviderProps extends FileTreeProps { }
 
 type FileTreeContextValue = {
   fileMap: TFileMap
@@ -99,23 +99,23 @@ const FileTreeProvider: React.FC<
   initialized,
   fileTreeData
 }) => {
-  return (
-    <FileTreeContext.Provider
-      value={{
-        onSelectTreeNode,
-        fileTreeData,
-        expandedKeys,
-        toggleExpandedKey,
-        activePath,
-        fileMap,
-        updateFileMap,
-        initialized
-      }}
-    >
-      {children}
-    </FileTreeContext.Provider>
-  )
-}
+    return (
+      <FileTreeContext.Provider
+        value={{
+          onSelectTreeNode,
+          fileTreeData,
+          expandedKeys,
+          toggleExpandedKey,
+          activePath,
+          fileMap,
+          updateFileMap,
+          initialized
+        }}
+      >
+        {children}
+      </FileTreeContext.Provider>
+    )
+  }
 
 const GridArea: React.FC<{ level: number }> = ({ level }) => {
   const items = React.useMemo(() => {
@@ -244,7 +244,8 @@ const DirectoryTreeNode: React.FC<DirectoryTreeNodeProps> = ({
   const initialized = React.useRef(false)
 
   const basename = root ? '' : node.file.basename
-  const expanded = expandedKeys.has(node.fullPath)
+  // const expanded = expandedKeys.has(node.fullPath)
+  const expanded = expandedKeys.has(basename)
   const shouldFetchChildren =
     node.file.kind === 'dir' &&
     !fileMap?.[node.fullPath]?.treeExpanded &&

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -22,11 +22,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 
 import { SourceCodeBrowserContext, TFileMap } from './source-code-browser'
-import {
-  resolveFileNameFromPath,
-  resolveRepositoryInfoFromPath,
-  toEntryRequestUrl
-} from './utils'
+import { resolveFileNameFromPath, toEntryRequestUrl } from './utils'
 
 type TFileTreeNode = {
   name: string
@@ -344,10 +340,12 @@ const DirectoryTreeNode: React.FC<DirectoryTreeNodeProps> = ({
 }
 
 const FileTreeRenderer: React.FC = () => {
-  const { repoMap } = React.useContext(SourceCodeBrowserContext)
-  const { initialized, activePath, fileTreeData, fetchingTreeEntries } =
+  const { repoMap, activeEntryInfo } = React.useContext(
+    SourceCodeBrowserContext
+  )
+  const { initialized, fileTreeData, fetchingTreeEntries } =
     React.useContext(FileTreeContext)
-  const { repositorySpecifier } = resolveRepositoryInfoFromPath(activePath)
+  const { repositorySpecifier } = activeEntryInfo
 
   const hasSelectedRepo = !!repositorySpecifier
   const hasNoRepoEntries = hasSelectedRepo && !fileTreeData?.length

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -144,7 +144,6 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
     QuickActionEventPayload | undefined
   >()
 
-  // todo rename
   const fetchAllEntries = React.useCallback(
     async (fullPath: string) => {
       if (!fullPath) return
@@ -159,7 +158,6 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
           repositorySpecifier ? repoMap?.[repositorySpecifier] : undefined
         )
         const expandedDirs = getDirectoriesFromBasename(basename)
-
         const patchMap: TFileMap = {}
         if (entries.length) {
           forEach(repoMap, (repo, repoKey) => {
@@ -187,7 +185,7 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
           }
         }
         const expandedKeys = expandedDirs.map(dir =>
-          [repositorySpecifier, dir].filter(Boolean).join('/')
+          [repositorySpecifier, rev, dir].filter(Boolean).join('/')
         )
         if (patchMap) {
           setFileMap(patchMap)
@@ -468,8 +466,6 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
       const { patchMap, expandedKeys, repos } = await getInitialFileData(
         activePath
       )
-      // todo if no rev, set default rev
-
       const redirect_filepath = searchParams.get('redirect_filepath')
       const redirect_git_url = searchParams.get('redirect_git_url')
       const line = searchParams.get('line')
@@ -739,7 +735,7 @@ async function getInitialFileData(path?: string) {
       }
     }
     const expandedKeys = initialExpandedDirs.map(dir =>
-      [resolveRepoSpecifierFromRepoInfo(initialRepo), dir]
+      [resolveRepoSpecifierFromRepoInfo(initialRepo), rev, dir]
         .filter(Boolean)
         .join('/')
     )

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -470,7 +470,6 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
       const redirect_git_url = searchParams.get('redirect_git_url')
       const line = searchParams.get('line')
 
-      // todo need ref info
       if (repos?.length && redirect_filepath && redirect_git_url) {
         // get repo from repos and redirect_git_url
         const targetRepo = repos.find(repo => repo.gitUrl === redirect_git_url)
@@ -488,7 +487,6 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
         }
       }
 
-      // todo if there's no rev, set default rev, should make a function to do it
       // By default, selecting the first repository if initialPath is empty
       if (repos?.length && !activePath) {
         const targetRepo = repos?.[0]

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -112,13 +112,12 @@ type SourceCodeBrowserContextValue = {
   isChatEnabled: boolean | undefined
   activeRepo: RepositoryItem | undefined
   activeRepoRef:
-  | { kind?: 'branch' | 'tag'; name?: string; ref: string }
-  | undefined
+    | { kind?: 'branch' | 'tag'; name?: string; ref: string }
+    | undefined
   isPathInitialized: boolean
   activeEntryInfo: ReturnType<typeof resolveRepositoryInfoFromPath>
   fetchingTreeEntries: boolean
   setFetchingTreeEntries: React.Dispatch<React.SetStateAction<boolean>>
-
 }
 
 const SourceCodeBrowserContext =
@@ -158,7 +157,7 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
       const { repositorySpecifier, basename, rev } =
         resolveRepositoryInfoFromPath(fullPath)
       const { repositorySpecifier: prevRepositorySpecifier, rev: prevRev } =
-      resolveRepositoryInfoFromPath(prevActivePath.current)
+        resolveRepositoryInfoFromPath(prevActivePath.current)
       try {
         setFetchingTreeEntries(true)
         // fetch dirs
@@ -183,7 +182,10 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
         // todo remove ''
         const expandedKeys = expandedDirs.filter(Boolean)
         if (patchMap) {
-          if (repositorySpecifier !== prevRepositorySpecifier || rev !== prevRev) {
+          if (
+            repositorySpecifier !== prevRepositorySpecifier ||
+            rev !== prevRev
+          ) {
             setFileMap(patchMap)
           } else {
             setFileMap(prev => ({
@@ -329,7 +331,6 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
     if (activePath) {
       update(activePath)
     }
-
   }, [activeEntryInfo, repoMap])
 
   return (
@@ -391,7 +392,7 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
     activeRepoRef,
     isPathInitialized,
     activeEntryInfo,
-    fetchingTreeEntries,
+    fetchingTreeEntries
   } = React.useContext(SourceCodeBrowserContext)
   const { searchParams } = useRouterStuff()
   const activeEntryPath = activeEntryInfo?.basename
@@ -416,40 +417,47 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
 
     const isDir = activeEntryInfo?.viewMode === 'tree'
     return isDir && activeEntryPath && !fileMap?.[activeEntryPath]?.treeExpanded
-  }, [activeEntryInfo?.viewMode, activeEntryPath, fileMap, initialized, fetchingTreeEntries])
+  }, [
+    activeEntryInfo?.viewMode,
+    activeEntryPath,
+    fileMap,
+    initialized,
+    fetchingTreeEntries
+  ])
 
   // fetch raw file
   // todo handle raw file error
-  const { data: rawFileResponse, isLoading: fetchingRawFile, error: rawFileError } =
-    useSWRImmutable<{
-      blob?: Blob
-      contentLength?: number
-    }>(
-      isBlobMode
-        ? toEntryRequestUrl(activeRepo, activeRepoRef?.name, activeBasename)
-        : null,
-      (url: string) =>
-        fetcher(url, {
-          responseFormatter: async response => {
-            if (!response.ok) return undefined
+  const {
+    data: rawFileResponse,
+    isLoading: fetchingRawFile,
+    error: rawFileError
+  } = useSWRImmutable<{
+    blob?: Blob
+    contentLength?: number
+  }>(
+    isBlobMode
+      ? toEntryRequestUrl(activeRepo, activeRepoRef?.name, activeBasename)
+      : null,
+    (url: string) =>
+      fetcher(url, {
+        responseFormatter: async response => {
+          if (!response.ok) return undefined
 
-            const contentLength = toNumber(
-              response.headers.get('Content-Length')
-            )
-            // todo abort big size request and truncate
-            const blob = await response.blob()
-            return {
-              contentLength,
-              blob
-            }
-          },
-          errorHandler(response) {
-              if (!response?.ok) {
-                throw new Error()
-              }
-          },
-        })
-    )
+          const contentLength = toNumber(response.headers.get('Content-Length'))
+          // todo abort big size request and truncate
+          const blob = await response.blob()
+          return {
+            contentLength,
+            blob
+          }
+        },
+        errorHandler(response) {
+          if (!response?.ok) {
+            throw new Error()
+          }
+        }
+      })
+  )
 
   const fileBlob = rawFileResponse?.blob
   const contentLength = rawFileResponse?.contentLength

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -514,6 +514,28 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
   }, [activePath, isBlobMode, fileBlob])
 
   React.useEffect(() => {
+    if (chatSideBarVisible) {
+      chatSideBarPanelRef.current?.expand()
+      chatSideBarPanelRef.current?.resize(chatSideBarPanelSize)
+    } else {
+      chatSideBarPanelRef.current?.collapse()
+    }
+  }, [chatSideBarVisible])
+
+  React.useEffect(() => {
+    if (!(fetchingRawFile || fetchingTreeEntries)) return
+
+    const { repositorySpecifier, rev } = activeEntryInfo
+    const { repositorySpecifier: prevRepositorySpecifier, rev: prevRev } =
+      resolveRepositoryInfoFromPath(prevActivePath.current)
+    if (repositorySpecifier !== prevRepositorySpecifier || rev !== prevRev) {
+      // cleanup cache
+      updateFileMap({}, true)
+      setExpandedKeys(new Set())
+    }
+  }, [activeEntryInfo])
+
+  React.useEffect(() => {
     const onCallCompletion = (data: QuickActionEventPayload) => {
       setChatSideBarVisible(true)
       setPendingEvent(data)
@@ -524,15 +546,6 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
       emitter.off('code_browser_quick_action', onCallCompletion)
     }
   }, [])
-
-  React.useEffect(() => {
-    if (chatSideBarVisible) {
-      chatSideBarPanelRef.current?.expand()
-      chatSideBarPanelRef.current?.resize(chatSideBarPanelSize)
-    } else {
-      chatSideBarPanelRef.current?.collapse()
-    }
-  }, [chatSideBarVisible])
 
   return (
     <ResizablePanelGroup

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -200,27 +200,25 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
 
   const activeRepo = React.useMemo(() => {
     const { repositoryKind, repositoryName, repositorySpecifier } =
-      resolveRepositoryInfoFromPath(activePath)
+      activeEntryInfo
     if (!repositoryKind || !repositoryName) return undefined
     return repositorySpecifier ? repoMap[repositorySpecifier] : undefined
-  }, [activePath, repoMap])
+  }, [repoMap, activeEntryInfo])
 
   const activeRepoRef = React.useMemo(() => {
-    if (!activePath || !activeRepo) return undefined
-    const rev = decodeURIComponent(
-      resolveRepositoryInfoFromPath(activePath)?.rev ?? ''
-    )
+    if (!activeEntryInfo || !activeRepo) return undefined
+    const rev = decodeURIComponent(activeEntryInfo?.rev ?? '')
     const activeRepoRef = activeRepo.refs?.find(
       ref => ref === `refs/heads/${rev}` || ref === `refs/tags/${rev}`
     )
     if (activeRepoRef) {
       return resolveRepoRef(activeRepoRef)
     }
-  }, [activePath, activeRepo])
+  }, [activeEntryInfo, activeRepo])
 
   const currentFileRoutes = React.useMemo(() => {
     if (!activePath) return []
-    const { basename = '' } = resolveRepositoryInfoFromPath(activePath)
+    const { basename = '' } = activeEntryInfo
     let result: TFileMapItem[] = [
       {
         file: {
@@ -240,7 +238,7 @@ const SourceCodeBrowserContextProvider: React.FC<PropsWithChildren> = ({
       result.push(fileMap?.[p])
     }
     return compact(result)
-  }, [activePath, fileMap])
+  }, [activePath, fileMap, activeEntryInfo])
 
   React.useEffect(() => {
     const regex = /^\/files\/(.*)/

--- a/ee/tabby-ui/app/files/components/text-file-view.tsx
+++ b/ee/tabby-ui/app/files/components/text-file-view.tsx
@@ -79,7 +79,7 @@ export const TextFileView: React.FC<TextFileViewProps> = ({
         )}
       </BlobHeader>
       <div className="rounded-b-lg border border-t-0 py-2">
-        <Suspense fallback={<ListSkeleton />}>
+        <Suspense fallback={<ListSkeleton className="p-2" />}>
           {showMarkdown ? (
             <MarkdownView value={value} />
           ) : (

--- a/ee/tabby-ui/app/files/components/utils.ts
+++ b/ee/tabby-ui/app/files/components/utils.ts
@@ -155,9 +155,8 @@ function encodeURIComponentIgnoringSlash(str: string) {
 function resolveRepoRef(ref: string): {
   kind?: 'branch' | 'tag'
   name?: string
-  ref?: string
+  ref: string
 } {
-  if (!ref) return {}
   const regx = /refs\/(\w+)\/(.*)/
   const match = ref.match(regx)
   if (match) {

--- a/ee/tabby-ui/app/files/components/utils.ts
+++ b/ee/tabby-ui/app/files/components/utils.ts
@@ -111,9 +111,9 @@ async function fetchEntriesFromPath(
 ) {
   if (!path || !repository) return []
 
-  const { basename, rev } = resolveRepositoryInfoFromPath(path)
+  const { basename, rev, viewMode } = resolveRepositoryInfoFromPath(path)
   // array of dir basename that do not include the repo name.
-  const directoryPaths = getDirectoriesFromBasename(basename)
+  const directoryPaths = getDirectoriesFromBasename(basename, viewMode === 'tree')
   // fetch all dirs from path
   const requests: Array<() => Promise<ResolveEntriesResponse>> =
     directoryPaths.map(

--- a/ee/tabby-ui/app/files/components/utils.ts
+++ b/ee/tabby-ui/app/files/components/utils.ts
@@ -113,7 +113,10 @@ async function fetchEntriesFromPath(
 
   const { basename, rev, viewMode } = resolveRepositoryInfoFromPath(path)
   // array of dir basename that do not include the repo name.
-  const directoryPaths = getDirectoriesFromBasename(basename, viewMode === 'tree')
+  const directoryPaths = getDirectoriesFromBasename(
+    basename,
+    viewMode === 'tree'
+  )
   // fetch all dirs from path
   const requests: Array<() => Promise<ResolveEntriesResponse>> =
     directoryPaths.map(

--- a/ee/tabby-ui/app/files/components/utils.ts
+++ b/ee/tabby-ui/app/files/components/utils.ts
@@ -210,7 +210,7 @@ function generateEntryPath(
   const finalRev = rev ?? 'main'
   return `${specifier}/-/${
     kind === 'dir' ? 'tree' : 'blob'
-  }/${finalRev}/${basename}`
+  }/${finalRev}/${encodeURIComponentIgnoringSlash(basename)}`
 }
 
 function toEntryRequestUrl(
@@ -224,9 +224,7 @@ function toEntryRequestUrl(
 
   const activeRepoIdentity = `${getProviderVariantFromKind(kind)}/${repoId}`
 
-  return `/repositories/${activeRepoIdentity}/rev/${rev}/${encodeURIComponentIgnoringSlash(
-    basename ?? ''
-  )}`
+  return `/repositories/${activeRepoIdentity}/rev/${rev}/${basename ?? ''}`
 }
 
 export {

--- a/ee/tabby-ui/components/topbar-progress-indicator.tsx
+++ b/ee/tabby-ui/components/topbar-progress-indicator.tsx
@@ -12,7 +12,7 @@ interface TopbarProgressProviderProps {
 
 interface TopbarProgressContextValue {
   progress: boolean
-  setProgress: React.Dispatch<React.SetStateAction<boolean>>
+  setProgress: (v: boolean) => void
 }
 
 const TopbarProgressContext = React.createContext<TopbarProgressContextValue>(
@@ -23,6 +23,14 @@ const TopbarProgressProvider: React.FC<TopbarProgressProviderProps> = ({
   children
 }) => {
   const [progress, setProgress] = React.useState(false)
+  const updateProgress = React.useCallback(
+    (v: boolean) => {
+      if (v !== progress) {
+        setProgress(v)
+      }
+    },
+    [progress, setProgress]
+  )
   const [debouncedProgress] = useDebounceValue(progress, 300, { leading: true })
   const { theme } = useTheme()
   React.useEffect(() => {
@@ -36,7 +44,7 @@ const TopbarProgressProvider: React.FC<TopbarProgressProviderProps> = ({
 
   return (
     <TopbarProgressContext.Provider
-      value={{ progress: debouncedProgress, setProgress }}
+      value={{ progress: debouncedProgress, setProgress: updateProgress }}
     >
       {debouncedProgress && <TopBarProgress />}
       {children}

--- a/ee/tabby-ui/components/topbar-progress-indicator.tsx
+++ b/ee/tabby-ui/components/topbar-progress-indicator.tsx
@@ -44,7 +44,7 @@ const TopbarProgressProvider: React.FC<TopbarProgressProviderProps> = ({
 
   return (
     <TopbarProgressContext.Provider
-      value={{ progress: debouncedProgress, setProgress: updateProgress }}
+      value={{ progress: debouncedProgress, setProgress }}
     >
       {debouncedProgress && <TopBarProgress />}
       {children}

--- a/ee/tabby-ui/components/topbar-progress-indicator.tsx
+++ b/ee/tabby-ui/components/topbar-progress-indicator.tsx
@@ -23,15 +23,7 @@ const TopbarProgressProvider: React.FC<TopbarProgressProviderProps> = ({
   children
 }) => {
   const [progress, setProgress] = React.useState(false)
-  const updateProgress = React.useCallback(
-    (v: boolean) => {
-      if (v !== progress) {
-        setProgress(v)
-      }
-    },
-    [progress, setProgress]
-  )
-  const [debouncedProgress] = useDebounceValue(progress, 300, { leading: true })
+  const [debouncedProgress] = useDebounceValue(progress, 200, { leading: true })
   const { theme } = useTheme()
   React.useEffect(() => {
     TopBarProgress.config({

--- a/ee/tabby-ui/components/ui/icons.tsx
+++ b/ee/tabby-ui/components/ui/icons.tsx
@@ -13,7 +13,8 @@ import {
   Play,
   Search,
   Sparkles,
-  Star
+  Star,
+  Tag
 } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -1498,6 +1499,13 @@ function IconBox({ className, ...props }: React.ComponentProps<typeof Box>) {
   return <Box className={cn('h4 w-4', className)} {...props} />
 }
 
+function IconTag({
+  className,
+  ...props
+}: React.ComponentProps<typeof Tag>) {
+  return <Tag className={cn('h4 w-4', className)} {...props} />
+}
+
 export {
   IconEdit,
   IconNextChat,
@@ -1579,5 +1587,6 @@ export {
   IconSparkles,
   IconSearch,
   IconPlay,
-  IconBox
+  IconBox,
+  IconTag
 }

--- a/ee/tabby-ui/components/ui/icons.tsx
+++ b/ee/tabby-ui/components/ui/icons.tsx
@@ -1499,10 +1499,7 @@ function IconBox({ className, ...props }: React.ComponentProps<typeof Box>) {
   return <Box className={cn('h4 w-4', className)} {...props} />
 }
 
-function IconTag({
-  className,
-  ...props
-}: React.ComponentProps<typeof Tag>) {
+function IconTag({ className, ...props }: React.ComponentProps<typeof Tag>) {
   return <Tag className={cn('h4 w-4', className)} {...props} />
 }
 

--- a/ee/tabby-webserver/development/Caddyfile
+++ b/ee/tabby-webserver/development/Caddyfile
@@ -1,4 +1,6 @@
 :8080 {
+	rewrite /files/* /files
+
 	@backend {
 		path /graphql
 		path /graphiql


### PR DESCRIPTION
### Changes
1. Support browsing different git tree in code browser
2. Optimize Code Browser URL Pattern
3. Simplify the implementation logic of the code browser and add cache refreshing when navigating in code browser
4. Add error view
5. Fix: handle gitlab project with multiple nested organization properly

### Screen Record
https://jam.dev/c/ff1a9189-f029-46d3-81e9-ee009ce817ff

### Preview
#### multiple nested organization support
<img width="1492" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/1114944c-665f-4fb3-b16e-35fda01b3672">

#### Error view
<img width="1500" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/9c02b8a5-1a6a-4567-b666-b7bf890930d3">



