### PR TITLE
refactor(scheduler): remove kv cache, using tantivy directly for incremental indexing + garbage collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1280,16 +1280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs4"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,7 +1355,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2367,20 +2357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620727085ac39ee9650b373fe6d8073a0aee6f99e52a9c72b25f7671078039ab"
-dependencies = [
- "pin-project-lite",
- "serde",
- "serde_json",
- "sled",
- "thiserror",
- "toml 0.5.11",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,7 +2819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
 dependencies = [
  "nucleo-matcher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rayon",
 ]
 
@@ -3199,37 +3175,12 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3762,15 +3713,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -4285,7 +4227,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "toml 0.7.8",
+ "toml",
  "trackable",
 ]
 
@@ -4299,7 +4241,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serial_test_derive 2.0.0",
 ]
 
@@ -4312,7 +4254,7 @@ dependencies = [
  "futures",
  "log",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "scc",
  "serial_test_derive 3.1.1",
 ]
@@ -4452,22 +4394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -4797,7 +4723,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -5117,7 +5043,6 @@ dependencies = [
  "htmd",
  "ignore",
  "insta",
- "kv",
  "lazy_static",
  "llama-cpp-server",
  "readable-readability",
@@ -5542,7 +5467,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5658,15 +5583,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/crates/tabby-scheduler/Cargo.toml
+++ b/crates/tabby-scheduler/Cargo.toml
@@ -27,7 +27,6 @@ ignore.workspace = true
 tokio-cron-scheduler = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
 text-splitter = { version = "0.13.3", features = ["code"] }
-kv = { version = "0.24.0", features = ["json-value"] }
 serde.workspace = true
 serde_json.workspace = true
 futures.workspace = true

--- a/crates/tabby-scheduler/src/code/cache.rs
+++ b/crates/tabby-scheduler/src/code/cache.rs
@@ -57,6 +57,10 @@ impl ToString for SourceFileKey {
     }
 }
 
+pub fn source_file_key_from_path(path: &Path) -> Option<String> {
+    SourceFileKey::try_from(path).map(|key| key.to_string()).ok()
+}
+
 pub struct CacheStore {
     store: Store,
 }
@@ -150,7 +154,7 @@ impl CacheStore {
     }
 }
 
-fn is_item_key_matched(item_key: &str) -> bool {
+pub fn is_item_key_matched(item_key: &str) -> bool {
     let Ok(key) = item_key.parse::<SourceFileKey>() else {
         return false;
     };

--- a/crates/tabby-scheduler/src/code/cache.rs
+++ b/crates/tabby-scheduler/src/code/cache.rs
@@ -89,18 +89,16 @@ impl CacheStore {
             .expect("Failed to access indexed files bucket")
     }
 
-    pub fn check_indexed(&self, path: &Path) -> (String, bool) {
-        let key = SourceFileKey::try_from(path)
-            .expect("Failed to create source file key")
-            .to_string();
+    pub fn check_indexed(&self, path: &Path) -> Result<(String, bool)> {
+        let key = SourceFileKey::try_from(path)?.to_string();
         let indexed = self
             .index_bucket()
             .get(&key)
             .expect("Failed to read index bucket");
-        (
+        Ok((
             key,
             indexed.is_some_and(|indexed| indexed == INDEX_ALGORITHM_VERSION),
-        )
+        ))
     }
 
     pub fn clear_indexed(&self) {

--- a/crates/tabby-scheduler/src/code/index.rs
+++ b/crates/tabby-scheduler/src/code/index.rs
@@ -8,12 +8,12 @@ use tabby_inference::Embedding;
 use tracing::{debug, info, warn};
 
 use super::{
-    cache::{source_file_key_from_path},
+    source_file_key::{source_file_key_from_path},
     create_code_index,
     intelligence::{CodeIntelligence, SourceCode},
     KeyedSourceCode,
 };
-use crate::{code::cache::is_item_key_matched, Indexer};
+use crate::{code::source_file_key::check_source_file_key_matched, Indexer};
 
 // Magic numbers
 static MAX_LINE_LENGTH_THRESHOLD: usize = 300;
@@ -106,7 +106,7 @@ async fn remove_staled_documents(index: &Indexer<KeyedSourceCode>) {
 
         for await id in index.iter_ids() {
             let item_key = id;
-            if is_item_key_matched(&item_key) {
+            if check_source_file_key_matched(&item_key) {
                 num_to_keep += 1;
             } else {
                 num_to_delete += 1;

--- a/crates/tabby-scheduler/src/code/index.rs
+++ b/crates/tabby-scheduler/src/code/index.rs
@@ -64,6 +64,7 @@ async fn add_changed_documents(repository: &RepositoryConfig, index: Indexer<Key
             };
 
             if cloned_index.is_id_indexed(&key) {
+                // Skip if already indexed
                 continue;
             }
 

--- a/crates/tabby-scheduler/src/code/index.rs
+++ b/crates/tabby-scheduler/src/code/index.rs
@@ -63,7 +63,7 @@ async fn add_changed_documents(repository: &RepositoryConfig, index: Indexer<Key
                 continue;
             };
 
-            if cloned_index.is_id_indexed(&key) {
+            if cloned_index.is_indexed(&key) {
                 // Skip if already indexed
                 continue;
             }

--- a/crates/tabby-scheduler/src/code/index.rs
+++ b/crates/tabby-scheduler/src/code/index.rs
@@ -114,9 +114,6 @@ async fn add_changed_documents(
     }
 }
 
-async fn remove_staled_documents(index: &Indexer<KeyedSourceCode>) {
-}
-
 fn is_valid_file(file: &SourceCode) -> bool {
     file.max_line_length <= MAX_LINE_LENGTH_THRESHOLD
         && file.avg_line_length <= AVG_LINE_LENGTH_THRESHOLD

--- a/crates/tabby-scheduler/src/code/index.rs
+++ b/crates/tabby-scheduler/src/code/index.rs
@@ -56,7 +56,10 @@ async fn add_changed_documents(
                 }
             };
 
-            let (key, indexed) = cache.check_indexed(file.path());
+            let Ok((key, indexed)) = cache.check_indexed(file.path()) else {
+                continue;
+            };
+
             if indexed {
                 continue;
             }

--- a/crates/tabby-scheduler/src/code/index.rs
+++ b/crates/tabby-scheduler/src/code/index.rs
@@ -8,9 +8,9 @@ use tabby_inference::Embedding;
 use tracing::{debug, info, warn};
 
 use super::{
-    source_file_key::{source_file_key_from_path},
     create_code_index,
     intelligence::{CodeIntelligence, SourceCode},
+    source_file_key::source_file_key_from_path,
     KeyedSourceCode,
 };
 use crate::{code::source_file_key::check_source_file_key_matched, Indexer};
@@ -19,10 +19,7 @@ use crate::{code::source_file_key::check_source_file_key_matched, Indexer};
 static MAX_LINE_LENGTH_THRESHOLD: usize = 300;
 static AVG_LINE_LENGTH_THRESHOLD: f32 = 150f32;
 
-pub async fn index_repository(
-    embedding: Arc<dyn Embedding>,
-    repository: &RepositoryConfig,
-) {
+pub async fn index_repository(embedding: Arc<dyn Embedding>, repository: &RepositoryConfig) {
     let index = create_code_index(Some(embedding));
     add_changed_documents(repository, index).await;
 }
@@ -48,10 +45,7 @@ pub async fn garbage_collection() {
     }.collect::<()>().await;
 }
 
-async fn add_changed_documents(
-    repository: &RepositoryConfig,
-    index: Indexer<KeyedSourceCode>,
-) {
+async fn add_changed_documents(repository: &RepositoryConfig, index: Indexer<KeyedSourceCode>) {
     let index = Arc::new(index);
     let cloned_index = index.clone();
     let s = stream! {

--- a/crates/tabby-scheduler/src/code/mod.rs
+++ b/crates/tabby-scheduler/src/code/mod.rs
@@ -49,6 +49,12 @@ struct KeyedSourceCode {
     code: SourceCode,
 }
 
+impl KeyedSourceCode {
+    fn build_id(&self) -> String {
+        self.key.clone()
+    }
+}
+
 struct CodeBuilder {
     embedding: Option<Arc<dyn Embedding>>,
 }
@@ -62,7 +68,7 @@ impl CodeBuilder {
 #[async_trait]
 impl IndexAttributeBuilder<KeyedSourceCode> for CodeBuilder {
     async fn build_id(&self, source_code: &KeyedSourceCode) -> String {
-        source_code.key.clone()
+        source_code.build_id()
     }
 
     async fn build_attributes(&self, _source_code: &KeyedSourceCode) -> serde_json::Value {

--- a/crates/tabby-scheduler/src/code/mod.rs
+++ b/crates/tabby-scheduler/src/code/mod.rs
@@ -38,10 +38,10 @@ impl CodeIndexer {
         index::index_repository(&mut cache, embedding, repository).await;
     }
 
-    pub fn garbage_collection(&mut self, repositories: &[RepositoryConfig]) {
+    pub async fn garbage_collection(&mut self, repositories: &[RepositoryConfig]) {
         self.is_dirty = false;
         let mut cache = cache::CacheStore::new(tabby_common::path::cache_dir());
-        index::garbage_collection(&mut cache);
+        index::garbage_collection(&mut cache).await;
         repository::garbage_collection(repositories);
     }
 }

--- a/crates/tabby-scheduler/src/code/mod.rs
+++ b/crates/tabby-scheduler/src/code/mod.rs
@@ -41,7 +41,6 @@ impl CodeIndexer {
     pub fn garbage_collection(&mut self, repositories: &[RepositoryConfig]) {
         self.is_dirty = false;
         let mut cache = cache::CacheStore::new(tabby_common::path::cache_dir());
-        cache.garbage_collection_for_source_files();
         index::garbage_collection(&mut cache);
         repository::garbage_collection(repositories);
     }

--- a/crates/tabby-scheduler/src/code/mod.rs
+++ b/crates/tabby-scheduler/src/code/mod.rs
@@ -15,7 +15,7 @@ use self::intelligence::SourceCode;
 use crate::{code::intelligence::CodeIntelligence, IndexAttributeBuilder, Indexer};
 
 ///  Module for creating code search index.
-mod cache;
+mod source_file_key;
 mod index;
 mod intelligence;
 mod languages;

--- a/crates/tabby-scheduler/src/code/mod.rs
+++ b/crates/tabby-scheduler/src/code/mod.rs
@@ -14,12 +14,12 @@ use tracing::{info, warn};
 use self::intelligence::SourceCode;
 use crate::{code::intelligence::CodeIntelligence, IndexAttributeBuilder, Indexer};
 
-///  Module for creating code search index.
-mod source_file_key;
 mod index;
 mod intelligence;
 mod languages;
 mod repository;
+///  Module for creating code search index.
+mod source_file_key;
 mod types;
 
 #[derive(Default)]

--- a/crates/tabby-scheduler/src/code/mod.rs
+++ b/crates/tabby-scheduler/src/code/mod.rs
@@ -14,11 +14,11 @@ use tracing::{info, warn};
 use self::intelligence::SourceCode;
 use crate::{code::intelligence::CodeIntelligence, IndexAttributeBuilder, Indexer};
 
+//  Modules for creating code search index.
 mod index;
 mod intelligence;
 mod languages;
 mod repository;
-///  Module for creating code search index.
 mod source_file_key;
 mod types;
 

--- a/crates/tabby-scheduler/src/code/mod.rs
+++ b/crates/tabby-scheduler/src/code/mod.rs
@@ -34,14 +34,12 @@ impl CodeIndexer {
         info!("Refreshing repository: {}", repository.canonical_git_url());
         repository::sync_repository(repository);
 
-        let mut cache = cache::CacheStore::new(tabby_common::path::cache_dir());
-        index::index_repository(&mut cache, embedding, repository).await;
+        index::index_repository(embedding, repository).await;
     }
 
     pub async fn garbage_collection(&mut self, repositories: &[RepositoryConfig]) {
         self.is_dirty = false;
-        let mut cache = cache::CacheStore::new(tabby_common::path::cache_dir());
-        index::garbage_collection(&mut cache).await;
+        index::garbage_collection().await;
         repository::garbage_collection(repositories);
     }
 }

--- a/crates/tabby-scheduler/src/code/source_file_key.rs
+++ b/crates/tabby-scheduler/src/code/source_file_key.rs
@@ -54,7 +54,9 @@ impl ToString for SourceFileKey {
 }
 
 pub fn source_file_key_from_path(path: &Path) -> Option<String> {
-    SourceFileKey::try_from(path).map(|key| key.to_string()).ok()
+    SourceFileKey::try_from(path)
+        .map(|key| key.to_string())
+        .ok()
 }
 
 pub fn check_source_file_key_matched(item_key: &str) -> bool {

--- a/crates/tabby-scheduler/src/code/source_file_key.rs
+++ b/crates/tabby-scheduler/src/code/source_file_key.rs
@@ -57,7 +57,7 @@ pub fn source_file_key_from_path(path: &Path) -> Option<String> {
     SourceFileKey::try_from(path).map(|key| key.to_string()).ok()
 }
 
-pub fn is_item_key_matched(item_key: &str) -> bool {
+pub fn check_source_file_key_matched(item_key: &str) -> bool {
     let Ok(key) = item_key.parse::<SourceFileKey>() else {
         return false;
     };

--- a/crates/tabby-scheduler/src/indexer.rs
+++ b/crates/tabby-scheduler/src/indexer.rs
@@ -130,7 +130,7 @@ impl<T: Send + 'static> Indexer<T> {
     }
 
     // Check whether the document ID presents in the corpus.
-    pub fn is_id_indexed(&self, id: &str) -> bool {
+    pub fn is_indexed(&self, id: &str) -> bool {
         let schema = IndexSchema::instance();
         let query = TermQuery::new(
             Term::from_field_text(schema.field_id, &self.format_id(id)),

--- a/crates/tabby-scheduler/src/indexer.rs
+++ b/crates/tabby-scheduler/src/indexer.rs
@@ -147,6 +147,7 @@ impl<T: Send + 'static> Indexer<T> {
         let schema = IndexSchema::instance();
 
         stream! {
+            // Based on https://github.com/quickwit-oss/tantivy/blob/main/examples/iterating_docs_and_positions.rs
             for (segment_ordinal, segment_reader) in self.searcher.segment_readers().iter().enumerate() {
                 let Ok(inverted_index) = segment_reader.inverted_index(schema.field_corpus) else {
                     continue;

--- a/crates/tabby-scheduler/src/indexer.rs
+++ b/crates/tabby-scheduler/src/indexer.rs
@@ -6,8 +6,7 @@ use tantivy::{
     doc,
     query::TermQuery,
     schema::{self, IndexRecordOption, Value},
-    DocAddress, DocSet, IndexReader, IndexWriter, Searcher, SegmentOrdinal, TantivyDocument, Term,
-    TERMINATED,
+    DocAddress, DocSet, IndexWriter, Searcher, TantivyDocument, Term, TERMINATED,
 };
 use tracing::info;
 

--- a/crates/tabby-scheduler/src/indexer.rs
+++ b/crates/tabby-scheduler/src/indexer.rs
@@ -158,6 +158,7 @@ impl<T: Send + 'static> Indexer<T> {
                     continue;
                 };
 
+                let prefix_to_strip = format!("{}:", self.kind);
                 let mut doc_id = postings.doc();
                 while doc_id != TERMINATED {
                     if !segment_reader.is_deleted(doc_id) {
@@ -166,7 +167,9 @@ impl<T: Send + 'static> Indexer<T> {
 
                         // Skip chunks, as we only want to iterate over the main docs
                         if doc.get_first(schema.field_chunk_id).is_none() {
-                            yield get_text(&doc, schema.field_id).strip_prefix(self.kind).unwrap().strip_prefix(':').unwrap().to_owned();
+                            if let Some(id) = get_text(&doc, schema.field_id).strip_prefix(&prefix_to_strip) {
+                                yield id.to_owned();
+                            }
                         }
                     }
                     doc_id = postings.advance();

--- a/crates/tabby-scheduler/src/lib.rs
+++ b/crates/tabby-scheduler/src/lib.rs
@@ -71,7 +71,7 @@ async fn scheduler_pipeline(config: &tabby_common::config::Config) {
         code.refresh(embedding.clone(), repository).await;
     }
 
-    code.garbage_collection(repositories);
+    code.garbage_collection(repositories).await;
 }
 
 pub async fn crawl_index_docs<F>(

--- a/ee/tabby-webserver/src/service/background_job/git.rs
+++ b/ee/tabby-webserver/src/service/background_job/git.rs
@@ -67,7 +67,7 @@ impl SchedulerGitJob {
 
         let mut code = CodeIndexer::default();
 
-        code.garbage_collection(&repositories);
+        code.garbage_collection(&repositories).await;
 
         for repository in repositories {
             let _ = job


### PR DESCRIPTION
After investigating tantivy in depth - it concludes that the KV functionality can be fully replaced by reading tantivy directly
