### PR TITLE
Revert "ci: add compat ld path for locatinglibcuda.so.1 in docker bui…

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -83,8 +83,6 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then  \
 
 COPY --from=build /opt/tabby /opt/tabby
 
-# Fix llama-server libcuda.so.1: cannot open shared object file
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/compat"
 ENV PATH="$PATH:/opt/tabby/bin"
 ENV TABBY_ROOT=/data
 


### PR DESCRIPTION
…ld "

This reverts commit 15e2e34441f28180fbd6ea231884c8bc64ba8ff7.


Fix https://github.com/TabbyML/tabby/issues/2548