### PR TITLE
fix(ui): correct text of line menu in code browser

### DIFF
--- a/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
+++ b/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
@@ -74,7 +74,7 @@ const lineMenuMarker = new (class extends GutterMarker {
               })
             }}
           >
-            Copy permalink
+            Copy link
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
### Change
change 'Copy permalink' to 'Copy link'


### Screenshot
<img width="853" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/6d30f46f-7dc8-4a9e-afb4-f295d0b55002">
