### PR TITLE
ci: add openmp lib to dockerfiles

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -54,6 +54,7 @@ RUN apt-get update && \
         unzip \
         openssh-client \
         ca-certificates \
+        libgomp1 \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -56,6 +56,7 @@ RUN apt-get update && \
     libssl3 \
     rocblas \
     hipblas \
+    libgomp1 \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
ref: https://github.com/ggerganov/llama.cpp/pull/7780
fix `tabbyml/tabby:nightly` cannot run with
`WARN llama_cpp_server::supervisor: crates/llama-cpp-server/src/supervisor.rs:106: <embedding>: /opt/tabby/bin/llama-server: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory`