### PR TITLE
chore(ui): render toml code syntax correctly

### DIFF
--- a/ee/tabby-ui/components/ui/codeblock.tsx
+++ b/ee/tabby-ui/components/ui/codeblock.tsx
@@ -68,6 +68,7 @@ const CodeBlock: FC<Props> = memo(({ language, value, onCopyContent }) => {
     copyToClipboard(value)
   }
 
+  const languageForSyntax = language === 'toml' ? 'bash' : language
   return (
     <div className="codeblock relative w-full bg-zinc-950 font-sans">
       <div className="flex w-full items-center justify-between bg-zinc-800 px-6 py-2 pr-4 text-zinc-100">
@@ -85,7 +86,7 @@ const CodeBlock: FC<Props> = memo(({ language, value, onCopyContent }) => {
         </div>
       </div>
       <SyntaxHighlighter
-        language={language}
+        language={languageForSyntax}
         style={coldarkDark}
         PreTag="div"
         showLineNumbers


### PR DESCRIPTION
### What to fix
The code block fails to display .toml files correctly
<img width="800" alt="2" src="https://github.com/TabbyML/tabby/assets/5305874/189838b0-b176-42b5-888e-4d0f2d0c029e">

### Why
`[workspace]` becomes multiple lines because `react-syntax-highlighter` add `.table` to the `workspace`, causing it to be displayed as a table and occupy a whole line
I didn't find any discuss addressing this issue so I guess that's because `react-syntax-highlighter` can't handle .toml correctly 

### How to fix
Use the bash syntax to render .toml files
<img width="730" alt="1" src="https://github.com/TabbyML/tabby/assets/5305874/1a679656-c056-40c4-921f-a7d7bf2064bc">

