### PR TITLE
fix(core): canonicalize git_url before performing code search

### DIFF
--- a/.changes/unreleased/Fixed and Improvements-20240710-185920.yaml
+++ b/.changes/unreleased/Fixed and Improvements-20240710-185920.yaml
@@ -1,0 +1,3 @@
+kind: Fixed and Improvements
+body: Canonicalize the git_url before performing a relevant code search. Previously, for git_urls with credentials, the canonicalized git_url was used in the index, but the query still used the raw git_url.
+time: 2024-07-10T18:59:20.774068+09:00

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -84,7 +84,7 @@ impl CodeSearchImpl {
             query.git_url, git_url
         );
 
-        query.git_url = git_url.to_owned();
+        query.git_url = RepositoryConfig::canonicalize_url(&git_url);
 
         let docs_from_embedding = {
             let embedding = self.embedding.embed(&query.content).await?;

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -84,7 +84,7 @@ impl CodeSearchImpl {
             query.git_url, git_url
         );
 
-        query.git_url = RepositoryConfig::canonicalize_url(&git_url);
+        query.git_url = RepositoryConfig::canonicalize_url(git_url);
 
         let docs_from_embedding = {
             let embedding = self.embedding.embed(&query.content).await?;


### PR DESCRIPTION
Previously, the git_url used in the index was not properly canonicalized, leading to inconsistencies when performing queries. This commit updates the code to ensure that the git_url is canonicalized before performing the code search.

cc @gyxlucy 