### PR TITLE
ci: add compat ld path for locatinglibcuda.so.1 in docker build

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -82,6 +82,8 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then  \
 
 COPY --from=build /opt/tabby /opt/tabby
 
+# Fix llama-server libcuda.so.1: cannot open shared object file
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/compat"
 ENV PATH="$PATH:/opt/tabby/bin"
 ENV TABBY_ROOT=/data
 


### PR DESCRIPTION
When use `tabbyml/tabby:latest`, we got
`WARN llama_cpp_server::supervisor: crates/llama-cpp-server/src/supervisor.rs:88: llama-server exited with status code 127, restarting...`
in container try run `llama-server` we got
`llama-server: error while loading shared libraries: libcuda.so.1: cannot open shared object file: No such file or directory`
So we add environment `LD_LIBRARY_PATH` to fix this base image bug