### PR TITLE
ci: fix dockerfile warnings: 'as' and 'FROM' keywords' casing do not match

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -6,7 +6,7 @@ ARG BASE_CUDA_DEV_CONTAINER=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VER
 # Target the CUDA runtime image
 ARG BASE_CUDA_RUN_CONTAINER=nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
 
-FROM ${BASE_CUDA_DEV_CONTAINER} as build
+FROM ${BASE_CUDA_DEV_CONTAINER} AS build
 
 # Rust toolchain version
 ARG RUST_TOOLCHAIN=stable
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # For compatibility with the legacy cpu build.
 RUN cp /opt/tabby/bin/tabby /opt/tabby/bin/tabby-cpu
 
-FROM ${BASE_CUDA_RUN_CONTAINER} as runtime
+FROM ${BASE_CUDA_RUN_CONTAINER} AS runtime
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
When docker build then log show:

```txt
 2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 49)
```