### PR TITLE
docs: add execution permission to the llama-server when running tabby…

### DIFF
--- a/website/docs/quick-start/installation/linux/index.mdx
+++ b/website/docs/quick-start/installation/linux/index.mdx
@@ -31,7 +31,7 @@ Running Tabby on Linux using Tabby's standalone executable distribution.
 ## Find the Linux executable file
 * Unzip the file you downloaded. The `tabby` executable will be in a subdirectory of dist.
 * Change to this subdirectory or relocate `tabby` to a folder of your choice.
-* Make it executable: `chmod +x tabby`
+* Make it executable: `chmod +x tabby llama-server`
 
 Run the following command:
 ```


### PR DESCRIPTION
… on Linux

The user should give execution permission to the llama-server when running on Tabby on a Linux standalone install. Otherwise, the application will crash due to a permission error. 

```sh
The application panicked (crashed).
Message:  Failed to start llama-server <embedding> with command Command { std: "/home/<user>/tabby/dist/tabby/llama-server" "-m" "/home/<user>/.tabby/models/TabbyML/Nomic-Embed-Text/ggml/model.gguf" "--cont-batching" "--port" "30888" "-np" "1" "--log-disable" "--ctx-size" "4096" "-ngl" "9999" "--embedding" "--ubatch-size" "4096", kill_on_drop: true }: Permission denied (os error 13)
Location: crates/llama-cpp-server/src/supervisor.rs:80
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for Linux to include making `llama-server` executable alongside `tabby`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->