### PR TITLE
fix(ui): disable posthog inside iframe

### DIFF
--- a/ee/tabby-ui/lib/posthog.tsx
+++ b/ee/tabby-ui/lib/posthog.tsx
@@ -35,6 +35,9 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (typeof window !== 'undefined' && isDemoMode) {
+      const isInIframe = window.self !== window.top
+      if (isInIframe) return
+
       const postHogInstance = posthog.init(POSTHOG_KEY, {
         api_host: POSTHOG_HOST,
         person_profiles: 'identified_only',


### PR DESCRIPTION
## Issue
When loading the site inside iFrame with postHogProvider, the iframe page is empty

## Why
PostHogProvider from `posthog-js/react` makes the bug, but not sure about the root reason at the moment.

PostHog has official doc about [Iframe recording](https://posthog.com/docs/session-replay/iframes), it says `If the iframe is from the same domain as the main page, there is no special setup needed.`. I didn't find we have setting up any restriction like Content-Security-Policy, so not sure what we can fix with PostHogProvider.

## Fix
Disable PostHogProvider inside iFrame
now when user opening `Ask Tabby` inside code browser, the event on PostHog dashboard is:
<img width="1609" alt="Screenshot 2024-06-28 08 03 21" src="https://github.com/TabbyML/tabby/assets/5305874/0af61f56-7353-4c5a-bd65-852b2ca4f30f">
