### PR TITLE
feat(ui): support selecting repositories in answer engine

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/providers/[kind]/detail/components/provider-detail.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/providers/[kind]/detail/components/provider-detail.tsx
@@ -381,7 +381,7 @@ const ActiveRepoTable: React.FC<{
           ) : (
             <TableRow>
               <TableCell colSpan={4} className="h-[100px] text-center">
-                No repositories yet.
+                No repositories
               </TableCell>
             </TableRow>
           )}

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -41,6 +41,7 @@ import Stats from './components/stats'
 
 import 'aos/dist/aos.css'
 
+import { AnswerRequest } from '@/lib/types'
 import { Separator } from '@/components/ui/separator'
 
 const resetUserAuthTokenDocument = graphql(/* GraphQL */ `
@@ -82,10 +83,19 @@ function MainPanel() {
 
   if (!healthInfo || !data?.me) return <></>
 
-  const onSearch = (question: string) => {
+  const onSearch = (
+    question: string,
+    code_query?: AnswerRequest['code_query']
+  ) => {
     setIsLoading(true)
     sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_MSG)
     sessionStorage.setItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG, question)
+    sessionStorage.setItem(
+      SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA,
+      JSON.stringify({
+        code_query
+      })
+    )
     router.push('/search')
   }
 

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -89,10 +89,10 @@ function MainPanel() {
   ) => {
     setIsLoading(true)
     sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_MSG)
-    sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_CONTEXT)
+    sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_EXTRA_CONTEXT)
     sessionStorage.setItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG, question)
     sessionStorage.setItem(
-      SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA,
+      SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA_CONTEXT,
       JSON.stringify({ code_query })
     )
     router.push('/search')

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -89,12 +89,11 @@ function MainPanel() {
   ) => {
     setIsLoading(true)
     sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_MSG)
+    sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_CONTEXT)
     sessionStorage.setItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG, question)
     sessionStorage.setItem(
       SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA,
-      JSON.stringify({
-        code_query
-      })
+      JSON.stringify({ code_query })
     )
     router.push('/search')
   }

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import tabbyUrl from '@/assets/logo-dark.png'
 import AOS from 'aos'
-import { noop } from 'lodash-es'
+import { noop, omit } from 'lodash-es'
 
 import { SESSION_STORAGE_KEY } from '@/lib/constants'
 import { useEnableSearch } from '@/lib/experiment-flags'
@@ -41,7 +41,7 @@ import Stats from './components/stats'
 
 import 'aos/dist/aos.css'
 
-import { AnswerRequest } from '@/lib/types'
+import { AnswerEngineExtraContext } from '@/lib/types'
 import { Separator } from '@/components/ui/separator'
 
 const resetUserAuthTokenDocument = graphql(/* GraphQL */ `
@@ -83,17 +83,16 @@ function MainPanel() {
 
   if (!healthInfo || !data?.me) return <></>
 
-  const onSearch = (
-    question: string,
-    code_query?: AnswerRequest['code_query']
-  ) => {
+  const onSearch = (question: string, ctx?: AnswerEngineExtraContext) => {
     setIsLoading(true)
     sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_MSG)
     sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_LATEST_EXTRA_CONTEXT)
     sessionStorage.setItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG, question)
     sessionStorage.setItem(
       SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA_CONTEXT,
-      JSON.stringify({ code_query })
+      JSON.stringify({
+        repository: ctx?.repository ? omit(ctx.repository, 'refs') : undefined
+      })
     )
     router.push('/search')
   }

