### PR TITLE
chore(ui): admin report padding & admin header padding

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
+++ b/ee/tabby-ui/app/(dashboard)/reports/components/report.tsx
@@ -210,7 +210,7 @@ export function Report() {
   }
 
   return (
-    <div className="mx-auto w-[calc(100vw-2rem)] max-w-5xl md:w-auto">
+    <div className="w-[calc(100vw-2rem)] md:w-auto 2xl:mx-auto 2xl:max-w-5xl">
       <div className="mb-4 flex flex-col items-center justify-between gap-y-2 lg:flex-row lg:items-end lg:gap-y-0">
         <SubHeader className="mb-0">
           Statistics around Tabby IDE / Extensions

--- a/ee/tabby-ui/components/header.tsx
+++ b/ee/tabby-ui/components/header.tsx
@@ -5,6 +5,7 @@ import { compare } from 'compare-versions'
 
 import { useHealth } from '@/lib/hooks/use-health'
 import { ReleaseInfo, useLatestRelease } from '@/lib/hooks/use-latest-release'
+import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
 import { IconNotice } from '@/components/ui/icons'
 
@@ -20,14 +21,14 @@ export function Header() {
   const newVersionAvailable = isNewVersionAvailable(version, latestRelease)
 
   return (
-    <header className="sticky top-0 z-50 flex h-16 w-full shrink-0 items-center justify-between border-b px-4 backdrop-blur-xl">
+    <header className="sticky top-0 z-50 flex h-16 w-full shrink-0 items-center justify-between border-b px-4 backdrop-blur-xl lg:px-10">
       <div className="flex items-center">
         {newVersionAvailable && (
           <a
             target="_blank"
             href="https://github.com/TabbyML/tabby/releases/latest"
             rel="noopener noreferrer"
-            className={buttonVariants({ variant: 'ghost' })}
+            className={cn('!pl-0', buttonVariants({ variant: 'ghost' }))}
           >
             <IconNotice className="text-yellow-600 dark:text-yellow-400" />
             <span className="ml-2 hidden md:flex">


### PR DESCRIPTION
### Before 2xl(1530px), keep same padding as other pages
<img width="1507" alt="Screenshot 2024-06-28 12 22 57" src="https://github.com/TabbyML/tabby/assets/5305874/32f2789a-aa75-4aec-a429-fd0543dad64d">

### After 2xl(1530px), still making the charts in the center
<img width="2340" alt="Screenshot 2024-06-28 12 26 44" src="https://github.com/TabbyML/tabby/assets/5305874/512e3885-8244-41e0-a3a2-1e1a1cc5d7f0">

Because too much width looks not suitable for the charts
<img width="2334" alt="Screenshot 2024-06-28 12 20 50" src="https://github.com/TabbyML/tabby/assets/5305874/a1859a0c-b110-4002-89d5-ac424eb82ef1">


### Adjust header's padding to align with content inside the page
Before:
<img width="1489" alt="Screenshot 2024-06-28 12 31 35" src="https://github.com/TabbyML/tabby/assets/5305874/28922c36-ef19-457e-9bfb-56e6e5ae1dd8">

After:
<img width="1497" alt="Screenshot 2024-06-28 12 32 43" src="https://github.com/TabbyML/tabby/assets/5305874/c508bee1-74b6-4837-bcb0-1d3559032ad7">


