### PR TITLE
build(tabby): disable debug symbols for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ insta.opt-level = 3
 
 [profile.dev.package."*"]
 debug = 0
+
+[profile.dev.package.tantivy]
+debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,6 @@ features = [
 
 [profile.dev.package]
 insta.opt-level = 3
+
+[profile.dev.package."*"]
+debug = 0


### PR DESCRIPTION
My build caches have been getting quite large, so I figured it might make sense to add this setting to disable debug symbols in dependency crates, since they will basically never be used. This reduces cache size by ~34%