### PR TITLE
feat(ui): add multiline highlight in code browser

### DIFF
--- a/ee/tabby-ui/app/files/components/code-editor-view.tsx
+++ b/ee/tabby-ui/app/files/components/code-editor-view.tsx
@@ -152,7 +152,7 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
             line: lineNumber,
             endLine: endLineNumber
           })
-          if (isPositionInView(editorView, lineNumber, 90)) {
+          if (isPositionInView(editorView, lineInfo.from, 90)) {
             return
           }
           editorView.dispatch({

--- a/ee/tabby-ui/app/files/components/code-editor-view.tsx
+++ b/ee/tabby-ui/app/files/components/code-editor-view.tsx
@@ -39,6 +39,7 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
   const { copyToClipboard } = useCopyToClipboard({})
   const [hash, updateHash] = useHash()
   const lineNumber = parseLineNumberFromHash(hash)?.start
+  const endLineNumber = parseLineNumberFromHash(hash)?.end
   const [editorView, setEditorView] = React.useState<EditorView | null>(null)
 
   const { isChatEnabled, activePath, activeEntryInfo, activeRepo } =
@@ -111,21 +112,28 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
     return () => {
       emitter.off('line_menu_action', onClickLineMenu)
     }
-  }, [value, lineNumber])
+  }, [value, lineNumber, endLineNumber])
 
   React.useEffect(() => {
     if (!isNil(lineNumber) && editorView && value) {
       try {
         const lineInfo = editorView?.state?.doc?.line(lineNumber)
+        const endLineInfo = !isNil(endLineNumber)
+          ? editorView?.state?.doc?.line(endLineNumber)
+          : null
 
         if (lineInfo) {
-          const pos = lineInfo.from
-          setSelectedLines(editorView, pos)
-          if (isPositionInView(editorView, pos, 90)) {
+          const lineNumber = lineInfo.number
+          const endLineNumber = endLineInfo?.number
+          setSelectedLines(editorView, {
+            line: lineNumber,
+            endLine: endLineNumber
+          })
+          if (isPositionInView(editorView, lineNumber, 90)) {
             return
           }
           editorView.dispatch({
-            effects: EditorView.scrollIntoView(pos, {
+            effects: EditorView.scrollIntoView(lineNumber, {
               y: 'start',
               yMargin: 200
             })

--- a/ee/tabby-ui/app/files/components/code-editor-view.tsx
+++ b/ee/tabby-ui/app/files/components/code-editor-view.tsx
@@ -49,7 +49,7 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
   const extensions = React.useMemo(() => {
     let result: Extension[] = [
       selectLinesGutter({
-        onSelectLine: v => {
+        onSelectLine: (v, isShiftDown) => {
           if (v === -1 || isNaN(v)) return
           // todo support multi lines
           updateHash(formatLineHashForCodeBrowser({ start: v }))

--- a/ee/tabby-ui/app/files/components/code-editor-view.tsx
+++ b/ee/tabby-ui/app/files/components/code-editor-view.tsx
@@ -52,7 +52,8 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
       selectLinesGutter({
         onSelectLine: (v, isShiftDown) => {
           if (v === -1 || isNaN(v)) return
-          // todo support multi lines
+          // FIXME support multi lines
+          // todo setEndLine()
           updateHash(formatLineHashForCodeBrowser({ start: v }))
         }
       }),
@@ -155,6 +156,12 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
           })
         }
       } catch (e) {}
+    }
+
+    return () => {
+      if (editorView) {
+        setSelectedLines(editorView, null)
+      }
     }
   }, [value, lineNumber, editorView])
 

--- a/ee/tabby-ui/app/files/components/code-editor-view.tsx
+++ b/ee/tabby-ui/app/files/components/code-editor-view.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { foldGutter } from '@codemirror/language'
 import { Extension, Line } from '@codemirror/state'
 import { drawSelection, EditorView } from '@codemirror/view'
-import { isNaN, isNil } from 'lodash-es'
+import { isNil } from 'lodash-es'
 import { useTheme } from 'next-themes'
 
 import { EXP_enable_code_browser_quick_action_bar } from '@/lib/experiment-flags'
@@ -50,11 +50,18 @@ const CodeEditorView: React.FC<CodeEditorViewProps> = ({ value, language }) => {
   const extensions = React.useMemo(() => {
     let result: Extension[] = [
       selectLinesGutter({
-        onSelectLine: (v, isShiftDown) => {
-          if (v === -1 || isNaN(v)) return
-          // FIXME support multi lines
-          // todo setEndLine()
-          updateHash(formatLineHashForCodeBrowser({ start: v }))
+        onSelectLine: range => {
+          if (!range) {
+            updateHash('')
+            return
+          }
+
+          updateHash(
+            formatLineHashForCodeBrowser({
+              start: range.line,
+              end: range.endLine
+            })
+          )
         }
       }),
       foldGutter({

--- a/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
+++ b/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
@@ -280,13 +280,16 @@ function formatSelectedLinesRange(
   }
 }
 
-function isValidLinesRange (range: SelectedLinesRange, doc: Text): boolean {
+function isValidLinesRange(range: SelectedLinesRange, doc: Text): boolean {
   if (!doc) return false
   const { lines } = doc
-  if (range?.line && range.line > lines || range?.endLine && range.endLine > lines) {
+  if (
+    (range?.line && range.line > lines) ||
+    (range?.endLine && range.endLine > lines)
+  ) {
     return false
   }
-  
+
   return true
 }
 

--- a/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
+++ b/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
@@ -98,28 +98,20 @@ const LineMenuButton = ({ isMulti }: { isMulti?: boolean }) => {
 
 // for single line
 const selectedLineMenuButton = new (class extends GutterMarker {
-  toDOM(view: EditorView) {
-    const range = view.state.field(selectedLinesField)
+  toDOM() {
     const dom = document.createElement('div')
     const root = ReactDOM.createRoot(dom)
-
-    const isMulti = !!range?.endLine
-
-    root.render(<LineMenuButton isMulti={isMulti} />)
+    root.render(<LineMenuButton isMulti={false} />)
     return dom
   }
 })()
 
 // for multi lines
 const selectedLinesMenuButton = new (class extends GutterMarker {
-  toDOM(view: EditorView) {
-    const range = view.state.field(selectedLinesField)
+  toDOM() {
     const dom = document.createElement('div')
     const root = ReactDOM.createRoot(dom)
-
-    const isMulti = !!range?.endLine
-
-    root.render(<LineMenuButton isMulti={isMulti} />)
+    root.render(<LineMenuButton isMulti />)
     return dom
   }
 })()
@@ -174,6 +166,7 @@ const selectableLineNumberTheme = EditorView.theme({
     width: '40px'
   },
   '.cm-lineNumbers': {
+    userSelect: 'none',
     cursor: 'pointer',
     color: 'var(--line-number-color)',
 
@@ -194,12 +187,6 @@ function setSelectedLines(
   return newRange
 }
 
-function clearSelectedLines(view: EditorView) {
-  view.dispatch({
-    effects: [selectLinesEffect.of({ line: -1 })]
-  })
-}
-
 const setEndLine = StateEffect.define<number>()
 
 type SelectLInesGutterOptions = {
@@ -211,8 +198,11 @@ function getMarkersFromSelectedLinesField(view: EditorView) {
   // FIXME compare line and endLine from range
   // FIXME check if range is valid
   if (range?.line) {
-    const pos = view.state.doc.line(range.line).from
-    const isMulti = !!range.endLine
+    const isMulti = !!range.endLine && range.line !== range.endLine
+    const lineNumber = range.endLine
+      ? Math.min(range.line, range.endLine)
+      : range.line
+    const pos = view.state.doc.line(lineNumber).from
     return RangeSet.empty.update({
       add: [
         isMulti
@@ -285,9 +275,4 @@ function formatSelectedLinesRange(
   }
 }
 
-export {
-  selectLinesGutter,
-  setSelectedLines,
-  clearSelectedLines,
-  formatSelectedLinesRange
-}
+export { selectLinesGutter, setSelectedLines, formatSelectedLinesRange }

--- a/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
+++ b/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
@@ -35,45 +35,6 @@ const selectedLineGutterMarker = new (class extends GutterMarker {
   elementClass = 'cm-selectedLineGutter'
 })()
 
-const selectedLineMenuButton = new (class extends GutterMarker {
-  toDOM() {
-    const dom = document.createElement('div')
-    const root = ReactDOM.createRoot(dom)
-    root.render(
-      <DropdownMenu modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button className="ml-1 h-5" size="icon" variant="secondary">
-            <IconMore />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onSelect={e => {
-              emitter.emit('line_menu_action', {
-                action: 'copy_line'
-              })
-            }}
-          >
-            Copy line
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onSelect={e => {
-              emitter.emit('line_menu_action', {
-                action: 'copy_permalink'
-              })
-            }}
-          >
-            Copy link
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    )
-    return dom
-  }
-})()
-
 const selectLinesEffect = StateEffect.define<SelectedLinesRange>()
 
 const selectedLinesField = StateField.define<SelectedLinesRange>({
@@ -101,6 +62,52 @@ const selectedLinesField = StateField.define<SelectedLinesRange>({
     ]
   }
 })
+
+const selectedLineMenuButton = new (class extends GutterMarker {
+  // eq(other: GutterMarker): boolean {
+  //   other.
+  // }
+  toDOM(view: EditorView) {
+    const range = view.state.field(selectedLinesField)
+    const dom = document.createElement('div')
+    const root = ReactDOM.createRoot(dom)
+
+    const isMulti = !!range?.endLine
+
+    root.render(
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button className="ml-1 h-5" size="icon" variant="secondary">
+            <IconMore />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={e => {
+              emitter.emit('line_menu_action', {
+                action: 'copy_line'
+              })
+            }}
+          >
+            {isMulti ? 'Copy lines' : 'Copy line'}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={e => {
+              emitter.emit('line_menu_action', {
+                action: 'copy_permalink'
+              })
+            }}
+          >
+            Copy link
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+    return dom
+  }
+})()
 
 function selectedLinesHighlighter(field: StateField<SelectedLinesRange>) {
   return EditorView.decorations.compute([field], state => {
@@ -204,6 +211,9 @@ const selectLinesGutter = ({ onSelectLine }: SelectLInesGutterOptions) => {
       class: 'cm-lineMenuGutter',
       markers: v => getMarkersFromSelectedLinesField(v),
       initialSpacer: () => selectedLineMenuButton,
+      updateSpacer(spacer, update) {
+          return selectedLineMenuButton
+      },
       domEventHandlers: {
         mousedown(view, line, event) {
           const mouseEvent = event as MouseEvent

--- a/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
+++ b/ee/tabby-ui/app/files/components/line-menu-extension/line-menu-extension.tsx
@@ -2,7 +2,8 @@ import {
   RangeSet,
   RangeSetBuilder,
   StateEffect,
-  StateField
+  StateField,
+  Text
 } from '@codemirror/state'
 import {
   Decoration,
@@ -180,9 +181,9 @@ function setSelectedLines(
   view: EditorView,
   newRange: SelectedLinesRange
 ): SelectedLinesRange {
-  // FIXME check if the range is valid
+  const isValid = isValidLinesRange(newRange, view.state.doc)
   view.dispatch({
-    effects: selectLinesEffect.of(newRange)
+    effects: selectLinesEffect.of(isValid ? newRange : null)
   })
   return newRange
 }
@@ -195,8 +196,12 @@ type SelectLInesGutterOptions = {
 
 function getMarkersFromSelectedLinesField(view: EditorView) {
   const range = view.state.field(selectedLinesField)
-  // FIXME compare line and endLine from range
-  // FIXME check if range is valid
+
+  // check if range is valid
+  if (!isValidLinesRange(range, view.state.doc)) {
+    return RangeSet.empty
+  }
+
   if (range?.line) {
     const isMulti = !!range.endLine && range.line !== range.endLine
     const lineNumber = range.endLine
@@ -273,6 +278,16 @@ function formatSelectedLinesRange(
   } else if (line) {
     return { line }
   }
+}
+
+function isValidLinesRange (range: SelectedLinesRange, doc: Text): boolean {
+  if (!doc) return false
+  const { lines } = doc
+  if (range?.line && range.line > lines || range?.endLine && range.endLine > lines) {
+    return false
+  }
+  
+  return true
 }
 
 export { selectLinesGutter, setSelectedLines, formatSelectedLinesRange }

--- a/ee/tabby-ui/components/codemirror/codemirror.tsx
+++ b/ee/tabby-ui/components/codemirror/codemirror.tsx
@@ -65,7 +65,8 @@ const CodeMirrorEditor = React.forwardRef<
       outline: 'none !important'
     },
     '& .cm-scroller': {
-      height: '100% !important'
+      height: '100% !important',
+      outline: 'none'
     },
     '& .cm-gutters': {
       background: 'hsl(var(--background))'

--- a/ee/tabby-ui/components/codemirror/codemirror.tsx
+++ b/ee/tabby-ui/components/codemirror/codemirror.tsx
@@ -62,7 +62,7 @@ const CodeMirrorEditor = React.forwardRef<
       background: 'hsl(var(--background))'
     },
     '&.cm-focused': {
-      outline: 'none'
+      outline: 'none !important'
     },
     '& .cm-scroller': {
       height: '100% !important'

--- a/ee/tabby-ui/components/codemirror/codemirror.tsx
+++ b/ee/tabby-ui/components/codemirror/codemirror.tsx
@@ -61,6 +61,9 @@ const CodeMirrorEditor = React.forwardRef<
       outline: 'none !important',
       background: 'hsl(var(--background))'
     },
+    '&.cm-focused': {
+      outline: 'none'
+    },
     '& .cm-scroller': {
       height: '100% !important'
     },


### PR DESCRIPTION
### Changes
1. Add multiline highlight in code browser
2. When multiple lines are highlighted, user can use the 'Copy lines' option in the line menus to copy the text content of the selected lines.

### Screen record
https://jam.dev/c/1986db82-b517-454f-b4b7-3a80ed88a7a5