### PR TITLE
feat: Bash support

### DIFF
--- a/crates/tabby-common/assets/languages.toml
+++ b/crates/tabby-common/assets/languages.toml
@@ -316,6 +316,39 @@ languages = ["powershell"]
 exts = ["ps1", "psd1", "psm1"]
 
 [[config]]
+languages = ["bash"]
+exts = ["sh"]
+line_comment = "#"
+top_level_keywords = [
+    "break",
+    "case",
+    "coproc",
+    "continue",
+    "do",
+    "done",
+    "else",
+    "elif",
+    "end",
+    "esac",
+    "eval",
+    "exec",
+    "exit",
+    "for",
+    "fi",
+    "function",
+    "if",
+    "in",
+    "return",
+    "select",
+    "shift",
+    "source",
+    "then",
+    "until",
+    "wait",
+    "while"
+]
+
+[[config]]
 languages = ["sql"]
 exts = ["sql"]
 

--- a/crates/tabby-scheduler/Cargo.toml
+++ b/crates/tabby-scheduler/Cargo.toml
@@ -24,6 +24,7 @@ tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev 
 tree-sitter-c-sharp = "0.21.2"
 tree-sitter-solidity = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "0e86ae647bda22c9bee00ec59752df7b3d3b000b" }
 tree-sitter-lua = "0.1.0"
+tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "d1a1a3f" }
 ignore.workspace = true
 tokio = { workspace = true, features = ["process"] }
 text-splitter = { version = "0.13.3", features = ["code"] }

--- a/crates/tabby-scheduler/queries/bash.scm
+++ b/crates/tabby-scheduler/queries/bash.scm
@@ -1,0 +1,3 @@
+(
+  (function_definition (identifier) @name) @definition.function
+)

--- a/crates/tabby-scheduler/src/code/languages.rs
+++ b/crates/tabby-scheduler/src/code/languages.rs
@@ -147,6 +147,17 @@ lazy_static! {
                     .unwrap(),
                 ),
             ),
+            (
+                "bash",
+                TagsConfigurationSync(
+                    TagsConfiguration::new(
+                        tree_sitter_bash::language(),
+                        include_str!("../../queries/bash.scm"),
+                        "",
+                    )
+                    .unwrap(),
+                ),
+            ),
         ])
     };
 }

--- a/website/docs/programming-languages.md
+++ b/website/docs/programming-languages.md
@@ -35,7 +35,8 @@ For an actual example of an issue or pull request adding the above support, plea
 * [Solidity](https://soliditylang.org/): Since v0.10.0
 * [R](https://www.r-project.org/): Since v0.12.0
 * [Dart](https://dart.dev/): Since v0.12.0
-* [Lua](https://www.lua.org): Since 0.14.0
+* [Lua](https://www.lua.org): Since v0.14.0
+* [Bash shell](https://www.gnu.org/software/bash/): Since v0.14.0
 
 ## Languages Missing Certain Support
 


### PR DESCRIPTION
support for bash shell scripting language

I think the only tag type applicable to scripts is function definitions; tree-sitter is all new to me so might want to have a look over that.

Also, while bash scripts commonly end in `.sh`, they often have no file extension, but are instead identified by the file beginning with `#!/bin/bash`,  `#!/bin/sh` or similar (they are also normally marked as executable). Not sure if there is any way to support looking for these attributes instead of just the filename.