### PR TITLE
fix(ui): adjust border color of search input in search page

### DIFF
--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -460,6 +460,7 @@ export function Search() {
                 className="lg:max-w-4xl"
                 placeholder="Ask a follow up question"
                 isLoading={isLoading}
+                inSearchPage
               />
             </div>
           </div>

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -16,7 +16,8 @@ export default function TextAreaSearch({
   isLoading,
   autoFocus,
   loadingWithSpinning,
-  cleanAfterSearch = true
+  cleanAfterSearch = true,
+  inSearchPage
 }: {
   onSearch: (value: string) => void
   className?: string
@@ -26,6 +27,7 @@ export default function TextAreaSearch({
   autoFocus?: boolean
   loadingWithSpinning?: boolean
   cleanAfterSearch?: boolean
+  inSearchPage?: boolean
 }) {
   const [isShow, setIsShow] = useState(false)
   const [isFocus, setIsFocus] = useState(false)
@@ -58,8 +60,11 @@ export default function TextAreaSearch({
       className={cn(
         'relative flex w-full items-center overflow-hidden rounded-lg border border-muted-foreground bg-background px-4 transition-all hover:border-muted-foreground/60',
         {
-          '!border-primary': isFocus,
-          'py-0': showBetaBadge
+          '!border-zinc-400': isFocus && inSearchPage && theme !== 'dark',
+          '!border-primary': isFocus && (!inSearchPage || theme === 'dark'),
+          'py-0': showBetaBadge,
+          'border-2 dark:border border-zinc-400 hover:border-zinc-400/60 dark:border-muted-foreground dark:hover:border-muted-foreground/60':
+            inSearchPage
         },
         className
       )}


### PR DESCRIPTION
### Before
<img width="994" alt="Screenshot 2024-06-28 10 37 04" src="https://github.com/TabbyML/tabby/assets/5305874/6a86b84f-cff3-4f50-9bfe-37aabebe0aa3">

<img width="992" alt="Screenshot 2024-06-28 10 37 49" src="https://github.com/TabbyML/tabby/assets/5305874/aad85f6c-7796-4a29-8960-02b89cb18c3f">

### After
<img width="1070" alt="Screenshot 2024-06-28 10 56 37" src="https://github.com/TabbyML/tabby/assets/5305874/82f845ce-2327-434d-a90e-f8c700c82fb6">

<img width="1035" alt="Screenshot 2024-06-28 10 56 31" src="https://github.com/TabbyML/tabby/assets/5305874/eed5fe60-cece-4149-86e9-dd795bf47ae4">

### The improvement only for the light theme in search page
The dark theme looks fine, so keep it same as before
<img width="1051" alt="Screenshot 2024-06-28 11 03 30" src="https://github.com/TabbyML/tabby/assets/5305874/9b6b48d5-f60b-46f9-8104-f99fea6872e2">

### Other attempts
Smaller search input
<img width="1083" alt="Screenshot 2024-06-28 10 41 32" src="https://github.com/TabbyML/tabby/assets/5305874/99b4b487-e823-4303-a131-dd98f16cd636">
