### PR TITLE
feat(ui): answer engine with thread sharing

### DIFF
--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -94,6 +94,7 @@ function MainPanel() {
         repository: ctx?.repository ? omit(ctx.repository, 'refs') : undefined
       })
     )
+
     router.push('/search?q=pending')
   }
 

--- a/ee/tabby-ui/app/(home)/page.tsx
+++ b/ee/tabby-ui/app/(home)/page.tsx
@@ -94,7 +94,7 @@ function MainPanel() {
         repository: ctx?.repository ? omit(ctx.repository, 'refs') : undefined
       })
     )
-    router.push('/search')
+    router.push('/search?q=pending')
   }
 
   const style = isShowDemoBanner

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -221,6 +221,7 @@ export function Search() {
       const initialExtraInfo = initialExtraContextStr
         ? JSON.parse(initialExtraContextStr)
         : undefined
+
       if (initialMessage) {
         sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG)
         sessionStorage.removeItem(
@@ -237,10 +238,25 @@ export function Search() {
         })
         setIsAuthor(true)
         setIsReady(true)
-        return
       } else {
         router.replace('/')
       }
+    }
+  }, [pathname])
+
+  // Handling /search/{subPath}
+  useEffect(() => {
+    const regex = /^\/search\/(.*)/
+    const subPath = pathname.match(regex)?.[1]
+    if (subPath) {
+      const title = subPath.split('/')[0]
+      const titleSplit = title.split('-')
+      const threadId = titleSplit[titleSplit.length - 1]
+      setThreadId(threadId)
+      setIsLoadingThread(true)
+      setIsReady(true)
+      // FIXME: go fetch thread from server, set isAuthor
+      // FIXME: after load thread, if blockIndex existed, scrolling to the block
     }
   }, [pathname])
 
@@ -421,7 +437,7 @@ export function Search() {
     )
     triggerRequest(answerRequest)
 
