### PR TITLE
fix(ui): stop button display after loading

### DIFF
--- a/ee/tabby-ui/app/(home)/components/search.tsx
+++ b/ee/tabby-ui/app/(home)/components/search.tsx
@@ -174,9 +174,10 @@ export function SearchRenderer({}, ref: ForwardedRef<SearchRef>) {
   }, [error])
 
   // Delay showing the stop button
+  let showStopTimeoutId: number
   useEffect(() => {
     if (isLoadingRef.current) {
-      setTimeout(() => {
+      showStopTimeoutId = window.setTimeout(() => {
         if (!isLoadingRef.current) return
         setShowStop(true)
 
@@ -196,6 +197,10 @@ export function SearchRenderer({}, ref: ForwardedRef<SearchRef>) {
 
     if (!isLoadingRef.current) {
       setShowStop(false)
+    }
+
+    return () => {
+      window.clearTimeout(showStopTimeoutId)
     }
   }, [isLoading])
 

--- a/ee/tabby-ui/app/(home)/components/search.tsx
+++ b/ee/tabby-ui/app/(home)/components/search.tsx
@@ -191,7 +191,7 @@ export function SearchRenderer({}, ref: ForwardedRef<SearchRef>) {
             })
           }
         }
-      }, 1500)
+      }, 300)
     }
 
     if (!isLoadingRef.current) {

--- a/ee/tabby-ui/app/(home)/components/search.tsx
+++ b/ee/tabby-ui/app/(home)/components/search.tsx
@@ -17,6 +17,7 @@ import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 
 import { useEnableSearch } from '@/lib/experiment-flags'
+import { useLatest } from '@/lib/hooks/use-latest'
 import { useIsChatEnabled } from '@/lib/hooks/use-server-info'
 import { useTabbyAnswer } from '@/lib/hooks/use-tabby-answer'
 import fetcher from '@/lib/tabby/fetcher'
@@ -113,6 +114,8 @@ export function SearchRenderer({}, ref: ForwardedRef<SearchRef>) {
     fetcher: tabbyFetcher
   })
 
+  const isLoadingRef = useLatest(isLoading)
+
   useImperativeHandle(
     ref,
     () => {
@@ -172,8 +175,9 @@ export function SearchRenderer({}, ref: ForwardedRef<SearchRef>) {
 
   // Delay showing the stop button
   useEffect(() => {
-    if (isLoading) {
+    if (isLoadingRef.current) {
       setTimeout(() => {
+        if (!isLoadingRef.current) return
         setShowStop(true)
 
         // Scroll to the bottom
@@ -190,7 +194,7 @@ export function SearchRenderer({}, ref: ForwardedRef<SearchRef>) {
       }, 1500)
     }
 
-    if (!isLoading) {
+    if (!isLoadingRef.current) {
       setShowStop(false)
     }
   }, [isLoading])


### PR DESCRIPTION
### Context
Show stop button `setShowStop(true)` after 1500ms when `isLoading` is true. However, a bug could occur if isLoading changes to false within those 1500ms. 

### Fix
I used useLatest(isLoading) to double-check the isLoading state before showing the stop button.