### PR TITLE
fix: Windows server_binary path adding unnecessary ".exe"

### DIFF
--- a/crates/llama-cpp-server/src/supervisor.rs
+++ b/crates/llama-cpp-server/src/supervisor.rs
@@ -36,8 +36,7 @@ impl LlamaCppSupervisor {
                     .expect("Failed to get parent directory")
                     .join(&binary_name)
                     .display()
-                    .to_string()
-                    + std::env::consts::EXE_SUFFIX;
+                    .to_string();
                 let mut command = tokio::process::Command::new(server_binary);
 
                 command


### PR DESCRIPTION
find_binary_name() already returns .exe at the end for the executable. So there is no need to add .exe a second time. Removing this fixes the bug on Windows where it will search for a binary ending on ".exe.exe". I have only tested this on Windows 11 23H2, but I don't think behaviour on other versions would be different.

Current behaviour:
![337783985-c2f5261d-54a9-4f28-be18-fd91a95ebc6c](https://github.com/TabbyML/tabby/assets/28774520/cbacbac1-0f8f-455a-8e0d-6dd90bee1ccb)

Behaviour after commit:
![337784273-9233f868-19d5-4252-9d98-b9ec847041c0](https://github.com/TabbyML/tabby/assets/28774520/7991a42c-9171-4460-a607-5d8af1902fbc)
