### PR TITLE
fix(vscode): chat panel context filepath should be decoded

### DIFF
--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -61,11 +61,11 @@ export class ChatViewProvider implements WebviewViewProvider {
     const workspaceFolder = workspace.getWorkspaceFolder(uri);
     const repo = gitProvider.getRepository(uri);
     const remoteUrl = repo ? gitProvider.getDefaultRemoteUrl(repo) : undefined;
-    let filePath = uri.toString();
+    let filePath = uri.toString(true);
     if (repo) {
-      filePath = filePath.replace(repo.rootUri.toString(), "");
+      filePath = filePath.replace(repo.rootUri.toString(true), "");
     } else if (workspaceFolder) {
-      filePath = filePath.replace(workspaceFolder.uri.toString(), "");
+      filePath = filePath.replace(workspaceFolder.uri.toString(true), "");
     }
 
     return {


### PR DESCRIPTION
### Issue
The filepath is not decoded
<img width="397" alt="Screenshot 2024-07-09 12 07 39" src="https://github.com/TabbyML/tabby/assets/5305874/e4afe25f-aca1-4f8f-a6a1-e5864ed8a9d4">

### After fix
<img width="399" alt="Screenshot 2024-07-09 12 31 39" src="https://github.com/TabbyML/tabby/assets/5305874/07d040c0-980f-4d9b-b6c8-c9e2b1180d49">

### The request sending to the server should use decoded filepath as well
**Request from VSCode after fix**
<img width="307" alt="Screenshot 2024-07-09 12 31 48" src="https://github.com/TabbyML/tabby/assets/5305874/3e378e0d-b9e4-43cc-b847-11b3d142a0d7">


**Request from web code browser currently**
<img width="396" alt="Screenshot 2024-07-09 12 26 17" src="https://github.com/TabbyML/tabby/assets/5305874/c90706d1-84fe-4667-9afb-b2240ee67f13">

