### PR TITLE
feat(vscode): separate chat panel rendering

### DIFF
--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -32,10 +32,12 @@ export interface ServerApi {
   init: (request: InitRequest) => void
   sendMessage: (message: ChatMessage) => void
   showError: (error: ErrorMessage) => void
+  cleanError: () => void
 }
 
 export interface ClientApi {
   navigate: (context: Context) => void
+  refresh?: () => Promise<void>
 }
 
 export interface ChatMessage {
@@ -48,6 +50,7 @@ export function createClient(target: HTMLIFrameElement, api: ClientApi): ServerA
   return createThreadFromIframe(target, {
     expose: {
       navigate: api.navigate,
+      refresh: api.refresh,
     },
   })
 }
@@ -58,6 +61,7 @@ export function createServer(api: ServerApi): ClientApi {
       init: api.init,
       sendMessage: api.sendMessage,
       showError: api.showError,
+      cleanError: api.cleanError,
     },
   })
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -23,10 +23,15 @@ export interface InitRequest {
   fetcherOptions: FetcherOptions
 }
 
+export interface ErrorMessage {
+  title?: string
+  content: string
+}
+
 export interface ServerApi {
   init: (request: InitRequest) => void
   sendMessage: (message: ChatMessage) => void
-
+  showError: (error: ErrorMessage) => void
 }
 
 export interface ClientApi {
@@ -52,6 +57,7 @@ export function createServer(api: ServerApi): ClientApi {
     expose: {
       init: api.init,
       sendMessage: api.sendMessage,
+      showError: api.showError,
     },
   })
 }

--- a/clients/vscode/assets/chat-panel.css
+++ b/clients/vscode/assets/chat-panel.css
@@ -15,34 +15,3 @@ iframe {
   width: 100%;
   height: 100vh;
 }
