### PR TITLE
feat(vscode): reorganize settings

### DIFF
--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -129,7 +129,7 @@
       "commandPalette": [
         {
           "command": "tabby.inlineCompletion.trigger",
-          "when": "config.tabby.inlineCompletion.triggerMode === 'manual' && !editorHasSelection && !inlineSuggestionsVisible"
+          "when": "tabby.inlineCompletionTriggerMode === 'manual' && !editorHasSelection && !inlineSuggestionsVisible"
         },
         {
           "command": "tabby.openTabbyAgentSettings",
@@ -234,25 +234,12 @@
       {
         "title": "Tabby",
         "properties": {
-          "tabby.api.endpoint": {
+          "tabby.endpoint": {
             "type": "string",
             "default": "",
             "pattern": "(^$)|(^https?:\\/\\/\\S+$)",
             "patternErrorMessage": "Please enter a validate http or https URL.",
             "markdownDescription": "Specify the API endpoint for the Tabby server.  \nIf authentication is required, please [Set Credentials](command:tabby.setApiToken).  \nIf left empty, the server endpoint specified in the [Tabby Agent Settings](command:tabby.openTabbyAgentSettings) will be used."
-          },
-          "tabby.inlineCompletion.triggerMode": {
-            "type": "string",
-            "enum": [
-              "automatic",
-              "manual"
-            ],
-            "default": "automatic",
-            "description": "Select the code completion trigger mode.",
-            "enumDescriptions": [
-              "Automatic trigger when you stop typing",
-              "Manual trigger by pressing `Alt + \\`"
-            ]
           },
           "tabby.keybindings": {
             "type": "string",
@@ -263,14 +250,28 @@
             "default": "vscode-style",
             "markdownDescription": "Select the keybinding profile to accept inline completion. You can also customize it in [Keyboard Shortcuts](command:tabby.openKeybindings). \n | | Next Line | Full Completion | Next Word | \n |:---|:---|:---|:---| \n | _vscode-style_ | - | `Tab` | `Ctrl + RightArrow` (macOS: `Cmd + RightArrow`) | \n | _tabby-style_  _(experimental)_ | `Tab` | `Ctrl + Tab` | `Ctrl + RightArrow` (macOS: `Cmd + RightArrow`) | \n"
           },
-          "tabby.usage.anonymousUsageTracking": {
+          "tabby.config.telemetry": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Disable anonymous usage tracking**  \nTabby collects aggregated anonymous usage data and sends it to the Tabby team to help improve our products.  \nYour code, generated completions, or any identifying information is never tracked or transmitted.  \nFor more details on data collection, please check our [online documentation](https://tabby.tabbyml.com/docs/extensions/configurations#usage-collection)."
           },
-          "tabby.experimental": {
+          "tabby.settings.advanced": {
             "default": {},
-            "properties": {}
+            "properties": {
+              "inlineCompletion.triggerMode": {
+                "type": "string",
+                "enum": [
+                  "automatic",
+                  "manual"
+                ],
+                "default": "automatic",
+                "description": "Select the code completion trigger mode.",
+                "enumDescriptions": [
+                  "Automatic trigger when you stop typing",
+                  "Manual trigger by pressing `Alt + \\`"
+                ]
+              }
+            }
           }
         }
       }
@@ -279,7 +280,7 @@
       {
         "key": "alt+\\",
         "command": "tabby.inlineCompletion.trigger",
-        "when": "config.tabby.inlineCompletion.triggerMode === 'manual' && editorTextFocus && !editorHasSelection && !inlineSuggestionsVisible"
+        "when": "tabby.inlineCompletionTriggerMode === 'manual' && editorTextFocus && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
         "command": "tabby.inlineCompletion.accept",

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -17,6 +17,7 @@ export class Config extends EventEmitter {
     context.subscriptions.push(
       workspace.onDidChangeConfiguration(async (event) => {
         if (event.affectsConfiguration("tabby")) {
+          contextVariables.inlineCompletionTriggerMode = this.inlineCompletionTriggerMode;
           this.emit("updated");
         }
       }),

--- a/clients/vscode/src/ContextVariables.ts
+++ b/clients/vscode/src/ContextVariables.ts
@@ -5,6 +5,7 @@ export class ContextVariables {
   private chatEnabledValue = false;
   private chatEditInProgressValue = false;
   private chatEditResolvingValue = false;
+  private inlineCompletionTriggerModeValue: "automatic" | "manual" = "automatic";
 
   constructor(private readonly client: Client) {
     this.chatEnabled = this.client.chat.isAvailable;
@@ -65,5 +66,14 @@ export class ContextVariables {
   set chatEditResolving(value: boolean) {
     commands.executeCommand("setContext", "tabby.chatEditResolving", value);
     this.chatEditResolvingValue = value;
+  }
+
+  get inlineCompletionTriggerMode(): "automatic" | "manual" {
+    return this.inlineCompletionTriggerModeValue;
+  }
+
+  set inlineCompletionTriggerMode(value: "automatic" | "manual") {
+    commands.executeCommand("setContext", "tabby.inlineCompletionTriggerMode", value);
+    this.inlineCompletionTriggerModeValue = value;
   }
 }

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -48,7 +48,8 @@ export async function activate(context: ExtensionContext) {
     const languageClient = new NodeLanguageClient("Tabby", serverOptions, clientOptions);
     client = new Client(context, languageClient);
   }
-  const config = new Config(context);
+  const contextVariables = new ContextVariables(client);
+  const config = new Config(context, contextVariables);
   const inlineCompletionProvider = new InlineCompletionProvider(client, config);
   const gitProvider = new GitProvider();
 
@@ -67,7 +68,6 @@ export async function activate(context: ExtensionContext) {
   );
 
   const issues = new Issues(client, config);
-  const contextVariables = new ContextVariables(client);
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */ /* @ts-expect-error noUnusedLocals */
   const statusBarItem = new StatusBarItem(context, client, config, issues, inlineCompletionProvider);
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */ /* @ts-expect-error noUnusedLocals */


### PR DESCRIPTION
# Main changes
## Update the settings page
![Screenshot 2024-06-25 15 09 47](https://github.com/TabbyML/tabby/assets/5305874/2db7d492-df77-46cf-b3d7-bb875f347ff2)

trigger mode in settings.json
![Screenshot 2024-06-25 14 01 27](https://github.com/TabbyML/tabby/assets/5305874/47f8b92a-1a0e-4a88-afd8-9103c7d1b5ec)

## New context variable `tabby.inlineCompletionTriggerMode`
After putting inlineCompletionTriggerMode into settings.advanced, we can't visit `config.tabby.settings.advanced.inlineCompletion.triggerMode`
So I create a new context variable
