### PR TITLE
fix(ui): persist chats on unmount

### DIFF
--- a/ee/tabby-ui/app/playground/components/chats.tsx
+++ b/ee/tabby-ui/app/playground/components/chats.tsx
@@ -79,7 +79,8 @@ export default function Chats() {
     {
       onUnmount(debounced) {
         debounced.flush()
-      }
+      },
+      leading: true
     }
   )
 

--- a/ee/tabby-ui/app/playground/components/chats.tsx
+++ b/ee/tabby-ui/app/playground/components/chats.tsx
@@ -75,7 +75,12 @@ export default function Chats() {
         updateMessages(chatId, messages)
       }
     },
-    1000
+    500,
+    {
+      onUnmount(debounced) {
+        debounced.flush()
+      }
+    }
   )
 
   const onThreadUpdates = (messages: QuestionAnswerPair[]) => {
@@ -121,10 +126,6 @@ export default function Chats() {
       shouldConsumeInitialMessage.current = false
     }
   }
-
-  React.useEffect(() => {
-    return () => persistChat.flush()
-  }, [])
 
   const style = isShowDemoBanner
     ? { height: `calc(100vh - ${BANNER_HEIGHT})` }

--- a/ee/tabby-ui/lib/hooks/use-debounce.ts
+++ b/ee/tabby-ui/lib/hooks/use-debounce.ts
@@ -1,19 +1,21 @@
 import React from 'react'
-import { debounce, type DebounceSettings } from 'lodash-es'
+import { debounce, DebouncedFunc, type DebounceSettings } from 'lodash-es'
 
 import { useLatest } from './use-latest'
 import { useUnmount } from './use-unmount'
 
 type noop = (...args: any[]) => any
 
-// interface UseDebounceOptions<T = any> extends DebounceSettings {
-//   onFire?: (value: T) => void
-// }
+interface UseDebounceOptions<T extends noop> extends DebounceSettings {
+  onUnmount?: (
+    debounced: DebouncedFunc<(...args: Parameters<T>) => ReturnType<T>>
+  ) => void
+}
 
 function useDebounceCallback<T extends noop>(
   fn: T,
   wait?: number,
-  options?: DebounceSettings
+  options?: UseDebounceOptions<T>
 ) {
   const fnRef = useLatest(fn)
   const debounced = React.useMemo(
@@ -28,7 +30,10 @@ function useDebounceCallback<T extends noop>(
     []
   )
 
-  useUnmount(() => debounced.cancel())
+  useUnmount(() => {
+    options?.onUnmount?.(debounced)
+    debounced.cancel()
+  })
 
   return {
     run: debounced,


### PR DESCRIPTION
Relates #2557 
Before unloading the `/playground` page, try to flush any pending invocations of the debounced function responsible for persisting chats.