### PR TITLE
feat(vscode): send chat message with selection if available

### DIFF
--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -38,6 +38,7 @@ export interface ServerApi {
 export interface ClientApi {
   navigate: (context: Context) => void
   refresh: () => Promise<void>
+  onSubmitMessage?: (msg: string) => Promise<void>
 }
 
 export interface ChatMessage {
@@ -51,6 +52,7 @@ export function createClient(target: HTMLIFrameElement, api: ClientApi): ServerA
     expose: {
       navigate: api.navigate,
       refresh: api.refresh,
+      onSubmitMessage: api.onSubmitMessage,
     },
   })
 }

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -56,7 +56,8 @@ export class Commands {
       commands.executeCommand("tabby.chatView.focus");
       const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
       if (!fileContext) {
-        return window.showInformationMessage("No selected codes");
+        window.showInformationMessage("No selected codes");
+        return
       }
 
       this.chatViewProvider.sendMessage({

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -57,7 +57,7 @@ export class Commands {
       const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
       if (!fileContext) {
         window.showInformationMessage("No selected codes");
-        return
+        return;
       }
 
       this.chatViewProvider.sendMessage({

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -50,6 +50,24 @@ export class Commands {
     this.context.subscriptions.push(...notNullRegistrations);
   }
 
+  private sendMessageToChatPanel(msg: string) {
+    const editor = window.activeTextEditor;
+    if (editor) {
+      commands.executeCommand("tabby.chatView.focus");
+      const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
+      if (!fileContext) {
+        return window.showInformationMessage("No selected codes");
+      }
+
+      this.chatViewProvider.sendMessage({
+        message: msg,
+        selectContext: fileContext,
+      });
+    } else {
+      window.showInformationMessage("No active editor");
+    }
+  }
+
   commands: Record<string, (...args: never[]) => void> = {
     applyCallback: (callback: (() => void) | undefined) => {
       callback?.();
@@ -216,56 +234,16 @@ export class Commands {
       }
     },
     "chat.explainCodeBlock": async () => {
-      const editor = window.activeTextEditor;
-      if (editor) {
-        commands.executeCommand("tabby.chatView.focus");
-        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
-        this.chatViewProvider.sendMessage({
-          message: "Explain the selected code:",
-          selectContext: fileContext,
-        });
-      } else {
-        window.showInformationMessage("No active editor");
-      }
+      this.sendMessageToChatPanel("Explain the selected code:");
     },
     "chat.fixCodeBlock": async () => {
-      const editor = window.activeTextEditor;
-      if (editor) {
-        commands.executeCommand("tabby.chatView.focus");
-        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
-        this.chatViewProvider.sendMessage({
-          message: "Identify and fix potential bugs in the selected code:",
-          selectContext: fileContext,
-        });
-      } else {
-        window.showInformationMessage("No active editor");
-      }
+      this.sendMessageToChatPanel("Identify and fix potential bugs in the selected code:");
     },
     "chat.generateCodeBlockDoc": async () => {
-      const editor = window.activeTextEditor;
-      if (editor) {
-        commands.executeCommand("tabby.chatView.focus");
-        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
-        this.chatViewProvider.sendMessage({
-          message: "Generate documentation for the selected code:",
-          selectContext: fileContext,
-        });
-      } else {
-        window.showInformationMessage("No active editor");
-      }
+      this.sendMessageToChatPanel("Generate documentation for the selected code:");
     },
     "chat.generateCodeBlockTest": async () => {
-      const editor = window.activeTextEditor;
-      if (editor) {
-        commands.executeCommand("tabby.chatView.focus");
-        const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
-        this.chatViewProvider.sendMessage({
-          message: "Generate a unit test for the selected code:",
-          selectContext: fileContext,
-        });
-      } else {
-        window.showInformationMessage("No active editor");
-      }
+      this.sendMessageToChatPanel("Generate a unit test for the selected code:");
     },
     "chat.edit.start": async () => {
       const editor = window.activeTextEditor;

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -123,7 +123,7 @@ export class ChatViewProvider implements WebviewViewProvider {
         };
         if (editor) {
           const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
-          if (fileContext) chatMessage.selectContext = fileContext;
+          if (fileContext) chatMessage.relevantContext = [fileContext];
         }
 
         this.sendMessage(chatMessage);

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -7,6 +7,7 @@ import {
   env,
   LogOutputChannel,
   TextEditor,
+  window,
 } from "vscode";
 import type { ServerApi, ChatMessage, Context } from "tabby-chat-panel";
 import hashObject from "object-hash";
@@ -26,6 +27,7 @@ export class ChatViewProvider implements WebviewViewProvider {
     private readonly context: ExtensionContext,
     private readonly agent: Agent,
     private readonly logger: LogOutputChannel,
+    private readonly gitProvider: GitProvider,
   ) {}
 
   static getFileContextFromSelection({
@@ -34,7 +36,7 @@ export class ChatViewProvider implements WebviewViewProvider {
   }: {
     editor: TextEditor;
     gitProvider: GitProvider;
-  }): Context {
+  }): Context | null {
     const alignIndent = (text: string) => {
       const lines = text.split("\n");
       const subsequentLines = lines.slice(1);
@@ -54,6 +56,8 @@ export class ChatViewProvider implements WebviewViewProvider {
 
     const uri = editor.document.uri;
     const text = editor.document.getText(editor.selection);
+    if (!text) return null;
+
     const workspaceFolder = workspace.getWorkspaceFolder(uri);
     const repo = gitProvider.getRepository(uri);
     const remoteUrl = repo ? gitProvider.getDefaultRemoteUrl(repo) : undefined;
@@ -111,6 +115,18 @@ export class ChatViewProvider implements WebviewViewProvider {
         const serverInfo = await this.agent.fetchServerInfo();
         await this.renderChatPage(serverInfo.config.endpoint);
         return;
+      },
+      onSubmitMessage: async (msg: string) => {
+        const editor = window.activeTextEditor;
+        const chatMessage: ChatMessage = {
+          message: msg,
+        };
+        if (editor) {
+          const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
+          if (fileContext) chatMessage.selectContext = fileContext;
+        }
+
+        this.sendMessage(chatMessage);
       },
     });
 
@@ -260,13 +276,14 @@ export class ChatViewProvider implements WebviewViewProvider {
                   const themeQuery = "&theme=" + theme
                   const fontSizeQuery = "&font-size=" + fontSize
                   const foregroundQuery = "&foreground=" + foreground.replace('#', '')
+                  const handlSubmitMessageQuery = "&handle-message-submit=true"
       
                   chatIframe.addEventListener('load', function() {
                     vscode.postMessage({ action: 'rendered' });
                     syncTheme()
                   });
 
-                  chatIframe.src=encodeURI("${endpoint}/chat?" + clientQuery + themeQuery + fontSizeQuery + foregroundQuery)
+                  chatIframe.src=encodeURI("${endpoint}/chat?" + clientQuery + themeQuery + fontSizeQuery + foregroundQuery + handlSubmitMessageQuery)
                 }
                 
                 window.addEventListener("message", (event) => {

--- a/clients/vscode/src/chat/chatPanel.ts
+++ b/clients/vscode/src/chat/chatPanel.ts
@@ -30,6 +30,7 @@ export function createClient(webview: WebviewView, api: ClientApi): ServerApi {
     expose: {
       navigate: api.navigate,
       refresh: api.refresh,
+      onSubmitMessage: api.onSubmitMessage,
     },
   });
 }

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -48,20 +48,20 @@ export async function activate(context: ExtensionContext) {
     const languageClient = new NodeLanguageClient("Tabby", serverOptions, clientOptions);
     client = new Client(context, languageClient);
   }
-  // Register chat panel
-  const chatViewProvider = new ChatViewProvider(context, client.agent, logger);
-  context.subscriptions.push(
-    window.registerWebviewViewProvider("tabby.chatView", chatViewProvider, {
-      webviewOptions: { retainContextWhenHidden: true },
-    }),
-  );
-
   const config = new Config(context);
   const inlineCompletionProvider = new InlineCompletionProvider(client, config);
   const gitProvider = new GitProvider();
   client.registerConfigManager(config);
   client.registerInlineCompletionProvider(inlineCompletionProvider);
   client.registerGitProvider(gitProvider);
+
+  // Register chat panel
+  const chatViewProvider = new ChatViewProvider(context, client.agent, logger, gitProvider);
+  context.subscriptions.push(
+    window.registerWebviewViewProvider("tabby.chatView", chatViewProvider, {
+      webviewOptions: { retainContextWhenHidden: true },
+    }),
+  );
 
   await client.start();
 

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -59,8 +59,11 @@ export default function ChatPage() {
   const initialForeground = searchParams.get('foreground')
     ? `#${searchParams.get('foreground')}`
     : undefined
+  const handleMessageSubmit =
+    searchParams.get('handle-message-submit') || undefined
 
   const isFromVSCode = client === 'vscode'
+  const isOnSubmitMessage = handleMessageSubmit === 'true'
   const maxWidth = isFromVSCode ? '5xl' : undefined
 
   useEffect(() => {
@@ -179,6 +182,10 @@ export default function ChatPage() {
     setIsRefreshLoading(false)
   }
 
+  const onSubmitMessage = async (msg: string) => {
+    return server?.onSubmitMessage?.(msg)
+  }
+
   function StaticContent({ children }: { children: React.ReactNode }) {
     return (
       <div
@@ -285,6 +292,7 @@ export default function ChatPage() {
         maxWidth={maxWidth}
         onCopyContent={client === 'vscode' ? onCopyContent : undefined}
         from={client}
+        onSubmitMessage={isOnSubmitMessage ? onSubmitMessage : undefined}
       />
     </ErrorBoundary>
   )

--- a/ee/tabby-ui/components/chat/chat.tsx
+++ b/ee/tabby-ui/components/chat/chat.tsx
@@ -122,6 +122,7 @@ interface ChatProps extends React.ComponentProps<'div'> {
   onCopyContent?: (value: string) => void
   isReferenceClickable?: boolean
   from?: string
+  onSubmitMessage?: (msg: string) => Promise<void>
 }
 
 function ChatRenderer(
@@ -143,7 +144,8 @@ function ChatRenderer(
     promptFormClassname,
     onCopyContent,
     isReferenceClickable = true,
-    from
+    from,
+    onSubmitMessage
   }: ChatProps,
   ref: React.ForwardedRef<ChatRef>
 ) {
@@ -345,6 +347,7 @@ function ChatRenderer(
   }
 
   const handleSubmit = async (value: string) => {
+    if (onSubmitMessage) return onSubmitMessage(value)
     return sendUserChat({
       message: value
     })


### PR DESCRIPTION
## Main feature
When code is selected in the editor, the chat panel can send a message containing the selected code to the server
<img width="600" alt="Screenshot 2024-07-03 15 42 25" src="https://github.com/TabbyML/tabby/assets/5305874/db3a7fc0-770b-4996-9a1a-7dce25e7abd0">

If no code is selected, the chat panel will not include additional information
<img width="600" alt="2" src="https://github.com/TabbyML/tabby/assets/5305874/43cfe5ee-01bd-4f02-af4f-849d34bbe813">

## Implementation
1. The `/chat` page has a new query parameter `handle-message-submit`. When `handle-message-submit=true`, `/chat` page delegates the handling of the submitted message to its parent container (e.g., VSCode).
2. In VSCode, when `onSubmitMessage` is called, it attempts to fetch the selected code snippets.
3. VSCode then calls the `/chat` endpoint to process the new message, including the selected code as relavantContext, and inside the /chat, it will take relavantContext as code_query.