### PR TITLE
fix(ollama-api-bindings): Fix model availability check

### DIFF
--- a/crates/ollama-api-bindings/src/model.rs
+++ b/crates/ollama-api-bindings/src/model.rs
@@ -44,9 +44,18 @@ impl OllamaModelExt for Ollama {
     async fn model_available(&self, name: impl AsRef<str> + Send) -> Result<bool> {
         let name = name.as_ref();
 
-        let models_available = self.list_local_models().await?;
+        let models_available = self.show_model_info(name.into()).await;
 
-        Ok(models_available.into_iter().any(|model| model.name == name))
+        match models_available {
+            Ok(_) => Ok(true),
+            Err(err) => {
+                if err.to_string().contains("not found") {
+                    Ok(false)
+                } else {
+                    Err(err.into())
+                }
+            }
+        }
     }
 
     async fn get_first_available_model(&self) -> Result<Option<String>> {


### PR DESCRIPTION
If model tag is unspecified the check will fail because `/api/tags` returns model name with `:latest` appended, so the check will mismatch. However, `/api/show` handles it correctly.

**example**
Specifying `llama3` as chat model was fail because was checked on 'llama3:latest'

My mistake, I've tested it on explicit tags on when implementing because using q5_K_M models. I am sorry, that I did not found it before release of 0.12 :cry: 