### PR TITLE
feat: add spinner for prod release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,6 +2646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "markup5ever"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4561,6 +4567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinners"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "strum 0.24.1",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5017,6 +5034,7 @@ dependencies = [
  "serde_json",
  "serdeconv",
  "serial_test 3.1.1",
+ "spinners",
  "strfmt",
  "strum 0.24.1",
  "sysinfo",

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -24,7 +24,7 @@ tabby-inference = { path = "../tabby-inference" }
 axum.workspace = true
 axum-extra = {workspace = true, features = ["typed-header"]}
 hyper = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras", "preserve_order"] }
 utoipa-swagger-ui = { version = "6", features = ["axum"] }
 serde = { workspace = true }

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -24,7 +24,7 @@ tabby-inference = { path = "../tabby-inference" }
 axum.workspace = true
 axum-extra = {workspace = true, features = ["typed-header"]}
 hyper = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 utoipa = { workspace = true, features = ["axum_extras", "preserve_order"] }
 utoipa-swagger-ui = { version = "6", features = ["axum"] }
 serde = { workspace = true }
@@ -56,6 +56,7 @@ parse-git-url = "0.5.1"
 color-eyre = { version = "0.6.3" }
 reqwest.workspace = true
 async-openai.workspace = true
+spinners = "4.1.1"
 
 [dependencies.openssl]
 optional = true

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -3,6 +3,8 @@ use std::{net::IpAddr, sync::Arc, time::Duration};
 use axum::{routing, Router};
 use clap::Args;
 use hyper::StatusCode;
+use spinners::{Spinner, Spinners, Stream};
+use tokio::sync::oneshot::Sender;
 use tabby_common::{
     api::{self, code::CodeSearch, event::EventLogger},
     config::{Config, ConfigAccess, ModelConfig, StaticConfigAccess},
@@ -118,7 +120,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
 
     load_model(&config).await;
 
-    debug!("Starting server, this might take a few minutes...");
+    let tx = try_run_spinner();
 
     #[cfg(feature = "ee")]
     #[allow(deprecated)]
@@ -182,6 +184,9 @@ pub async fn main(config: &Config, args: &ServeArgs) {
         ui = new_ui;
     };
 
+    if let Some(tx) = tx {
+        tx.send(()).unwrap_or_else(|_| warn!("Spinner channel is closed"));
+    }
     start_heartbeat(args, &config, webserver);
     run_app(api, Some(ui), args.host, args.port).await
 }
@@ -399,4 +404,23 @@ fn merge_args(config: &Config, args: &ServeArgs) -> Config {
     }
 
     config
+}
+
+fn try_run_spinner() -> Option<Sender<()>> {
+    if cfg!(feature = "prod") {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::task::spawn(async move {
+            let mut sp = Spinner::with_timer_and_stream(
+                Spinners::Dots,
+                "Starting...".into(),
+                Stream::Stdout,
+            );
+            let _ = rx.await;
+            sp.stop_with_symbol("\x1b[32m🗸\x1b[0m");
+        });
+        Some(tx)
+    } else {
+        debug!("Starting server, this might take a few minutes...");
+        None
+    }
 }

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -416,7 +416,7 @@ fn try_run_spinner() -> Option<Sender<()>> {
                 Stream::Stdout,
             );
             let _ = rx.await;
-            sp.stop_with_symbol("\x1b[32m🗸\x1b[0m");
+            sp.stop_with_message("".into());
         });
         Some(tx)
     } else {

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -4,14 +4,13 @@ use axum::{routing, Router};
 use clap::Args;
 use hyper::StatusCode;
 use spinners::{Spinner, Spinners, Stream};
-use tokio::sync::oneshot::Sender;
 use tabby_common::{
     api::{self, code::CodeSearch, event::EventLogger},
     config::{Config, ConfigAccess, ModelConfig, StaticConfigAccess},
     usage,
 };
 use tabby_inference::Embedding;
-use tokio::time::sleep;
+use tokio::{sync::oneshot::Sender, time::sleep};
 use tower_http::timeout::TimeoutLayer;
 use tracing::{debug, warn};
 use utoipa::{
@@ -185,7 +184,8 @@ pub async fn main(config: &Config, args: &ServeArgs) {
     };
 
     if let Some(tx) = tx {
-        tx.send(()).unwrap_or_else(|_| warn!("Spinner channel is closed"));
+        tx.send(())
+            .unwrap_or_else(|_| warn!("Spinner channel is closed"));
     }
     start_heartbeat(args, &config, webserver);
     run_app(api, Some(ui), args.host, args.port).await


### PR DESCRIPTION
For closing https://github.com/TabbyML/tabby/issues/2457

- Add `spinner` dep
- If binary is `prod` release, spawn the spinner in a tokio task, if binary is dev release, just print debug log as before
  - Use `onshot` channel to coordinate with main thread

Test result:
![Animation](https://github.com/TabbyML/tabby/assets/1013532/d63203e0-7481-4f76-872e-54c87dcdd098)