--- a/ee/tabby-ui/app/files/components/file-tree-header.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree-header.tsx
@@ -259,7 +259,7 @@ const FileTreeHeader: React.FC<FileTreeHeaderProps> = ({
           <SelectContent className="max-h-[50vh] overflow-y-auto">
             {noIndexedRepo ? (
               <SelectItem isPlaceHolder value="" disabled>
-                No indexed repository
+                No repositories
               </SelectItem>
             ) : (
               <>

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React from 'react'
-import { isEmpty } from 'lodash-es'
 import { useInView } from 'react-intersection-observer'
 import { SWRResponse } from 'swr'
 import useSWRImmutable from 'swr/immutable'

--- a/ee/tabby-ui/app/files/components/file-tree.tsx
+++ b/ee/tabby-ui/app/files/components/file-tree.tsx
@@ -352,13 +352,6 @@ const FileTreeRenderer: React.FC = () => {
 
   if (!initialized) return <FileTreeSkeleton />
 
-  if (isEmpty(repoMap))
-    return (
-      <div className="flex h-full items-center justify-center">
-        No Indexed repository
-      </div>
-    )
-
   if (!hasSelectedRepo) {
     return null
   }

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -14,6 +14,7 @@ import { useIsChatEnabled } from '@/lib/hooks/use-server-info'
 import { filename2prism } from '@/lib/language-utils'
 import fetcher from '@/lib/tabby/fetcher'
 import { client } from '@/lib/tabby/gql'
+import { repositoryListQuery } from '@/lib/tabby/query'
 import type { ResolveEntriesResponse, TFile } from '@/lib/types'
 import { cn, formatLineHashForCodeBrowser } from '@/lib/utils'
 import {
@@ -74,18 +75,6 @@ type TFileMapItem = {
 }
 type TFileMap = Record<string, TFileMapItem>
 type RepositoryItem = RepositoryListQuery['repositoryList'][0]
-
-const repositoryListQuery = graphql(/* GraphQL */ `
-  query RepositoryList {
-    repositoryList {
-      id
-      name
-      kind
-      gitUrl
-      refs
-    }
-  }
-`)
 
 const repositoryGrepQuery = graphql(/* GraphQL */ `
   query RepositoryGrep($id: ID!, $kind: RepositoryKind!, $query: String!) {

--- a/ee/tabby-ui/app/files/components/source-code-browser.tsx
+++ b/ee/tabby-ui/app/files/components/source-code-browser.tsx
@@ -345,9 +345,10 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
   const isSearchMode = activeEntryInfo?.viewMode === 'search'
 
   const shouldFetchTree =
-    !!isPathInitialized && !isEmpty(repoMap) && !!activePath && !isSearchMode
+    !!initialized && !isEmpty(repoMap) && !!activePath && !isSearchMode
   const shouldFetchRepositoryGrep =
-    !!isPathInitialized && !isEmpty(repoMap) && !!activePath && isSearchMode
+    !!initialized && !isEmpty(repoMap) && !!activePath && isSearchMode
+  const shouldFetchRawFile = !!initialized && isBlobMode && activeRepo
 
   // fetch tree
   const {
@@ -382,7 +383,7 @@ const SourceCodeBrowserRenderer: React.FC<SourceCodeBrowserProps> = ({
     contentLength?: number
     fileDisplayType: FileDisplayType
   }>(
-    isBlobMode && activeRepo
+    shouldFetchRawFile
       ? [
           toEntryRequestUrl(activeRepo, activeRepoRef?.name, activeBasename),
           activeBasename

--- a/ee/tabby-ui/app/files/components/tree-mode-view.tsx
+++ b/ee/tabby-ui/app/files/components/tree-mode-view.tsx
@@ -4,7 +4,13 @@ import { find, isEmpty, omit } from 'lodash-es'
 
 import { useDebounceValue } from '@/lib/hooks/use-debounce'
 import { cn } from '@/lib/utils'
-import { IconDirectorySolid, IconFile } from '@/components/ui/icons'
+import { buttonVariants } from '@/components/ui/button'
+import {
+  IconArrowRight,
+  IconDirectorySolid,
+  IconFile,
+  IconFileSearch
+} from '@/components/ui/icons'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table'
 
@@ -150,8 +156,20 @@ const TreeModeView: React.FC<TreeModeViewProps> = ({
           </TableBody>
         </Table>
       ) : isEmpty(repoMap) ? (
-        <div className="flex justify-center py-8">
-          No indexed repository yet
+        <div className="flex min-h-[30vh] items-center justify-center">
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex items-center gap-2">
+              <IconFileSearch className="h-6 w-6" />
+              <div className="text-xl font-semibold">No repositories</div>
+            </div>
+            <Link
+              href="/settings/providers/git"
+              className={cn(buttonVariants(), 'gap-2')}
+            >
+              <span>Connect</span>
+              <IconArrowRight />
+            </Link>
+          </div>
         </div>
       ) : null}
     </div>

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -460,7 +460,7 @@ export function Search() {
                 className="lg:max-w-4xl"
                 placeholder="Ask a follow up question"
                 isLoading={isLoading}
-                inSearchPage
+                isFollowup
               />
             </div>
           </div>

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -159,14 +159,16 @@ export function Search() {
       SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG
     )
     const initialExtraContextStr = sessionStorage.getItem(
-      SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA
+      SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA_CONTEXT
     )
     const initialExtraInfo = initialExtraContextStr
       ? JSON.parse(initialExtraContextStr)
       : undefined
     if (initialMessage) {
       sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG)
-      sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA)
+      sessionStorage.removeItem(
+        SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA_CONTEXT
+      )
       setIsReady(true)
       setExtraContext(p => ({
         ...p,
@@ -181,7 +183,7 @@ export function Search() {
       SESSION_STORAGE_KEY.SEARCH_LATEST_MSG
     )
     const latestConversationContext = sessionStorage.getItem(
-      SESSION_STORAGE_KEY.SEARCH_LATEST_CONTEXT
+      SESSION_STORAGE_KEY.SEARCH_LATEST_EXTRA_CONTEXT
     )
     if (latesConversation) {
       const conversation = JSON.parse(
@@ -191,7 +193,7 @@ export function Search() {
 
       if (latestConversationContext) {
         const conversationContext = JSON.parse(
-          latesConversation
+          latestConversationContext
         ) as ExtraContext
         setExtraContext(conversationContext)
       }
@@ -314,7 +316,7 @@ export function Search() {
   // Save conversation context into sessionStorage
   useEffect(() => {
     sessionStorage.setItem(
-      SESSION_STORAGE_KEY.SEARCH_LATEST_CONTEXT,
+      SESSION_STORAGE_KEY.SEARCH_LATEST_EXTRA_CONTEXT,
       JSON.stringify(extraContext)
     )
   }, [extraContext])
@@ -712,7 +714,7 @@ function AnswerBlock({
                 <div
                   key={index}
                   className="flex cursor-pointer items-center justify-between rounded-lg border p-4 py-3 transition-opacity hover:opacity-70"
-                  onClick={onSubmitSearch.bind(null, related)}
+                  onClick={() => onSubmitSearch(related)}
                 >
                   <p className="w-full overflow-hidden text-ellipsis text-sm">
                     {related}

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -596,7 +596,7 @@ function AnswerBlock({
           >
             {answer.relevant_code.map((code, index) => (
               <RelevantCodeCard
-                key={code.filepath + code.git_url}
+                key={code.filepath + code.git_url + index}
                 code={code}
                 showMore={showMoreCode}
               />

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -115,7 +115,9 @@ export function Search() {
   const [container, setContainer] = useState<HTMLDivElement | null>(null)
   const [title, setTitle] = useState('')
   const [isReady, setIsReady] = useState(false)
-  const [extraRequestPayload, setExtraRequestPayload] = useState<Omit<AnswerRequest, 'user' | 'messages'>>({
+  const [extraRequestPayload, setExtraRequestPayload] = useState<
+    Omit<AnswerRequest, 'user' | 'messages'>
+  >({
     doc_query: true,
     generate_relevant_questions: true,
     collect_relevant_code_using_user_message: true
@@ -153,7 +155,10 @@ export function Search() {
       sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG)
       sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA)
       setIsReady(true)
-      setExtraRequestPayload(p => ({...p, code_query: initialExtraInfo?.code_query}))
+      setExtraRequestPayload(p => ({
+        ...p,
+        code_query: initialExtraInfo?.code_query
+      }))
       onSubmitSearch(initialMessage, initialExtraInfo?.code_query)
       return
     }
@@ -307,7 +312,7 @@ export function Search() {
     const answerRequest: AnswerRequest = {
       messages: [...previousMessages, newUserMessage],
       ...extraRequestPayload,
-      code_query: code_query || extraRequestPayload.code_query,
+      code_query: code_query || extraRequestPayload.code_query
     }
 
     setCurrentLoadingId(newAssistantId)

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -115,6 +115,11 @@ export function Search() {
   const [container, setContainer] = useState<HTMLDivElement | null>(null)
   const [title, setTitle] = useState('')
   const [isReady, setIsReady] = useState(false)
+  const [extraRequestPayload, setExtraRequestPayload] = useState<Omit<AnswerRequest, 'user' | 'messages'>>({
+    doc_query: true,
+    generate_relevant_questions: true,
+    collect_relevant_code_using_user_message: true
+  })
   const [currentLoadindId, setCurrentLoadingId] = useState<string>('')
   const contentContainerRef = useRef<HTMLDivElement>(null)
   const [showSearchInput, setShowSearchInput] = useState(false)
@@ -148,6 +153,7 @@ export function Search() {
       sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG)
       sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA)
       setIsReady(true)
+      setExtraRequestPayload(p => ({...p, code_query: initialExtraInfo?.code_query}))
       onSubmitSearch(initialMessage, initialExtraInfo?.code_query)
       return
     }
@@ -300,10 +306,8 @@ export function Search() {
 
     const answerRequest: AnswerRequest = {
       messages: [...previousMessages, newUserMessage],
-      code_query,
-      doc_query: true,
-      generate_relevant_questions: true,
-      collect_relevant_code_using_user_message: true
+      ...extraRequestPayload,
+      code_query: code_query || extraRequestPayload.code_query,
     }
 
     setCurrentLoadingId(newAssistantId)

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -58,7 +58,7 @@ export default function TextAreaSearch({
   const [isShow, setIsShow] = useState(false)
   const [isFocus, setIsFocus] = useState(false)
   const [value, setValue] = useState('')
-  const [selectedRepo, setSelectedRepo] = useState<RepoItem | undefined>()
+  const [selectedRepo, setSelectedRepo] = useState<Repository | undefined>()
   const { theme } = useCurrentTheme()
 
   useEffect(() => {
@@ -78,10 +78,10 @@ export default function TextAreaSearch({
 
   const search = () => {
     if (!value || isLoading) return
-    const code_query: AnswerRequest['code_query'] = selectedRepo
-      ? { git_url: selectedRepo.gitUrl, content: '' }
-      : undefined
-    onSearch(value, code_query)
+    onSearch(
+      value,
+      selectedRepo ? { git_url: selectedRepo.gitUrl, content: '' } : undefined
+    )
     if (cleanAfterSearch) setValue('')
   }
 
@@ -170,12 +170,9 @@ export default function TextAreaSearch({
     </div>
   )
 }
-
-type RepoItem = Pick<Repository, 'gitUrl' | 'name'>
-
 interface RepoSelectProps {
-  value: RepoItem | undefined
-  onChange: (val: RepoItem | undefined) => void
+  value: Repository | undefined
+  onChange: (val: Repository | undefined) => void
   className?: string
 }
 function RepoSelect({ value, onChange, className }: RepoSelectProps) {

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -241,7 +241,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
         <PopoverPortal>
           <PopoverContent className="min-w-[300px]" align="start" side="bottom">
             <Command>
-              <CommandInput placeholder="Search repositories" />
+              <CommandInput placeholder="Search" />
               <CommandList className="max-h-[200px]">
                 <CommandEmpty>
                   {fetching ? (

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -231,7 +231,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
           </TooltipTrigger>
         </PopoverTrigger>
         <PopoverPortal>
-          <PopoverContent className="min-w-[300px]" align="start" side="bottom">
+          <PopoverContent className="min-w-[300px] lg:max-w-[60vw]" align="start" side="bottom">
             <Command>
               <CommandInput placeholder="Search" />
               <CommandList className="max-h-[200px]">
@@ -254,12 +254,12 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                           onChange({ ...repo })
                           setCommandVisible(false)
                         }}
-                        className="flex cursor-pointer items-center gap-2"
+                        className="flex cursor-pointer items-center gap-2 overflow-hidden"
                       >
                         <div className="h-4 w-4 shrink-0">
                           {isSelected && <IconCheck className="shrink-0" />}
                         </div>
-                        <span>{repo.name}</span>
+                        <span className='truncate'>{repo.name}</span>
                       </CommandItem>
                     )
                   })}

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -192,7 +192,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
             href="/settings/providers/git"
             className={cn(buttonVariants({ size: 'sm' }), 'gap-1')}
           >
-            Add repositories
+    Connect
             <IconArrowRight />
           </Link>
         </div>

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -298,17 +298,15 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
               {!!value && (
                 <>
                   <CommandSeparator />
-                  <CommandGroup>
-                    <CommandItem
-                      onSelect={() => {
-                        onChange(undefined)
-                        setCommandVisible(false)
-                      }}
-                      className="!pointer-events-auto cursor-pointer justify-center text-center !opacity-100"
-                    >
-                      Clear
-                    </CommandItem>
-                  </CommandGroup>
+                  <CommandItem
+                    onSelect={() => {
+                      onChange(undefined)
+                      setCommandVisible(false)
+                    }}
+                    className="!pointer-events-auto cursor-pointer justify-center text-center !opacity-100 mt-1"
+                  >
+                    Clear
+                  </CommandItem>
                 </>
               )}
             </Command>

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -132,7 +132,7 @@ export default function TextAreaSearch({
         minRows={isFollowup ? 1 : 2}
       />
       <div
-        className={cn('flex justify-between items-center', {
+        className={cn('flex items-center justify-between', {
           'pb-2': !isFollowup
         })}
       >
@@ -141,7 +141,7 @@ export default function TextAreaSearch({
         )}
         <div
           className={cn(
-            'flex justify-center items-center rounded-lg p-1 transition-all',
+            'flex items-center justify-center rounded-lg p-1 transition-all',
             {
               'bg-primary text-primary-foreground cursor-pointer':
                 value.length > 0,
@@ -181,7 +181,7 @@ function RepoSelect({ value, onChange }: RepoSelectProps) {
   const emptyText = useMemo(() => {
     if (!repos?.length)
       return (
-        <div className="py-2 space-y-4">
+        <div className="space-y-4 py-2">
           <p className="font-semibold">No indexed repositories</p>
           <Link
             href="/settings/providers/git"
@@ -206,7 +206,7 @@ function RepoSelect({ value, onChange }: RepoSelectProps) {
             <div
               className={cn(
                 buttonVariants({ variant: 'ghost' }),
-                'rounded-full cursor-pointer px-2 -ml-2'
+                '-ml-2 cursor-pointer rounded-full px-2'
               )}
             >
               <div className="flex items-center gap-1">

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -314,7 +314,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
         </PopoverPortal>
       </Popover>
       <TooltipContent>
-        Select indexed repositories to enhance the answer engine
+    Effortlessly interact with your repositories for contextualized search and assistance.
       </TooltipContent>
     </Tooltip>
   )

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -251,9 +251,10 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                 </CommandEmpty>
                 <CommandGroup>
                   {repos?.map(repo => {
-                    const isSelected = repo.gitUrl === value?.gitUrl
+                    const isSelected = !!value?.id && repo.id === value.id
                     return (
                       <CommandItem
+                        value={repo.id}
                         key={repo.id}
                         onSelect={() => {
                           onChange({ ...repo })

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -112,6 +112,7 @@ export default function TextAreaSearch({
         className={cn(
           'text-area-autosize flex-1 resize-none rounded-lg !border-none bg-transparent !shadow-none !outline-none !ring-0 !ring-offset-0',
           {
+            'w-full': !isFollowup,
             '!h-[48px]': !isShow,
             'pt-4': !showBetaBadge,
             'pt-5': showBetaBadge,
@@ -131,8 +132,8 @@ export default function TextAreaSearch({
         minRows={isFollowup ? 1 : 2}
       />
       <div
-        className={cn('flex justify-between', {
-          'pb-4': !isFollowup
+        className={cn('flex justify-between items-center', {
+          'pb-2': !isFollowup
         })}
       >
         {!isFollowup && (
@@ -147,7 +148,7 @@ export default function TextAreaSearch({
               '!bg-muted !text-primary !cursor-default':
                 isLoading || value.length === 0,
               'mr-1.5': !showBetaBadge,
-              'h-8 w-8': !isFollowup
+              'h-6 w-6': !isFollowup
               // 'mr-6': showBetaBadge,
             }
           )}

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -1,12 +1,38 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { findIndex } from 'lodash-es'
 import TextareaAutosize from 'react-textarea-autosize'
+import { useQuery } from 'urql'
 
+import { RepositoryListQuery } from '@/lib/gql/generates/graphql'
 import { useCurrentTheme } from '@/lib/hooks/use-current-theme'
+import { repositoryListQuery } from '@/lib/tabby/query'
 import { cn } from '@/lib/utils'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverPortal,
+  PopoverTrigger
+} from '@/components/ui/popover'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '@/components/ui/tooltip'
 
-import { IconArrowRight, IconSpinner } from './ui/icons'
+import { buttonVariants } from './ui/button'
+import { IconArrowRight, IconCheck, IconCode, IconSpinner } from './ui/icons'
 
 export default function TextAreaSearch({
   onSearch,
@@ -17,7 +43,7 @@ export default function TextAreaSearch({
   autoFocus,
   loadingWithSpinning,
   cleanAfterSearch = true,
-  inSearchPage
+  isFollowup
 }: {
   onSearch: (value: string) => void
   className?: string
@@ -27,11 +53,14 @@ export default function TextAreaSearch({
   autoFocus?: boolean
   loadingWithSpinning?: boolean
   cleanAfterSearch?: boolean
-  inSearchPage?: boolean
+  isFollowup?: boolean
 }) {
   const [isShow, setIsShow] = useState(false)
   const [isFocus, setIsFocus] = useState(false)
   const [value, setValue] = useState('')
+  const [selectedRepos, setSelectRepos] = useState<
+    RepositoryListQuery['repositoryList']
+  >([])
   const { theme } = useCurrentTheme()
 
   useEffect(() => {
@@ -58,13 +87,15 @@ export default function TextAreaSearch({
   return (
     <div
       className={cn(
-        'relative flex w-full items-center overflow-hidden rounded-lg border border-muted-foreground bg-background px-4 transition-all hover:border-muted-foreground/60',
+        'relative overflow-hidden rounded-lg border border-muted-foreground bg-background px-4 transition-all hover:border-muted-foreground/60',
         {
-          '!border-zinc-400': isFocus && inSearchPage && theme !== 'dark',
-          '!border-primary': isFocus && (!inSearchPage || theme === 'dark'),
+          'flex-col gap-1 w-full': !isFollowup,
+          'flex w-full items-center ': isFollowup,
+          '!border-zinc-400': isFocus && isFollowup && theme !== 'dark',
+          '!border-primary': isFocus && (!isFollowup || theme === 'dark'),
           'py-0': showBetaBadge,
           'border-2 dark:border border-zinc-400 hover:border-zinc-400/60 dark:border-muted-foreground dark:hover:border-muted-foreground/60':
-            inSearchPage
+            isFollowup
         },
         className
       )}
@@ -82,8 +113,10 @@ export default function TextAreaSearch({
           'text-area-autosize flex-1 resize-none rounded-lg !border-none bg-transparent !shadow-none !outline-none !ring-0 !ring-offset-0',
           {
             '!h-[48px]': !isShow,
-            'py-4': !showBetaBadge,
-            'py-5': showBetaBadge
+            'pt-4': !showBetaBadge,
+            'pt-5': showBetaBadge,
+            'pb-4': isFollowup && !showBetaBadge,
+            'pb-5': isFollowup && showBetaBadge
           }
         )}
         placeholder={placeholder || 'Ask anything...'}
@@ -95,24 +128,212 @@ export default function TextAreaSearch({
         onChange={e => setValue(e.target.value)}
         value={value}
         autoFocus={autoFocus}
+        minRows={isFollowup ? 1 : 2}
       />
       <div
-        className={cn('mr-6 flex items-center rounded-lg p-1 transition-all', {
-          'bg-primary text-primary-foreground cursor-pointer': value.length > 0,
-          '!bg-muted !text-primary !cursor-default':
-            isLoading || value.length === 0,
-          'mr-6': showBetaBadge,
-          'mr-1.5': !showBetaBadge
+        className={cn('flex justify-between', {
+          'pb-4': !isFollowup
         })}
-        onClick={search}
       >
-        {loadingWithSpinning && isLoading && (
-          <IconSpinner className="h-3.5 w-3.5" />
+        {!isFollowup && (
+          <RepoSelect value={selectedRepos} onChange={setSelectRepos} />
         )}
-        {(!loadingWithSpinning || !isLoading) && (
-          <IconArrowRight className="h-3.5 w-3.5" />
-        )}
+        <div
+          className={cn(
+            'flex justify-center items-center rounded-lg p-1 transition-all',
+            {
+              'bg-primary text-primary-foreground cursor-pointer':
+                value.length > 0,
+              '!bg-muted !text-primary !cursor-default':
+                isLoading || value.length === 0,
+              'mr-1.5': !showBetaBadge,
+              'h-8 w-8': !isFollowup
+              // 'mr-6': showBetaBadge,
+            }
+          )}
+          onClick={search}
+        >
+          {loadingWithSpinning && isLoading && (
+            <IconSpinner className="h-3.5 w-3.5" />
+          )}
+          {(!loadingWithSpinning || !isLoading) && (
+            <IconArrowRight className="h-3.5 w-3.5" />
+          )}
+        </div>
       </div>
     </div>
+  )
+}
+
+interface RepoSelectProps {
+  value: RepositoryListQuery['repositoryList']
+  onChange: (val: RepositoryListQuery['repositoryList']) => void
+  className?: string
+}
+function RepoSelect({ value, onChange }: RepoSelectProps) {
+  const [{ data, fetching }] = useQuery({
+    query: repositoryListQuery
+  })
+  const repos = data?.repositoryList
+  // const repos: any[] = []
+
+  const emptyText = useMemo(() => {
+    if (!repos?.length)
+      return (
+        <div className="py-2 space-y-4">
+          <p className="font-semibold">No indexed repositories</p>
+          <Link
+            href="/settings/providers/git"
+            className={cn(buttonVariants({ size: 'sm' }), 'gap-1')}
+          >
+            Add repositories
+            <IconArrowRight />
+          </Link>
+        </div>
+      )
+
+    return 'No results found'
+  }, [repos])
+
+  const isAllSelected = !!repos?.length && value?.length === repos.length
+
+  return (
+    <Tooltip delayDuration={0}>
+      <Popover>
+        <PopoverTrigger asChild>
+          <TooltipTrigger asChild>
+            <div
+              className={cn(
+                buttonVariants({ variant: 'ghost' }),
+                'rounded-full cursor-pointer px-2 -ml-2'
+              )}
+            >
+              <div className="flex items-center gap-1">
+                <IconCode
+                  className={cn(
+                    'shrink-0',
+                    value?.length ? 'text-foreground/70' : 'text-foreground/50'
+                  )}
+                />
+                <p
+                  className={cn(
+                    'w-full overflow-hidden text-ellipsis',
+                    value?.length ? 'text-foreground/70' : 'text-foreground/50'
+                  )}
+                >
+                  {isAllSelected
+                    ? 'All Repositories'
+                    : !value?.length
+                    ? 'Select repositories'
+                    : value?.length === 1
+                    ? value[0].name
+                    : `${value.length} ${
+                        value.length > 1 ? 'repositories' : 'repository'
+                      } selected`}
+                </p>
+              </div>
+            </div>
+          </TooltipTrigger>
+        </PopoverTrigger>
+        <PopoverPortal>
+          <PopoverContent className="min-w-[300px]" align="start" side="bottom">
+            <Command>
+              <CommandInput placeholder="Search repositories" />
+              <CommandList>
+                <CommandEmpty>
+                  {fetching ? (
+                    <div className="flex justify-center">
+                      <IconSpinner className="h-6 w-6" />
+                    </div>
+                  ) : (
+                    emptyText
+                  )}
+                </CommandEmpty>
+                <CommandGroup>
+                  {!!repos?.length && (
+                    <>
+                      <CommandItem
+                        key="all"
+                        onSelect={e => {
+                          if (value?.length === repos.length) {
+                            onChange([])
+                          } else {
+                            onChange(repos.slice())
+                          }
+                        }}
+                        className="!pointer-events-auto cursor-pointer !opacity-100"
+                      >
+                        <div
+                          className={cn(
+                            'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                            isAllSelected
+                              ? 'bg-primary text-primary-foreground'
+                              : 'opacity-50 [&_svg]:invisible'
+                          )}
+                        >
+                          <IconCheck className={cn('h-4 w-4')} />
+                        </div>
+                        <span>All indexed repositories</span>
+                      </CommandItem>
+                      <CommandSeparator className="my-2" />
+                    </>
+                  )}
+                  {repos?.map(repo => {
+                    const isSelected =
+                      findIndex(value, v => v.id === repo.id) > -1
+                    return (
+                      <CommandItem
+                        key={repo.id}
+                        onSelect={() => {
+                          const newSelect = [...value]
+                          if (isSelected) {
+                            const idx = newSelect.findIndex(
+                              item => item.id === repo.id
+                            )
+                            if (idx !== -1) newSelect.splice(idx, 1)
+                          } else {
+                            newSelect.push(repo)
+                          }
+                          onChange(newSelect)
+                        }}
+                        className="!pointer-events-auto cursor-pointer !opacity-100"
+                      >
+                        <div
+                          className={cn(
+                            'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                            isSelected
+                              ? 'bg-primary text-primary-foreground'
+                              : 'opacity-50 [&_svg]:invisible'
+                          )}
+                        >
+                          <IconCheck className={cn('h-4 w-4')} />
+                        </div>
+                        <span>{repo.name}</span>
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+                {value.length > 0 && (
+                  <>
+                    <CommandSeparator />
+                    <CommandGroup>
+                      <CommandItem
+                        onSelect={() => onChange([])}
+                        className="!pointer-events-auto cursor-pointer justify-center text-center !opacity-100"
+                      >
+                        Clear
+                      </CommandItem>
+                    </CommandGroup>
+                  </>
+                )}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </PopoverPortal>
+      </Popover>
+      <TooltipContent>
+        Select indexed repositories to enhance the answer engine
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -284,7 +284,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                           onChange({ ...repo, allCode: false })
                           setCommandVisible(false)
                         }}
-                        className="flex gap-2 items-center cursor-pointer"
+                        className="flex cursor-pointer items-center gap-2"
                       >
                         <div className="h-4 w-4 shrink-0">
                           {isSelected && <IconCheck className="shrink-0" />}

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -232,7 +232,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                     ? 'All Repositories'
                     : value
                     ? value.name
-                    : 'Select repositories'}
+                    : 'Select repository'}
                 </span>
               </div>
             </div>

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -192,7 +192,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
             href="/settings/providers/git"
             className={cn(buttonVariants({ size: 'sm' }), 'gap-1')}
           >
-    Connect
+            Connect
             <IconArrowRight />
           </Link>
         </div>
@@ -314,7 +314,8 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
         </PopoverPortal>
       </Popover>
       <TooltipContent>
-    Effortlessly interact with your repositories for contextualized search and assistance.
+        Effortlessly interact with your repositories for contextualized search
+        and assistance.
       </TooltipContent>
     </Tooltip>
   )

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -251,11 +251,13 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                 </CommandEmpty>
                 <CommandGroup>
                   {repos?.map(repo => {
-                    const isSelected = !!value?.id && repo.id === value.id
+                    const isSelected =
+                      !!value?.id &&
+                      `${repo.kind}_${repo.id}` === `${value.kind}_${value.id}`
                     return (
                       <CommandItem
-                        value={repo.id}
-                        key={repo.id}
+                        value={`${repo.kind}_${repo.id}`}
+                        key={`${repo.kind}_${repo.id}`}
                         onSelect={() => {
                           onChange({ ...repo })
                           setCommandVisible(false)

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -167,9 +167,7 @@ export default function TextAreaSearch({
   )
 }
 
-type RepoItem = Pick<Partial<Repository>, 'id' | 'kind' | 'name'> & {
-  allCode?: boolean
-}
+type RepoItem = Pick<Partial<Repository>, 'id' | 'kind' | 'name'>
 
 interface RepoSelectProps {
   value: RepoItem | undefined
@@ -201,8 +199,6 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
     return 'No results found'
   }, [repos])
 
-  const isAllSelected = !!repos?.length && value?.allCode
-
   return (
     <Tooltip delayDuration={0}>
       <Popover open={commandVisible} onOpenChange={e => setCommandVisible(e)}>
@@ -228,11 +224,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                     value ? 'text-foreground/70' : 'text-foreground/50'
                   )}
                 >
-                  {isAllSelected
-                    ? 'All Repositories'
-                    : value
-                    ? value.name
-                    : 'Select repository'}
+                  {value?.name ?? 'Select repository'}
                 </span>
               </div>
             </div>
@@ -253,35 +245,13 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                   )}
                 </CommandEmpty>
                 <CommandGroup>
-                  {!!repos?.length && (
-                    <>
-                      <CommandItem
-                        key="all"
-                        onSelect={e => {
-                          if (isAllSelected) {
-                            onChange(undefined)
-                          } else {
-                            onChange({ allCode: true })
-                          }
-                          setCommandVisible(false)
-                        }}
-                        className="flex items-center gap-2"
-                      >
-                        <div className="w-4 shrink-0">
-                          {isAllSelected && <IconCheck className="shrink-0" />}
-                        </div>
-                        <span>All indexed repositories</span>
-                      </CommandItem>
-                      <CommandSeparator className="my-2" />
-                    </>
-                  )}
                   {repos?.map(repo => {
                     const isSelected = repo.id === value?.id
                     return (
                       <CommandItem
                         key={repo.id}
                         onSelect={() => {
-                          onChange({ ...repo, allCode: false })
+                          onChange({ ...repo })
                           setCommandVisible(false)
                         }}
                         className="flex cursor-pointer items-center gap-2"

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -187,7 +187,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
     if (!repos?.length)
       return (
         <div className="space-y-4 py-2">
-          <p className="font-semibold">No indexed repositories</p>
+          <p className="font-semibold">No repositories</p>
           <Link
             href="/settings/providers/git"
             className={cn(buttonVariants({ size: 'sm' }), 'gap-1')}

--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -303,7 +303,7 @@ function RepoSelect({ value, onChange, className }: RepoSelectProps) {
                       onChange(undefined)
                       setCommandVisible(false)
                     }}
-                    className="!pointer-events-auto cursor-pointer justify-center text-center !opacity-100 mt-1"
+                    className="!pointer-events-auto mt-1 cursor-pointer justify-center text-center !opacity-100"
                   >
                     Clear
                   </CommandItem>

--- a/ee/tabby-ui/lib/constants/index.ts
+++ b/ee/tabby-ui/lib/constants/index.ts
@@ -6,5 +6,6 @@ export const SESSION_STORAGE_KEY = {
   DEMO_AUTO_LOGIN: '_tabby_demo_autologin',
   SEARCH_INITIAL_MSG: '_tabby_search_initial_msg',
   SEARCH_INITIAL_EXTRA: '_tabby_search_initial_extra',
-  SEARCH_LATEST_MSG: '_tabby_search_latest_msg'
+  SEARCH_LATEST_MSG: '_tabby_search_latest_msg',
+  SEARCH_LATEST_CONTEXT: '_tabby_search_latest_context'
 }

--- a/ee/tabby-ui/lib/constants/index.ts
+++ b/ee/tabby-ui/lib/constants/index.ts
@@ -5,5 +5,6 @@ export const DEFAULT_PAGE_SIZE = 20
 export const SESSION_STORAGE_KEY = {
   DEMO_AUTO_LOGIN: '_tabby_demo_autologin',
   SEARCH_INITIAL_MSG: '_tabby_search_initial_msg',
+  SEARCH_INITIAL_EXTRA: '_tabby_search_initial_extra',
   SEARCH_LATEST_MSG: '_tabby_search_latest_msg'
 }

--- a/ee/tabby-ui/lib/constants/index.ts
+++ b/ee/tabby-ui/lib/constants/index.ts
@@ -5,7 +5,7 @@ export const DEFAULT_PAGE_SIZE = 20
 export const SESSION_STORAGE_KEY = {
   DEMO_AUTO_LOGIN: '_tabby_demo_autologin',
   SEARCH_INITIAL_MSG: '_tabby_search_initial_msg',
-  SEARCH_INITIAL_EXTRA: '_tabby_search_initial_extra',
+  SEARCH_INITIAL_EXTRA_CONTEXT: '_tabby_search_initial_extra_context',
   SEARCH_LATEST_MSG: '_tabby_search_latest_msg',
-  SEARCH_LATEST_CONTEXT: '_tabby_search_latest_context'
+  SEARCH_LATEST_EXTRA_CONTEXT: '_tabby_search_latest_extra_context'
 }

--- a/ee/tabby-ui/lib/tabby/gql.ts
+++ b/ee/tabby-ui/lib/tabby/gql.ts
@@ -100,7 +100,8 @@ const client = new Client({
         GrepLine: () => null,
         GrepFile: () => null,
         GrepTextOrBase64: () => null,
-        GrepSubMatch: () => null
+        GrepSubMatch: () => null,
+        Repository: (data: any) => (data ? `${data.kind}_${data.id}` : null)
       },
       resolvers: {
         Query: {

--- a/ee/tabby-ui/lib/tabby/query.ts
+++ b/ee/tabby-ui/lib/tabby/query.ts
@@ -299,3 +299,15 @@ export const listWebCrawlerUrl = graphql(/* GraphQL */ `
     }
   }
 `)
+
+export const repositoryListQuery = graphql(/* GraphQL */ `
+  query RepositoryList {
+    repositoryList {
+      id
+      name
+      kind
+      gitUrl
+      refs
+    }
+  }
+`)

--- a/ee/tabby-ui/lib/types/chat.ts
+++ b/ee/tabby-ui/lib/types/chat.ts
@@ -1,6 +1,8 @@
 import type { ChatMessage } from 'tabby-chat-panel'
 import type { components as TabbyOpenApiComponents } from 'tabby-openapi'
 
+import { Repository } from '../gql/generates/graphql'
+
 export interface UserMessage extends ChatMessage {
   id: string
 }
@@ -62,3 +64,7 @@ type MergeUnionType<T> = {
 export type AnswerResponse = MergeUnionType<
   TabbyOpenApiComponents['schemas']['AnswerResponseChunk']
 >
+
+export type AnswerEngineExtraContext = {
+  repository?: Omit<Repository, 'refs'>
+}


### PR DESCRIPTION
## Changes
Support selecting repositories to enhance answer engine.

## Screen recoed
https://jam.dev/c/90930692-ae11-4e57-8efd-c459fa4cc64c

## Preview
### Display relevant code & selected repository
<img width="950" alt="image" src="https://github.com/user-attachments/assets/f738437f-45b6-4770-affd-43e30cfae106">

### Selecting repo
<img width="919" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/7352658d-2c09-422e-a490-bab5b61b086e">

### No repos
<img width="932" alt="image" src="https://github.com/TabbyML/tabby/assets/17516233/e173d4ff-777b-4f40-ab39-7e46ab070de2">

