### PR TITLE
feat(ui): add posthog tracking on the demo web

### DIFF
--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { Provider as UrqlProvider } from 'urql'
 
+import { PostHogProvider } from '@/lib/posthog'
 import { AuthProvider, useAuthenticatedSession } from '@/lib/tabby/auth'
 import { client } from '@/lib/tabby/gql'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -25,8 +26,10 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
           <AuthProvider>
             <TopbarProgressProvider>
               <ShowDemoBannerProvider>
-                {!isPublicPath && <EnsureSignin />}
-                {children}
+                <PostHogProvider>
+                  {!isPublicPath && <EnsureSignin />}
+                  {children}
+                </PostHogProvider>
               </ShowDemoBannerProvider>
             </TopbarProgressProvider>
           </AuthProvider>

--- a/ee/tabby-ui/lib/posthog.tsx
+++ b/ee/tabby-ui/lib/posthog.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+import posthog, { PostHog } from 'posthog-js'
+import { PostHogProvider as Provider, usePostHog } from 'posthog-js/react'
+
+import { useIsDemoMode } from '@/lib/hooks/use-server-info'
+
+const POSTHOG_KEY = 'phc_aBzNGHzlOy2C8n1BBDtH7d4qQsIw9d8T0unVlnKfdxB'
+const POSTHOG_HOST = 'https://us.i.posthog.com'
+
+function PostHogPageView(): null {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const posthog = usePostHog()
+  useEffect(() => {
+    if (pathname && posthog) {
+      let url = window.origin + pathname
+      if (searchParams.toString()) {
+        url = url + `?${searchParams.toString()}`
+      }
+      posthog.capture('$pageview', {
+        $current_url: url
+      })
+    }
+  }, [pathname, searchParams, posthog])
+
+  return null
+}
+
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  const isDemoMode = useIsDemoMode()
+  const [postHogInstance, setPostHogInstance] = useState<PostHog | null>(null)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && isDemoMode) {
+      const postHogInstance = posthog.init(POSTHOG_KEY, {
+        api_host: POSTHOG_HOST,
+        person_profiles: 'identified_only',
+        capture_pageview: false
+      })
+      setPostHogInstance(postHogInstance || null)
+    }
+  }, [isDemoMode])
+
+  if (!isDemoMode || !postHogInstance) return children
+  return (
+    <Provider client={postHogInstance}>
+      <>
+        <PostHogPageView />
+        {children}
+      </>
+    </Provider>
+  )
+}

--- a/ee/tabby-ui/package.json
+++ b/ee/tabby-ui/package.json
@@ -77,6 +77,7 @@
     "next-themes": "^0.2.1",
     "numeral": "^2.0.6",
     "openai-edge": "^0.5.1",
+    "posthog-js": "^1.139.0",
     "pretty-bytes": "^6.1.1",
     "react": "^18.2.0",
     "react-activity-calendar": "^2.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,9 @@ importers:
       openai-edge:
         specifier: ^0.5.1
         version: 0.5.1
+      posthog-js:
+        specifier: ^1.139.0
+        version: 1.139.0
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -5848,6 +5851,9 @@ packages:
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
@@ -8243,6 +8249,12 @@ packages:
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  posthog-js@1.139.0:
+    resolution: {integrity: sha512-FuYlxQFO0Dq5X1/bFEM8F+NgOqZiVh4fPVHHeOTWMkqVP+pCnODQitbtW0hgT0/EE665w0xpZBk93YavaZRhzQ==}
+
+  preact@10.22.0:
+    resolution: {integrity: sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==}
 
   prebuild-install@7.1.2:
     resolution: {integrity: sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==}
@@ -16651,6 +16663,8 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
+  fflate@0.4.8: {}
+
   fflate@0.7.4: {}
 
   figures@3.2.0:
@@ -19432,6 +19446,13 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
+
+  posthog-js@1.139.0:
+    dependencies:
+      fflate: 0.4.8
+      preact: 10.22.0
+
+  preact@10.22.0: {}
 
   prebuild-install@7.1.2:
     dependencies:


### PR DESCRIPTION
Enable for demo mode

### Local request
<img width="785" alt="local" src="https://github.com/TabbyML/tabby/assets/5305874/a874ee29-4858-4dee-a319-3ad4fe8eb10a">

### Posthog dashboard
<img width="1979" alt="posthog" src="https://github.com/TabbyML/tabby/assets/5305874/7fd7bdcc-0d59-4990-9196-c194f1e5a826">

