### PR TITLE
feat(agent): http proxy support

### DIFF
--- a/clients/tabby-agent/package.json
+++ b/clients/tabby-agent/package.json
@@ -85,6 +85,7 @@
     "tsc-watch": "^6.2.0",
     "tsup": "^8.0.2",
     "typescript": "^5.3.2",
+    "undici": "^6.19.2",
     "uri-js": "^4.4.1",
     "uuid": "^9.0.0",
     "vscode-languageserver": "^9.0.1",

--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -5,6 +5,10 @@ export type AgentConfig = {
     requestHeaders: Record<string, string | number | boolean | null | undefined>;
     requestTimeout: number;
   };
+  proxy: {
+    url: string;
+    authorization: string;
+  };
   completion: {
     prompt: {
       maxPrefixLines: number;
@@ -117,6 +121,10 @@ export const defaultAgentConfig: AgentConfig = {
     token: "",
     requestHeaders: {},
     requestTimeout: 2 * 60 * 1000, // 2 minutes
+  },
+  proxy: {
+    url: "",
+    authorization: "",
   },
   completion: {
     prompt: {

--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -7,7 +7,6 @@ export type AgentConfig = {
   };
   proxy: {
     url: string;
-    authorization: string;
   };
   completion: {
     prompt: {
@@ -124,7 +123,6 @@ export const defaultAgentConfig: AgentConfig = {
   },
   proxy: {
     url: "",
-    authorization: "",
   },
   completion: {
     prompt: {

--- a/clients/tabby-agent/src/configFile.ts
+++ b/clients/tabby-agent/src/configFile.ts
@@ -17,15 +17,21 @@ const configTomlTemplate = `## Tabby agent configuration file
 ## Configurations in this file have lower priority than the IDE settings.
 
 ## Server
-## You can set the server endpoint here and an optional authentication token if required.
+## You can set the server endpoint and token here.
 # [server]
 # endpoint = "http://localhost:8080" # http or https URL
-# token = "your-token-here" # if token is set, request header Authorization = "Bearer $token" will be added automatically
+# token = "your-token-here" # if set, request header Authorization = "Bearer $token" will be added
 
 ## You can add custom request headers.
 # [server.requestHeaders]
 # Header1 = "Value1" # list your custom headers here
 # Header2 = "Value2" # values can be strings, numbers or booleans
+
+## Proxy
+## You can specify an optional http/https proxy when required, overrides environment variable settings.
+# [proxy]
+# url = "http://your-proxy-server" # the URL of the proxy
+# authorization = "" # if set, request header Proxy-Authorization = "$proxyAuthorization" will be added
 
 ## Logs
 ## You can set the log level here. The log file is located at ~/.tabby-client/agent/logs/.
@@ -48,6 +54,9 @@ const typeCheckSchema: Record<string, string> = {
   "server.token": "string",
   "server.requestHeaders": "object",
   "server.requestTimeout": "number",
+  proxy: "object",
+  "proxy.url": "string",
+  "proxy.authorization": "string",
   completion: "object",
   "completion.prompt": "object",
   "completion.prompt.maxPrefixLines": "number",
@@ -116,14 +125,10 @@ class ConfigFile extends EventEmitter {
     try {
       const fileContent = await fs.readFile(this.filepath, "utf8");
       const data = toml.parse(fileContent);
-      // If the config file contains no value, overwrite it with the new template.
-      if (Object.keys(data).length === 0 && fileContent.trim() !== configTomlTemplate.trim()) {
-        await this.createTemplate();
-        return;
-      }
       this.data = validateConfig(data);
     } catch (error) {
       if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        this.logger.info("Config file not exist, creating template config file.");
         await this.createTemplate();
       } else {
         this.logger.error("Failed to load config file.", error);

--- a/clients/tabby-agent/src/configFile.ts
+++ b/clients/tabby-agent/src/configFile.ts
@@ -31,7 +31,6 @@ const configTomlTemplate = `## Tabby agent configuration file
 ## You can specify an optional http/https proxy when required, overrides environment variable settings.
 # [proxy]
 # url = "http://your-proxy-server" # the URL of the proxy
-# authorization = "" # if set, request header Proxy-Authorization = "$proxyAuthorization" will be added
 
 ## Logs
 ## You can set the log level here. The log file is located at ~/.tabby-client/agent/logs/.
@@ -56,7 +55,6 @@ const typeCheckSchema: Record<string, string> = {
   "server.requestTimeout": "number",
   proxy: "object",
   "proxy.url": "string",
-  "proxy.authorization": "string",
   completion: "object",
   "completion.prompt": "object",
   "completion.prompt.maxPrefixLines": "number",

--- a/clients/tabby-agent/src/http/proxy.ts
+++ b/clients/tabby-agent/src/http/proxy.ts
@@ -1,0 +1,40 @@
+import { Dispatcher, ProxyAgent, EnvHttpProxyAgent } from "undici";
+import { parse as uriParse } from "uri-js";
+import { isBrowser } from "../env";
+import { getLogger } from "../logger";
+
+export type ProxyConfig =
+  | {
+      url: string;
+      authorization?: string;
+      noProxy?: string;
+    }
+  | { fromEnv: true };
+
+const logger = getLogger("proxy")
+
+export function createProxyForUrl(url: string, configs: ProxyConfig[]): Dispatcher | null {
+  if (isBrowser) {
+    return null;
+  }
+  const { host } = uriParse(url);
+  if (!host) {
+    return null;
+  }
+  for (const config of configs) {
+    if ("fromEnv" in config && config["fromEnv"]) {
+      logger.info("Using proxy from environment variables.");
+      return new EnvHttpProxyAgent();
+    } else if ("url" in config && config["url"]) {
+      const noProxyList = config["noProxy"]?.split(/,|\s+/).map((item) => item.trim());
+      if (!noProxyList || !noProxyList.includes(host)) {
+        logger.info(`Using proxy ${config["url"]}.`);
+        return new ProxyAgent({
+          uri: config["url"],
+          token: config["authorization"],
+        });
+      }
+    }
+  }
+  return null;
+}

--- a/clients/tabby-agent/src/http/proxy.ts
+++ b/clients/tabby-agent/src/http/proxy.ts
@@ -11,7 +11,7 @@ export type ProxyConfig =
     }
   | { fromEnv: true };
 
-const logger = getLogger("proxy")
+const logger = getLogger("proxy");
 
 export function createProxyForUrl(url: string, configs: ProxyConfig[]): Dispatcher | null {
   if (isBrowser) {

--- a/clients/tabby-agent/tsup.config.ts
+++ b/clients/tabby-agent/tsup.config.ts
@@ -108,6 +108,7 @@ export default defineConfig(async () => {
         "win-ca",
         "mac-ca",
         "vscode-languageserver/node",
+        "undici",
       ],
       esbuildPlugins: [
         processWinCa(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9743,10 +9743,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@5.28.4:
-    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
-    engines: {node: '>=14.0'}
-
   undici@6.19.2:
     resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
     engines: {node: '>=18.17'}
@@ -13552,23 +13548,6 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.3.101':
     optional: true
 
-  '@swc/core@1.3.101':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.7
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.101
-      '@swc/core-darwin-x64': 1.3.101
-      '@swc/core-linux-arm-gnueabihf': 1.3.101
-      '@swc/core-linux-arm64-gnu': 1.3.101
-      '@swc/core-linux-arm64-musl': 1.3.101
-      '@swc/core-linux-x64-gnu': 1.3.101
-      '@swc/core-linux-x64-musl': 1.3.101
-      '@swc/core-win32-arm64-msvc': 1.3.101
-      '@swc/core-win32-ia32-msvc': 1.3.101
-      '@swc/core-win32-x64-msvc': 1.3.101
-    optional: true
-
   '@swc/core@1.3.101(@swc/helpers@0.5.2)':
     dependencies:
       '@swc/counter': 0.1.3
@@ -16013,11 +15992,11 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
-  esbuild-plugin-copy@2.1.1(esbuild@0.20.2):
+  esbuild-plugin-copy@2.1.1(esbuild@0.19.12):
     dependencies:
       chalk: 4.1.2
       chokidar: 3.6.0
-      esbuild: 0.20.2
+      esbuild: 0.19.12
       fs-extra: 10.1.0
       globby: 11.1.0
 
@@ -21123,7 +21102,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.3.101
+      '@swc/core': 1.3.101(@swc/helpers@0.5.2)
 
   ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5):
     dependencies:
@@ -21213,7 +21192,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.3.101
+      '@swc/core': 1.3.101(@swc/helpers@0.5.2)
       postcss: 8.4.38
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -21411,10 +21390,6 @@ snapshots:
   underscore@1.13.6: {}
 
   undici-types@5.26.5: {}
-
-  undici@5.28.4:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   undici@6.19.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.3
+      undici:
+        specifier: ^6.19.2
+        version: 6.19.2
       uri-js:
         specifier: ^4.4.1
         version: 4.4.1
@@ -9740,6 +9743,14 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+
+  undici@6.19.2:
+    resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
+    engines: {node: '>=18.17'}
+
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
@@ -13541,6 +13552,23 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.3.101':
     optional: true
 
+  '@swc/core@1.3.101':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.7
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.3.101
+      '@swc/core-darwin-x64': 1.3.101
+      '@swc/core-linux-arm-gnueabihf': 1.3.101
+      '@swc/core-linux-arm64-gnu': 1.3.101
+      '@swc/core-linux-arm64-musl': 1.3.101
+      '@swc/core-linux-x64-gnu': 1.3.101
+      '@swc/core-linux-x64-musl': 1.3.101
+      '@swc/core-win32-arm64-msvc': 1.3.101
+      '@swc/core-win32-ia32-msvc': 1.3.101
+      '@swc/core-win32-x64-msvc': 1.3.101
+    optional: true
+
   '@swc/core@1.3.101(@swc/helpers@0.5.2)':
     dependencies:
       '@swc/counter': 0.1.3
@@ -13718,7 +13746,7 @@ snapshots:
 
   '@types/node-fetch@2.6.6':
     dependencies:
-      '@types/node': 18.19.33
+      '@types/node': 20.12.12
       form-data: 4.0.0
 
   '@types/node-forge@1.3.11':
@@ -13808,7 +13836,7 @@ snapshots:
 
   '@types/ws@8.5.9':
     dependencies:
-      '@types/node': 18.19.33
+      '@types/node': 20.12.12
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
@@ -15985,11 +16013,11 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
-  esbuild-plugin-copy@2.1.1(esbuild@0.19.12):
+  esbuild-plugin-copy@2.1.1(esbuild@0.20.2):
     dependencies:
       chalk: 4.1.2
       chokidar: 3.6.0
-      esbuild: 0.19.12
+      esbuild: 0.20.2
       fs-extra: 10.1.0
       globby: 11.1.0
 
@@ -21095,7 +21123,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.3.101(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.101
 
   ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5):
     dependencies:
@@ -21185,7 +21213,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.3.101(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.101
       postcss: 8.4.38
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -21383,6 +21411,12 @@ snapshots:
   underscore@1.13.6: {}
 
   undici-types@5.26.5: {}
+
+  undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@6.19.2: {}
 
   unicode-trie@2.0.0:
     dependencies:


### PR DESCRIPTION
Changes:
- Add support for http proxy. The proxy can be configured using:
  - environment variables ( http_proxy, https_proxy, no_proxy ) [more detail](https://github.com/nodejs/undici/blob/main/docs/docs/api/EnvHttpProxyAgent.md)
  - in `~/.tabby-client/agent/config.toml`, override environment variables
    ```yaml
    [proxy]
    url = "http://127.0.0.1:1087"  # or http://user:pass@127.0.0.1:1087  if auth required
    ```
Proxy config in IDE (VSCode) is not supported for now. This is planned to be supported in a future release.