-
-/* Static content page */
-.static-content {
-  padding: 0.65rem 1.2rem;
-}
-
-.static-content .avatar {
-  display: flex;
-  align-items: center;
-}
-
-.static-content .avatar img {
-  width: 1rem;
-  height: 1rem;
-  object-fit: contain;
-  border-radius: 100%;
-  margin-right: 0.4rem;
-  padding: 0.2rem;
-  border: 1px solid var(--vscode-editorWidget-border);
-  background-color: rgb(232, 226, 210);
-}
-
-.static-content .title {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-}
-
-.static-content p {
-  line-height: 1.45;
-  margin: 0.45rem 0;
-}

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -191,7 +191,7 @@ export class ChatViewProvider implements WebviewViewProvider {
     if (!this.isChatPanelAvailable(serverInfo)) {
       this.client?.showError({
         content:
-          "Please update to the latest release of the Tabby server.\n\nYou also need to launch the server with the chat model enabled; for example, use `--chat-model Mistral-7B`.",
+          "Please update to the latest release of the Tabby server.\n\nYou also need to launch the server with the chat model enabled; for example, use `--chat-model Qwen2-1.5B-Instruct`.",
       });
       return;
     }

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -183,7 +183,6 @@ export class ChatViewProvider implements WebviewViewProvider {
 
     if (agentStatus === "unauthorized") {
       return this.client?.showError({
-        title: "Tabby is not available",
         content:
           "Before you can start chatting, please take a moment to set up your credentials to connect to the Tabby server.",
       });
@@ -191,7 +190,6 @@ export class ChatViewProvider implements WebviewViewProvider {
 
     if (!this.isChatPanelAvailable(serverInfo)) {
       this.client?.showError({
-        title: "Tabby is not available",
         content:
           "Please update to the latest release of the Tabby server.\n\nYou also need to launch the server with the chat model enabled; for example, use `--chat-model Mistral-7B`.",
       });

--- a/clients/vscode/src/chat/chatPanel.ts
+++ b/clients/vscode/src/chat/chatPanel.ts
@@ -29,6 +29,7 @@ export function createClient(webview: WebviewView, api: ClientApi): ServerApi {
   return createThreadFromWebview(webview, {
     expose: {
       navigate: api.navigate,
+      refresh: api.refresh,
     },
   });
 }

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -48,16 +48,6 @@ export async function activate(context: ExtensionContext) {
     const languageClient = new NodeLanguageClient("Tabby", serverOptions, clientOptions);
     client = new Client(context, languageClient);
   }
-  const config = new Config(context);
-  const inlineCompletionProvider = new InlineCompletionProvider(client, config);
-  const gitProvider = new GitProvider();
-
-  client.registerConfigManager(config);
-  client.registerInlineCompletionProvider(inlineCompletionProvider);
-  client.registerGitProvider(gitProvider);
-
-  await client.start();
-
   // Register chat panel
   const chatViewProvider = new ChatViewProvider(context, client.agent, logger);
   context.subscriptions.push(
@@ -65,6 +55,15 @@ export async function activate(context: ExtensionContext) {
       webviewOptions: { retainContextWhenHidden: true },
     }),
   );
+
+  const config = new Config(context);
+  const inlineCompletionProvider = new InlineCompletionProvider(client, config);
+  const gitProvider = new GitProvider();
+  client.registerConfigManager(config);
+  client.registerInlineCompletionProvider(inlineCompletionProvider);
+  client.registerGitProvider(gitProvider);
+
+  await client.start();
 
   const issues = new Issues(client, config);
   const contextVariables = new ContextVariables(client, config);

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -192,12 +192,11 @@ export default function ChatPage() {
           <Image
             src={tabbyUrl}
             alt="logo"
-            className="rounded-full border"
+            className="rounded-full"
             style={{
               background: 'rgb(232, 226, 210)',
               marginRight: '0.375em',
-              padding: '0.125em',
-              borderColor: isThemeSynced ? 'inherit' : initialForeground
+              padding: '0.15em'
             }}
             width={18}
           />

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -16,7 +16,7 @@ import type {
 } from 'tabby-chat-panel'
 import { useServer } from 'tabby-chat-panel/react'
 
-import { cn, nanoid } from '@/lib/utils'
+import { nanoid } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { IconSpinner } from '@/components/ui/icons'
 import { Chat, ChatRef } from '@/components/chat/chat'
@@ -181,7 +181,7 @@ export default function ChatPage() {
   function StaticContent({ children }: { children: React.ReactNode }) {
     return (
       <div
-        className='h-screen w-screen'
+        className="h-screen w-screen"
         style={{
           fontSize: isThemeSynced ? 'inherit' : initialFontSize,
           color: isThemeSynced ? 'inherit' : initialForeground,

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -181,17 +181,14 @@ export default function ChatPage() {
   function StaticContent({ children }: { children: React.ReactNode }) {
     return (
       <div
-        className={cn(
-          'h-screen w-screen'
-          // !isThemeSynced && `${initialTheme} ${initialTheme}-foreground`
-        )}
+        className='h-screen w-screen'
         style={{
-          fontSize: initialFontSize,
-          color: initialForeground,
+          fontSize: isThemeSynced ? 'inherit' : initialFontSize,
+          color: isThemeSynced ? 'inherit' : initialForeground,
           padding: '5px 18px'
         }}
       >
-        <div className="flex items-center" style={{ marginBottom: '0.5em' }}>
+        <div className="flex items-center" style={{ marginBottom: '0.55em' }}>
           <Image
             src={tabbyUrl}
             alt="logo"
@@ -200,7 +197,7 @@ export default function ChatPage() {
               background: 'rgb(232, 226, 210)',
               marginRight: '0.375em',
               padding: '0.125em',
-              borderColor: initialForeground
+              borderColor: isThemeSynced ? 'inherit' : initialForeground
             }}
             width={18}
           />
@@ -223,7 +220,7 @@ export default function ChatPage() {
             {errorMessage.content}
           </MemoizedReactMarkdown>
           <Button
-            className="mt-3 flex items-center gap-x-2 text-sm leading-none"
+            className="mt-5 flex items-center gap-x-2 text-sm leading-none"
             onClick={refresh}
           >
             {isRefreshLoading && <IconSpinner />}

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -86,10 +86,6 @@
   body {
     @apply bg-background text-foreground; 
   }
-
-  body .dark.dark-foreground {
-    @apply text-foreground;
-  }
 }
 
 .prose-full-width {

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -84,7 +84,11 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground; 
+  }
+
+  body .dark.dark-foreground {
+    @apply text-foreground;
   }
 }
 

--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { Provider as UrqlProvider } from 'urql'
@@ -19,6 +19,15 @@ const publicPaths = ['/chat']
 export function Providers({ children, ...props }: ThemeProviderProps) {
   const pathName = usePathname()
   const isPublicPath = publicPaths.includes(pathName)
+  const searchParams = useSearchParams()
+  const themeFromQuery = searchParams.get('theme')
+  const clientFromQuery = searchParams.get('client')
+  if (themeFromQuery) props.defaultTheme = themeFromQuery
+  if (clientFromQuery === 'vscode') {
+    // The dark theme's default background color does not match VSCode's theme
+    // when rendering in VSCode, we use a separate CSS variable instead of relying on the theme
+    props.defaultTheme = 'none'
+  }
   return (
     <NextThemesProvider {...props}>
       <UrqlProvider value={client}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19358,23 +19358,7 @@ snapshots:
       postcss: 8.4.31
       ts-node: 10.9.2(@types/node@17.0.45)(typescript@5.2.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)):
-    dependencies:
-      lilconfig: 3.1.1
-      yaml: 2.4.2
-    optionalDependencies:
-      postcss: 8.4.38
-      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)
-
   postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)):
-    dependencies:
-      lilconfig: 3.1.1
-      yaml: 2.4.2
-    optionalDependencies:
-      postcss: 8.4.38
-      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)
-
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.2
@@ -19388,7 +19372,7 @@ snapshots:
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.4.38
-      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)
 
   postcss-merge-longhand@7.0.0(postcss@8.4.38):
     dependencies:
@@ -21109,7 +21093,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5))
       resolve-from: 5.0.0
       rollup: 4.17.2
       source-map: 0.8.0-beta.0
@@ -21133,7 +21117,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2)
       resolve-from: 5.0.0
       rollup: 4.17.2
       source-map: 0.8.0-beta.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19358,7 +19358,23 @@ snapshots:
       postcss: 8.4.31
       ts-node: 10.9.2(@types/node@17.0.45)(typescript@5.2.2)
 
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)):
+    dependencies:
+      lilconfig: 3.1.1
+      yaml: 2.4.2
+    optionalDependencies:
+      postcss: 8.4.38
+      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)
+
   postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)):
