### PR TITLE
fix(ui): only display the spinner when the job state is 'running'

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-row.tsx
+++ b/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-row.tsx
@@ -123,6 +123,7 @@ export default function JobRow({ name }: { name: string }) {
           <div className="grid grid-cols-5 flex-wrap gap-1.5  xl:flex">
             {displayJobs?.map(job => {
               const { createdAt, finishedAt, startedAt } = job.node
+              const isJobRunning = !finishedAt && !!startedAt
               const createAt =
                 createdAt && moment(createdAt).format('YYYY-MM-DD HH:mm')
               const duration: string | null =
@@ -182,7 +183,7 @@ export default function JobRow({ name }: { name: string }) {
                         )}
                       >
                         {displayedDuration}
-                        {!displayedDuration && <IconSpinner />}
+                        {isJobRunning && <IconSpinner />}
                       </Link>
                     </TooltipTrigger>
                     <TooltipContent>


### PR DESCRIPTION
### Screen record
https://jam.dev/c/a8a60d50-f9ee-4e46-b477-1410613ecd89