-    // FIXME(wwayne): update thread in server
+    // FIXME: update thread in server
   }
 
   const onRegenerateResponse = (
@@ -467,7 +483,7 @@ export function Search() {
     setConversation(newConversation)
     triggerRequest(answerRequest)
 
-    // FIXME(wwayne): update thread in server
+    // FIXME: update thread in server
   }
 
   const onCopy = () => {

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -263,7 +263,7 @@ export function Search() {
           strict: true // Remove special characters
         })
 
-        // FIXME: should add threadId into the condition
+        // FIXME(wwayne): should add threadId into the condition
         if (isSearchPending) {
           const normalizedTitle = slugify(title, {
             lower: true,
@@ -584,7 +584,7 @@ export function Search() {
                               idx === conversation.length - 1
                             }
                             showRegenerateButton={
-                              idx === conversation.length - 1
+                              idx === conversation.length - 1 && isAuthor
                             }
                             blockIndex={blockIndex}
                           />

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -255,28 +255,25 @@ export function Search() {
   // Update page url if needed
   useEffect(() => {
     if (isFirstAnswerLoaded) {
-      // FIXME(wwayne): what if user click stop for the first answer
-      if (isSearchPending) {
-        const firstQuestion = conversation[0]
-        if (firstQuestion) {
-          const title = firstQuestion.content
-          document.title = slugify(title, {
-            replacement: ' ',
-            lower: false,
-            strict: true // Remove special characters
-          })
+      const title = conversation[0]?.content
+      if (title) {
+        document.title = slugify(title, {
+          replacement: ' ',
+          lower: false,
+          strict: true // Remove special characters
+        })
 
-          if (isSearchPending) {
-            const normalizedTitle = slugify(title, {
-              lower: true,
-              strict: true
-            })
-              .split('-')
-              .slice(0, 10)
-              .join('-')
-            // FIXME(wwayne): add threadId in the end
-            window.history.replaceState(null, '', `/search/${normalizedTitle}`)
-          }
+        // FIXME: should add threadId into the condition
+        if (isSearchPending) {
+          const normalizedTitle = slugify(title, {
+            lower: true,
+            strict: true
+          })
+            .split('-')
+            .slice(0, 10)
+            .join('-')
+          // FIXME(wwayne): add threadId in the end
+          window.history.replaceState(null, '', `/search/${normalizedTitle}`)
         }
       }
     }

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -11,7 +11,7 @@ import {
   useState
 } from 'react'
 import Image from 'next/image'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import defaultFavicon from '@/assets/default-favicon.png'
 import { Message } from 'ai'
 import DOMPurify from 'dompurify'
@@ -20,9 +20,11 @@ import { marked } from 'marked'
 import { nanoid } from 'nanoid'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
+import slugify from 'slugify'
 
 import { SESSION_STORAGE_KEY } from '@/lib/constants'
 import { useEnableDeveloperMode, useEnableSearch } from '@/lib/experiment-flags'
+import { useCopyToClipboard } from '@/lib/hooks/use-copy-to-clipboard'
 import { useCurrentTheme } from '@/lib/hooks/use-current-theme'
 import { useLatest } from '@/lib/hooks/use-latest'
 import { useIsChatEnabled } from '@/lib/hooks/use-server-info'
@@ -44,9 +46,11 @@ import {
 import {
   IconBlocks,
   IconBug,
+  IconCheck,
   IconChevronLeft,
   IconChevronRight,
   IconLayers,
+  IconLink,
   IconPlus,
   IconRefresh,
   IconSparkles,
@@ -61,15 +65,17 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '@/components/ui/tooltip'
 import { ButtonScrollToBottom } from '@/components/button-scroll-to-bottom'
-import { ClientOnly } from '@/components/client-only'
 import { CopyButton } from '@/components/copy-button'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
+import LoadingWrapper from '@/components/loading-wrapper'
 import { MemoizedReactMarkdown } from '@/components/markdown'
 import TextAreaSearch from '@/components/textarea-search'
-import { ThemeToggle } from '@/components/theme-toggle'
-import { UserAvatar } from '@/components/user-avatar'
-import UserPanel from '@/components/user-panel'
 
 import './search.css'
 
@@ -80,11 +86,6 @@ import { useQuery } from 'urql'
 
 import { RepositoryListQuery } from '@/lib/gql/generates/graphql'
 import { repositoryListQuery } from '@/lib/tabby/query'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
-} from '@/components/ui/tooltip'
 import { CodeReferences } from '@/components/chat/question-answer'
 
 import { DevPanel } from './dev-panel'
@@ -141,11 +142,11 @@ const SOURCE_CARD_STYLE = {
 
 export function Search() {
   const isChatEnabled = useIsChatEnabled()
+  const searchParams = useSearchParams()
   const [searchFlag] = useEnableSearch()
   const [conversation, setConversation] = useState<ConversationMessage[]>([])
   const [showStop, setShowStop] = useState(true)
   const [container, setContainer] = useState<HTMLDivElement | null>(null)
-  const [title, setTitle] = useState('')
   const [isReady, setIsReady] = useState(false)
   const [extraContext, setExtraContext] = useState<AnswerEngineExtraContext>({})
   const [currentLoadindId, setCurrentLoadingId] = useState<string>('')
@@ -167,6 +168,17 @@ export function Search() {
     query: repositoryListQuery
   })
   const repositoryList = data?.repositoryList
+  const pathname = usePathname()
+  const { isCopied, copyToClipboard } = useCopyToClipboard({
+    timeout: 2000
+  })
+  const [threadId, setThreadId] = useState('')
+  const [isAuthor, setIsAuthor] = useState(false)
+  const [isFirstAnswerLoaded, setIsFirstAnswerLoaded] = useState(false)
+  const [blockIndex, setBlockIndex] = useState(0)
+  const [isLoadingThread, setIsLoadingThread] = useState(false)
+
+  const isSearchPending = searchParams.get('q') === 'pending'
 
   const { triggerRequest, isLoading, error, answer, stop } = useTabbyAnswer({
     fetcher: tabbyFetcher
@@ -194,87 +206,90 @@ export function Search() {
     }
   }
 
-  // Check sessionStorage for initial message or most recent conversation
+  // Handling /search?q=pending
   useEffect(() => {
-    if (initCheckRef.current) return
+    if (isSearchPending) {
+      if (initCheckRef.current) return
+      initCheckRef.current = true
 
-    initCheckRef.current = true
-
-    const initialMessage = sessionStorage.getItem(
-      SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG
-    )
-    const initialExtraContextStr = sessionStorage.getItem(
-      SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA_CONTEXT
-    )
-    const initialExtraInfo = initialExtraContextStr
-      ? JSON.parse(initialExtraContextStr)
-      : undefined
-    if (initialMessage) {
-      sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG)
-      sessionStorage.removeItem(
+      const initialMessage = sessionStorage.getItem(
+        SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG
+      )
+      const initialExtraContextStr = sessionStorage.getItem(
         SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA_CONTEXT
       )
-      setIsReady(true)
-      setExtraContext(p => ({
-        ...p,
-        repository: initialExtraInfo?.repository
-      }))
-      // FIXME(jueliang) just use the value in context
-      onSubmitSearch(initialMessage, {
-        repository: initialExtraInfo?.repository
-      })
-      return
-    }
-
-    const latesConversation = sessionStorage.getItem(
-      SESSION_STORAGE_KEY.SEARCH_LATEST_MSG
-    )
-    const latestConversationContext = sessionStorage.getItem(
-      SESSION_STORAGE_KEY.SEARCH_LATEST_EXTRA_CONTEXT
-    )
-    if (latesConversation) {
-      const conversation = JSON.parse(
-        latesConversation
-      ) as ConversationMessage[]
-      setConversation(conversation)
-
-      if (latestConversationContext) {
-        const conversationContext = JSON.parse(
-          latestConversationContext
-        ) as AnswerEngineExtraContext
-        setExtraContext(conversationContext)
+      const initialExtraInfo = initialExtraContextStr
+        ? JSON.parse(initialExtraContextStr)
+        : undefined
+      if (initialMessage) {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY.SEARCH_INITIAL_MSG)
+        sessionStorage.removeItem(
+          SESSION_STORAGE_KEY.SEARCH_INITIAL_EXTRA_CONTEXT
+        )
+        setIsReady(true)
+        setExtraContext(p => ({
+          ...p,
+          repository: initialExtraInfo?.repository
+        }))
+        // FIXME(jueliang) just use the value in context
+        onSubmitSearch(initialMessage, {
+          repository: initialExtraInfo?.repository
+        })
+        setIsAuthor(true)
+        setIsReady(true)
+        return
+      } else {
+        router.replace('/')
       }
-
-      // Set title
-      if (conversation[0]) setTitle(conversation[0].content)
-
-      // Check if any answer is loading
-      const loadingIndex = conversation.findIndex(item => item.isLoading)
-      if (loadingIndex !== -1) {
-        const loadingAnswer = conversation[loadingIndex]
-        if (loadingAnswer) onRegenerateResponse(loadingAnswer.id, conversation)
-      }
-
-      setIsReady(true)
-      return
     }
+  }, [pathname])
 
-    router.replace('/')
+  // Update blockIndex
+  useEffect(() => {
+    if (window.location.hash) {
+      setBlockIndex(parseInt(window.location.hash.replace('#', ''), 10))
+    }
   }, [])
 
-  // Set page title to the value of the first quesiton
+  // Update page title
+  // Update page url if needed
   useEffect(() => {
-    if (title) document.title = title
-  }, [title])
+    if (isFirstAnswerLoaded) {
+      // FIXME(wwayne): what if user click stop for the first answer
+      if (isSearchPending) {
+        const firstQuestion = conversation[0]
+        if (firstQuestion) {
+          const title = firstQuestion.content
+          document.title = slugify(title, {
+            replacement: ' ',
+            lower: false,
+            strict: true // Remove special characters
+          })
 
-  // Display the input field with a delayed animatio
+          if (isSearchPending) {
+            const normalizedTitle = slugify(title, {
+              lower: true,
+              strict: true
+            })
+              .split('-')
+              .slice(0, 10)
+              .join('-')
+            // FIXME(wwayne): add threadId in the end
+            window.history.replaceState(null, '', `/search/${normalizedTitle}`)
+          }
+        }
+      }
+    }
+  }, [isFirstAnswerLoaded])
+
+  // Display the input field with a delayed animation
   useEffect(() => {
-    if (isReady) {
+    if (isReady && isAuthor) {
       setTimeout(() => {
         setShowSearchInput(true)
       }, 300)
     }
-  }, [isReady])
+  }, [isReady, isAuthor])
 
   // Initialize the reference to the ScrollArea used for scrolling to the bottom
   useEffect(() => {
@@ -298,6 +313,14 @@ export function Search() {
     currentAnswer.isLoading = isLoading
     setConversation(newConversation)
   }, [isLoading, answer])
+
+  // Update isFirstAnswerLoaded based on conversation data
+  useEffect(() => {
+    if (isFirstAnswerLoaded) return
+    if (conversation[1]?.isLoading === false) {
+      setIsFirstAnswerLoaded(true)
+    }
+  }, [conversation])
 
   // Handling the error response from useTabbyAnswer
   useEffect(() => {
@@ -352,21 +375,7 @@ export function Search() {
     }
   }, [])
 
-  // Save conversation into sessionStorage
-  useEffect(() => {
-    sessionStorage.setItem(
-      SESSION_STORAGE_KEY.SEARCH_LATEST_MSG,
-      JSON.stringify(conversation)
-    )
-  }, [conversation])
-
-  // Save conversation context into sessionStorage
-  useEffect(() => {
-    sessionStorage.setItem(
-      SESSION_STORAGE_KEY.SEARCH_LATEST_EXTRA_CONTEXT,
-      JSON.stringify(extraContext)
-    )
-  }, [extraContext])
+  const getBlockIdByIndex = (index: number) => `block-${index}`
 
   useEffect(() => {
     if (devPanelOpen) {
@@ -415,8 +424,7 @@ export function Search() {
     )
     triggerRequest(answerRequest)
 
-    // Update HTML page title
-    if (!title) setTitle(question)
+    // FIXME(wwayne): update thread in server
   }
 
   const onRegenerateResponse = (
@@ -461,6 +469,13 @@ export function Search() {
     setCurrentLoadingId(newTargetAnswer.id)
     setConversation(newConversation)
     triggerRequest(answerRequest)
+
+    // FIXME(wwayne): update thread in server
+  }
+
+  const onCopy = () => {
+    if (isCopied) return
+    copyToClipboard(window.location.href)
   }
 
   const onToggleFullScreen = (fullScreen: boolean) => {
@@ -509,51 +524,82 @@ export function Search() {
                   Home
                 </Button>
               </div>
-              <div className="flex items-center gap-x-6">
-                <ClientOnly>
-                  <ThemeToggle />
-                </ClientOnly>
-                <UserPanel showHome={false} showSetting>
-                  <UserAvatar className="h-10 w-10 border" />
-                </UserPanel>
+              <div className="flex items-center gap-x-1">
+                {isFirstAnswerLoaded && (
+                  <Tooltip delayDuration={300}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        className="gap-x-2 text-sm text-muted-foreground"
+                        onClick={onCopy}
+                      >
+                        {isCopied ? (
+                          <IconCheck className="text-green-600" />
+                        ) : (
+                          <IconLink />
+                        )}
+                        Share
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent align="end">
+                      <p>Copy Thread Link</p>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
               </div>
             </header>
 
-            <main className="h-[calc(100%-4rem)] overflow-auto pb-8 lg:pb-0">
-              <ScrollArea className="h-full" ref={contentContainerRef}>
-                <div className="mx-auto px-4 pb-32 lg:max-w-4xl lg:px-0">
-                  <div className="flex flex-col">
-                    {conversation.map((item, idx) => {
-                      if (item.role === 'user') {
-                        return (
-                          <div key={item.id + idx}>
-                            {idx !== 0 && <Separator />}
-                            <div className="pb-2 pt-8">
-                              <MessageMarkdown
-                                message={item.content}
-                                headline
-                              />
-                            </div>
+        <main className="h-[calc(100%-4rem)] overflow-auto pb-8 lg:pb-0">
+          <ScrollArea className="h-full" ref={contentContainerRef}>
+            <div className="mx-auto px-4 pb-32 lg:max-w-4xl lg:px-0">
+              <LoadingWrapper
+                loading={isLoadingThread}
+                fallback={
+                  <>
+                    <Skeleton className="h-20 w-full" />
+                    <Skeleton className="mt-5 h-64 w-full" />
+                  </>
+                }
+              >
+                <div className="flex flex-col">
+                  {conversation.map((item, idx) => {
+                    if (item.role === 'user') {
+                      const blockIndex = Math.ceil((idx + 1) / 2)
+                      return (
+                        <div
+                          key={item.id + idx}
+                          id={getBlockIdByIndex(blockIndex)}
+                        >
+                          {idx !== 0 && <Separator />}
+                          <div className="pb-2 pt-8">
+                            <MessageMarkdown message={item.content} headline />
                           </div>
-                        )
-                      }
-                      if (item.role === 'assistant') {
-                        return (
-                          <div key={item.id + idx} className="pb-8 pt-2">
-                            <AnswerBlock
-                              answer={item}
-                              showRelatedQuestion={
-                                idx === conversation.length - 1
-                              }
-                            />
-                          </div>
-                        )
-                      }
-                      return <></>
-                    })}
-                  </div>
+                        </div>
+                      )
+                    }
+                    if (item.role === 'assistant') {
+                      const blockIndex = Math.ceil(idx / 2)
+                      return (
+                        <div key={item.id + idx} className="pb-8 pt-2">
+                          <AnswerBlock
+                            answer={item}
+                            showRelatedQuestion={
+                              idx === conversation.length - 1
+                            }
+                            showRegenerateButton={
+                              idx === conversation.length - 1
+                            }
+                            blockIndex={blockIndex}
+                          />
+                        </div>
+                      )
+                    }
+                    return <></>
+                  })}
                 </div>
-              </ScrollArea>
+              </LoadingWrapper>
+            </div>
+          </ScrollArea>
 
               {container && (
                 <ButtonScrollToBottom
@@ -647,11 +693,18 @@ export function Search() {
 
 function AnswerBlock({
   answer,
-  showRelatedQuestion
+  showRelatedQuestion,
+  showRegenerateButton,
+  blockIndex
 }: {
   answer: ConversationMessage
   showRelatedQuestion: boolean
+  showRegenerateButton: boolean
+  blockIndex: number
 }) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard({
+    timeout: 2000
+  })
   const {
     onRegenerateResponse,
     onSubmitSearch,
@@ -677,6 +730,11 @@ function AnswerBlock({
       .map((relevent, idx) => `[${idx + 1}] ${relevent.link}`)
       .join('\n')
     return `${content}\n\nCitations:\n${citations}`
+  }
+
+  const onCopy = () => {
+    if (isCopied) return
+    copyToClipboard(`${window.location.href}#${blockIndex}`)
   }
 
   const IconAnswer = answer.isLoading ? IconSpinner : IconSparkles
@@ -821,7 +879,7 @@ function AnswerBlock({
               value={getCopyContent(answer)}
               text="Copy"
             />
-            {!isLoading && (
+            {!isLoading && showRegenerateButton && (
               <Button
                 className="flex items-center gap-x-1 px-1 font-normal text-muted-foreground"
                 variant="ghost"
@@ -831,6 +889,25 @@ function AnswerBlock({
                 <p>Regenerate</p>
               </Button>
             )}
+            <Tooltip delayDuration={300}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex items-center gap-x-1 px-1 font-normal text-muted-foreground"
+                  onClick={onCopy}
+                >
+                  {isCopied ? (
+                    <IconCheck className="text-green-600" />
+                  ) : (
+                    <IconLink />
+                  )}
+                  Share
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Copy Link</p>
+              </TooltipContent>
+            </Tooltip>
           </div>
         )}
       </div>

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -522,7 +522,7 @@ export function Search() {
                 </Button>
               </div>
               <div className="flex items-center gap-x-1">
-                {isFirstAnswerLoaded && (
+                {isFirstAnswerLoaded && threadId && (
                   <Tooltip delayDuration={300}>
                     <TooltipTrigger asChild>
                       <Button

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -562,57 +562,60 @@ export function Search() {
               </div>
             </header>
 
-        <main className="h-[calc(100%-4rem)] overflow-auto pb-8 lg:pb-0">
-          <ScrollArea className="h-full" ref={contentContainerRef}>
-            <div className="mx-auto px-4 pb-32 lg:max-w-4xl lg:px-0">
-              <LoadingWrapper
-                loading={isLoadingThread}
-                fallback={
-                  <>
-                    <Skeleton className="h-20 w-full" />
-                    <Skeleton className="mt-5 h-64 w-full" />
-                  </>
-                }
-              >
-                <div className="flex flex-col">
-                  {conversation.map((item, idx) => {
-                    if (item.role === 'user') {
-                      const blockIndex = Math.ceil((idx + 1) / 2)
-                      return (
-                        <div
-                          key={item.id + idx}
-                          id={getBlockIdByIndex(blockIndex)}
-                        >
-                          {idx !== 0 && <Separator />}
-                          <div className="pb-2 pt-8">
-                            <MessageMarkdown message={item.content} headline />
-                          </div>
-                        </div>
-                      )
+            <main className="h-[calc(100%-4rem)] overflow-auto pb-8 lg:pb-0">
+              <ScrollArea className="h-full" ref={contentContainerRef}>
+                <div className="mx-auto px-4 pb-32 lg:max-w-4xl lg:px-0">
+                  <LoadingWrapper
+                    loading={isLoadingThread}
+                    fallback={
+                      <>
+                        <Skeleton className="h-20 w-full" />
+                        <Skeleton className="mt-5 h-64 w-full" />
+                      </>
                     }
-                    if (item.role === 'assistant') {
-                      const blockIndex = Math.ceil(idx / 2)
-                      return (
-                        <div key={item.id + idx} className="pb-8 pt-2">
-                          <AnswerBlock
-                            answer={item}
-                            showRelatedQuestion={
-                              idx === conversation.length - 1
-                            }
-                            showRegenerateButton={
-                              idx === conversation.length - 1 && isAuthor
-                            }
-                            blockIndex={blockIndex}
-                          />
-                        </div>
-                      )
-                    }
-                    return <></>
-                  })}
+                  >
+                    <div className="flex flex-col">
+                      {conversation.map((item, idx) => {
+                        if (item.role === 'user') {
+                          const blockIndex = Math.ceil((idx + 1) / 2)
+                          return (
+                            <div
+                              key={item.id + idx}
+                              id={getBlockIdByIndex(blockIndex)}
+                            >
+                              {idx !== 0 && <Separator />}
+                              <div className="pb-2 pt-8">
+                                <MessageMarkdown
+                                  message={item.content}
+                                  headline
+                                />
+                              </div>
+                            </div>
+                          )
+                        }
+                        if (item.role === 'assistant') {
+                          const blockIndex = Math.ceil(idx / 2)
+                          return (
+                            <div key={item.id + idx} className="pb-8 pt-2">
+                              <AnswerBlock
+                                answer={item}
+                                showRelatedQuestion={
+                                  idx === conversation.length - 1
+                                }
+                                showRegenerateButton={
+                                  idx === conversation.length - 1 && isAuthor
+                                }
+                                blockIndex={blockIndex}
+                              />
+                            </div>
+                          )
+                        }
+                        return <></>
+                      })}
+                    </div>
+                  </LoadingWrapper>
                 </div>
-              </LoadingWrapper>
-            </div>
-          </ScrollArea>
+              </ScrollArea>
 
               {container && (
                 <ButtonScrollToBottom

--- a/ee/tabby-ui/components/ui/icons.tsx
+++ b/ee/tabby-ui/components/ui/icons.tsx
@@ -13,6 +13,7 @@ import {
   GitFork,
   IndentIncrease,
   Layers2,
+  Link,
   Mail,
   Search,
   Sparkles,
@@ -1527,6 +1528,10 @@ function IconBug({ className, ...props }: React.ComponentProps<typeof Bug>) {
   return <Bug className={cn('h-4 w-4', className)} {...props} />
 }
 
+function IconLink({ className, ...props }: React.ComponentProps<typeof Link>) {
+  return <Link className={cn('h-4 w-4', className)} {...props} />
+}
+
 export {
   IconEdit,
   IconNextChat,
@@ -1612,5 +1617,6 @@ export {
   IconTag,
   IconFileText,
   IconApplyInEditor,
-  IconBug
+  IconBug,
+  IconLink
 }

--- a/ee/tabby-ui/package.json
+++ b/ee/tabby-ui/package.json
@@ -103,6 +103,7 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "seedrandom": "^3.0.5",
+    "slugify": "^1.6.6",
     "sonner": "^1.3.1",
     "swr": "^2.2.4",
     "tabby-chat-panel": "workspace:*",

--- a/ee/tabby-webserver/development/Caddyfile
+++ b/ee/tabby-webserver/development/Caddyfile
@@ -1,5 +1,6 @@
 :8080 {
 	rewrite /files/* /files
+	rewrite /search/* /search
 
 	@backend {
 		path /graphql

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,9 @@ importers:
       seedrandom:
         specifier: ^3.0.5
         version: 3.0.5
+      slugify:
+        specifier: ^1.6.6
+        version: 1.6.6
       sonner:
         specifier: ^1.3.1
         version: 1.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -9031,6 +9034,10 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  slugify@1.6.6:
+    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
+    engines: {node: '>=8.0.0'}
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -20501,6 +20508,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  slugify@1.6.6: {}
 
   snake-case@3.0.4:
     dependencies:


### PR DESCRIPTION
Mock for review first, not merging

### Screen record:
https://jam.dev/c/39e63f7a-b5e5-4725-9b68-994aaf68895a

### Screenshots
Why I only put a button for coping link:
* Currently, we only share the link. There is no authentication protection or sharing to other platforms, so adding a popup to the share button would be redundant.
* Using the text `Copy Link` or `Copy Thread` feels a bit wired on UI. Therefore, I use the word `Share` with a tooltip that says `Copy Thread Link`

<img width="600" alt="Screenshot 2024-07-10 15 41 46" src="https://github.com/TabbyML/tabby/assets/5305874/7414ca5b-714b-4bf0-b990-2ac3bfd09da9">

<img width="600" alt="Screenshot 2024-07-10 15 33 58" src="https://github.com/TabbyML/tabby/assets/5305874/ac156d38-9f93-4178-a027-e1a94873df7e">

<img width="600" alt="Screenshot 2024-07-10 15 34 03" src="https://github.com/TabbyML/tabby/assets/5305874/3b3da8eb-0c46-4d69-b241-b411b1b555ab">

### Details
#### Asking a Question on the Home Page
1. We will open `/search?q=pending`
2. After the first answer loads and the threadId is obtained:
   * The url will be modified to `/search/title-threadId`
   * The top-right button will show up (in the mock, we hide this button bc missing threadId, we can modify the react logic to display this button for testing)
**Note:** After modifying the URL, you can use the browser's back navigation to return to the home page. However, you won't be able to use the browser's forward navigation after that. It should because of using `window.history.replaceState`, but I haven't found better solution.

#### When loading a page `/search/title-threadId`
* The frontend will extract the threadId from the URL path.
* The page will display a loading skeleton and fetch the thread from the server
* After retrieving the thread's author information, the frontend will detect if the current user is the author, and if so, show the follow-up question input field.

#### TODO
* Integrate with the backend thread data (create / update)
* Get the thread's author info from the backend
* When opening `/search/title-threadId#number`, it should smooth scrolling down to the corresponding question/answer block 
* web server path for the /search (already known how to update)