+    dependencies:
+      lilconfig: 3.1.1
+      yaml: 2.4.2
+    optionalDependencies:
+      postcss: 8.4.38
+      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)
+
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.2
@@ -19372,7 +19388,7 @@ snapshots:
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.4.38
-      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)
 
   postcss-merge-longhand@7.0.0(postcss@8.4.38):
     dependencies:
@@ -21093,7 +21109,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(typescript@5.4.5))
       resolve-from: 5.0.0
       rollup: 4.17.2
       source-map: 0.8.0-beta.0
@@ -21117,7 +21133,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3))
       resolve-from: 5.0.0
       rollup: 4.17.2
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
## Main changes
* In the chat panel, we render the /chat website asap without waiting agent's response
* In the `/vscode/src/extension.ts`, I move the place of registering chat panel before `await client.start()` because client.start usually takes 2+ seconds
* Inside /chat page, adding new logics to
  * Display loading
  * Display error message
* When VSCode side got error (Unauthorized or unavailable), it send message to /chat page to display the error
* In ChatViewProvider, now I have 2 separate logics for the chat page
  1. **renderChatPage**: this will render the /chat iframe, only `endpoint` is needed; This method will be called for the first time opening the panel & `agent.on("didUpdateServerInfo"`
  2. **reloadChatPage** (maybe can have a better name): it will fetchServerInfo and check agent.status, able to send /chat to display error message or init the chat page; This method will be called in `agent.on("didChangeStatus"` & re-open the chat panel in VSCode & right after the iframe /chat finish rendered 

## Questions
* Do we still need `<!--hash: ${hashObject(serverInfo)}-->` for the webview HTML? Because we only render the page once,  I'm unsure if the hash tag serves any additional purpose.
* Not a question, but to confirm. When click the refresh, I will do `reloadChatPage` which means it will refetch the server info and re-check agent status, as we discussed before, we still need an API here to refresh serverInfo I guess.

## Screenshots
Loading
<img width="376" alt="Screenshot 2024-06-27 18 05 45" src="https://github.com/TabbyML/tabby/assets/5305874/0ae541ca-685e-4fb2-9eb4-cda677916c8d">

Unauthorized
<img width="372" alt="Screenshot 2024-06-27 18 06 18" src="https://github.com/TabbyML/tabby/assets/5305874/6fa6a820-7e9c-493a-b40b-152717e7a8ff">

isChatPanelAvailable = false
<img width="372" alt="Screenshot 2024-06-27 18 05 31" src="https://github.com/TabbyML/tabby/assets/5305874/691c151f-3640-43db-9555-bab3f5ecc762">
