### PR TITLE
refactor: panic on invalid config.toml loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5028,6 +5028,7 @@ dependencies = [
  "temp_testdir",
  "thiserror",
  "tokio",
+ "tracing",
  "url",
  "utoipa",
  "uuid",

--- a/crates/tabby-common/Cargo.toml
+++ b/crates/tabby-common/Cargo.toml
@@ -21,6 +21,7 @@ thiserror.workspace = true
 url.workspace = true
 derive_builder.workspace = true
 hash-ids.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 temp_testdir = { workspace = true }

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -27,8 +27,11 @@ pub struct Config {
 impl Config {
     pub fn load() -> Result<Self> {
         let cfg_path = crate::path::config_file();
+        if !cfg_path.as_path().exists() {
+            return Ok(Default::default());
+        }
         let mut cfg: Self = serdeconv::from_toml_file(cfg_path.as_path()).context(format!(
-            "Config file '{}' is missing or not valid",
+            "Config file '{}' is not valid",
             cfg_path.display()
         ))?;
 

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -28,12 +28,22 @@ impl Config {
     pub fn load() -> Result<Self> {
         let cfg_path = crate::path::config_file();
         if !cfg_path.as_path().exists() {
+            InfoMessage::new(
+                "Tabby config file missing",
+                HeaderFormat::Blue,
+                &[
+                    &format!(
+                        "Warning: Could not find the Tabby configuration at {}",
+                        cfg_path.display()
+                    ),
+                    "Applying default configuration",
+                ],
+            )
+            .print();
             return Ok(Default::default());
         }
-        let mut cfg: Self = serdeconv::from_toml_file(cfg_path.as_path()).context(format!(
-            "Config file '{}' is not valid",
-            cfg_path.display()
-        ))?;
+        let mut cfg: Self = serdeconv::from_toml_file(cfg_path.as_path())
+            .context(format!("Config file '{}' is not valid", cfg_path.display()))?;
 
         if let Err(e) = cfg.validate_dirs() {
             cfg = Default::default();

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -6,6 +6,7 @@ use derive_builder::Builder;
 use hash_ids::HashIds;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use crate::{
     path::repositories_dir,
@@ -28,18 +29,7 @@ impl Config {
     pub fn load() -> Result<Self> {
         let cfg_path = crate::path::config_file();
         if !cfg_path.as_path().exists() {
-            InfoMessage::new(
-                "Tabby config file missing",
-                HeaderFormat::Blue,
-                &[
-                    &format!(
-                        "Warning: Could not find the Tabby configuration at {}",
-                        cfg_path.display()
-                    ),
-                    "Applying default configuration",
-                ],
-            )
-            .print();
+            debug!("Config file {} not found, apply default configuration", cfg_path.display());
             return Ok(Default::default());
         }
         let mut cfg: Self = serdeconv::from_toml_file(cfg_path.as_path())

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -29,7 +29,10 @@ impl Config {
     pub fn load() -> Result<Self> {
         let cfg_path = crate::path::config_file();
         if !cfg_path.as_path().exists() {
-            debug!("Config file {} not found, apply default configuration", cfg_path.display());
+            debug!(
+                "Config file {} not found, apply default configuration",
+                cfg_path.display()
+            );
             return Ok(Default::default());
         }
         let mut cfg: Self = serdeconv::from_toml_file(cfg_path.as_path())

--- a/crates/tabby/src/main.rs
+++ b/crates/tabby/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
     let cli = Cli::parse();
     init_logging();
 
-    let config = Config::load().unwrap_or_default();
+    let config = Config::load().expect("Must be able to load config");
     let root = tabby_common::path::tabby_root();
     std::fs::create_dir_all(&root).expect("Must be able to create tabby root");
     #[cfg(target_family = "unix")]


### PR DESCRIPTION
Original issue https://github.com/TabbyML/tabby/issues/2228 suggests print warning or error log if `config.toml` is invalid.

Well, it's viable, what I'm thinking is perhaps stop until `config.toml` is fixed properly by the user.

This change applies following logic

- If `config.toml` is missing, return default config allow tabby to be started with a `Warning` mesage
<img width="902" alt="Screenshot 2024-06-21 232403" src="https://github.com/TabbyML/tabby/assets/1013532/80c9523e-a16d-43b1-9487-d3c06a201a84">

- if `config.toml` is invalid, panic & display error
<img width="880" alt="Screenshot 2024-06-20 210934" src="https://github.com/TabbyML/tabby/assets/1013532/c1b15318-9ff0-4471-99ea-d9b775122790">
