### PR TITLE
chore(ui): search li displaying issue

### DIFF
--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -758,7 +758,13 @@ function MessageMarkdown({
 
           if (children.length) {
             return (
-              <div className="mb-2 inline-block leading-relaxed last:mb-0">
+              <div
+                className="mb-2 inline-block leading-relaxed last:mb-0"
+                // To ensure the list marker aligns with the top of the <li> when a <p> element is inside it, apply vertical-align: top
+                style={{
+                  verticalAlign: 'top'
+                }}
+              >
                 {children.map((childrenItem, index) => {
                   if (typeof childrenItem === 'string') {
                     return renderTextWithCitation(childrenItem, index)


### PR DESCRIPTION
## What to fix
The list marker appear in the bottom
<img width="963" alt="Screenshot 2024-06-27 19 31 11" src="https://github.com/TabbyML/tabby/assets/5305874/05006793-0189-48a6-8e28-baa6050043b1">

## Fix
The issue is because inside `<li>`, somehow it render a content as `<p>`, after adding style `verticalAlign: 'top'` on the `<p>` can solve the issue
<img width="1008" alt="Screenshot 2024-06-27 19 36 53" src="https://github.com/TabbyML/tabby/assets/5305874/2c6cec2a-eeb5-4347-b906-1f34c388ff84">

## Would it affect other places if adding `verticalAlign: 'top'` on `<p>`?
No, my testing examples:
<img width="1018" alt="Screenshot 2024-06-27 19 30 16" src="https://github.com/TabbyML/tabby/assets/5305874/f38ce550-cbc5-4d97-9033-577141578cb5">
<img width="1125" alt="Screenshot 2024-06-27 19 30 09" src="https://github.com/TabbyML/tabby/assets/5305874/7fe4cbee-caa2-452d-a901-1153dd6e8950">

## The issue seems a edge case
I can only find the issue on current DEMO page.
It can't be re-produced on the current main branch with similar response:
<img width="957" alt="Screenshot 2024-06-27 19 35 04" src="https://github.com/TabbyML/tabby/assets/5305874/d7c16809-7903-4ec5-a813-049957ebd2b1">

