### PR TITLE
fix(ui): fix home height and autofocus and stop button not working

### DIFF
--- a/ee/tabby-ui/app/(home)/components/search.tsx
+++ b/ee/tabby-ui/app/(home)/components/search.tsx
@@ -147,15 +147,15 @@ export function SearchRenderer({}, ref: ForwardedRef<SearchRef>) {
 
   // Handling the stream response from useTabbyAnswer
   useEffect(() => {
-    if (!answer) return
     const newConversation = [...conversation]
     const currentAnswer = newConversation.find(
       item => item.id === currentLoadindId
     )
+
     if (!currentAnswer) return
-    currentAnswer.content = answer.answer_delta || ''
-    currentAnswer.relevant_documents = answer.relevant_documents
-    currentAnswer.relevant_questions = answer.relevant_questions
+    currentAnswer.content = answer?.answer_delta || ''
+    currentAnswer.relevant_documents = answer?.relevant_documents
+    currentAnswer.relevant_questions = answer?.relevant_questions
     currentAnswer.isLoading = isLoading
     setConversation(newConversation)
   }, [isLoading, answer])

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -170,10 +170,7 @@ function MainPanel() {
             </div>
             {isChatEnabled && searchFlag.value && (
               <div className="mb-10 w-full" data-aos="fade-down">
-                <TextAreaSearch
-                  onSearch={onSearch}
-                  showBetaBadge
-                  autoFocus />
+                <TextAreaSearch onSearch={onSearch} showBetaBadge autoFocus />
               </div>
             )}
             <div className="flex w-full flex-col gap-x-5 lg:flex-row">

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -170,7 +170,10 @@ function MainPanel() {
             </div>
             {isChatEnabled && searchFlag.value && (
               <div className="mb-10 w-full" data-aos="fade-down">
-                <TextAreaSearch onSearch={onSearch} showBetaBadge />
+                <TextAreaSearch
+                  onSearch={onSearch}
+                  showBetaBadge
+                  autoFocus />
               </div>
             )}
             <div className="flex w-full flex-col gap-x-5 lg:flex-row">

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -139,7 +139,7 @@ function MainPanel() {
         ref={elementRef}
       >
         {!isSearch && (
-          <div className="mx-auto flex w-full flex-col items-center px-10 lg:-mt-[2vh] lg:max-w-4xl lg:px-0">
+          <div className="mx-auto flex min-h-0 w-full flex-col items-center px-10 lg:-mt-[2vh] lg:max-w-4xl lg:px-0">
             <Image
               src={tabbyUrl}
               alt="logo"

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -13,13 +13,15 @@ export default function TextAreaSearch({
   className,
   placeholder,
   showBetaBadge,
-  isLoading
+  isLoading,
+  autoFocus
 }: {
   onSearch: (value: string) => void
   className?: string
   placeholder?: string
   showBetaBadge?: boolean
   isLoading?: boolean
+  autoFocus?: boolean
 }) {
   const [isShow, setIsShow] = useState(false)
   const [isFocus, setIsFocus] = useState(false)
@@ -81,6 +83,7 @@ export default function TextAreaSearch({
         onBlur={() => setIsFocus(false)}
         onChange={e => setValue(e.target.value)}
         value={value}
+        autoFocus={autoFocus}
       />
       <div
         className={cn('mr-6 flex items-center rounded-lg p-1 transition-all', {


### PR DESCRIPTION
## Stop button not working issue
### Context
When clicking the `stop` button immediately after starting a search, the answer still appears to be loading.

### Fix
The logic `if (!answer) return` is useless.
Previously, the stop button was displayed after a 1500ms delay, which prevented this potential bug 

## Home height issue
happened when the height is very small
issue: https://jam.dev/c/ca8e58cb-07e7-4bb6-aaff-75ad7ba0e673 
CSS problem, adding `min-h-0`

## Auto focus
In the home page, auto focus on the input at the beginning