### PR TITLE
fix(ui): add backward compatibilty for line query

### DIFF
--- a/ee/tabby-ui/lib/hooks/use-router-stuff.ts
+++ b/ee/tabby-ui/lib/hooks/use-router-stuff.ts
@@ -83,7 +83,7 @@ function resolveUrlComponents(
     newPath += `?${queryString}`
   }
   if (options.hash) {
-    newPath += options.hash
+    newPath += `#${options.hash.replace(/^#/, '')}`
   }
   return newPath
 }

--- a/ee/tabby-ui/lib/utils.ts
+++ b/ee/tabby-ui/lib/utils.ts
@@ -91,9 +91,11 @@ export function formatLineHashForCodeBrowser(
   if (!range) return ''
 
   const { start, end } = range
-  if (isNil(start)) return ''
+  if (isNil(start) || isNaN(start)) return ''
   if (start === end) return `L${start}`
   return compact(
-    [start, end].map(num => (typeof num === 'number' ? `L${num}` : undefined))
+    [start, end].map(num =>
+      typeof num === 'number' && !isNaN(num) ? `L${num}` : undefined
+    )
   ).join('-')
 }


### PR DESCRIPTION
### Background
In PR #2436 , i updated the comcatenation logic for URL in the chat view of VSCode client to use hash  like `#L{number}` instead of  searchParam like `?line={number}`
https://github.com/TabbyML/tabby/pull/2436/files#diff-22897189febb57c85bc910ac40ed86b59d35c03d5e051b9c4741c37eb749bfc7R109

### Solution
add a backward compatibilty logic