### PR TITLE
fix(ui): relevantContext to chat message

### DIFF
--- a/ee/tabby-ui/components/chat/chat.tsx
+++ b/ee/tabby-ui/components/chat/chat.tsx
@@ -81,14 +81,14 @@ function userMessageToMessage(
     id,
     role: 'user',
     content: includeTransformedSelectContext
-      ? message + selectContextToMessageContent(userMessage.selectContext)
+      ? message +
+        selectContextToMessageContent(userMessage.selectContext) +
+        userMessage.relevantContext?.map(selectContextToMessageContent).join('')
       : message
   }
 }
 
-function selectContextToMessageContent(
-  context: UserMessage['selectContext']
-): string {
+function selectContextToMessageContent(context?: Context): string {
   if (!context || !context.content) return ''
   const { content, filepath } = context
   const language = filename2prism(filepath)?.[0]


### PR DESCRIPTION
relevantContext added into the method `userMessageToMessage` in `/components/chat`

<img width="650" alt="Screenshot 2024-07-03 17 56 56" src="https://github.com/TabbyML/tabby/assets/5305874/17b55524-fcdc-4303-9a51-0bcbf1347877">

<img width="650" alt="Screenshot 2024-07-03 17 54 59" src="https://github.com/TabbyML/tabby/assets/5305874/cb443fc9-4c96-4bbb-b22f-608f8d8d33e4">
