### PR TITLE
fix(index): there's no need to strip prefix as we no longer prepend c…

### DIFF
--- a/crates/tabby-index/src/indexer.rs
+++ b/crates/tabby-index/src/indexer.rs
@@ -201,7 +201,6 @@ impl Indexer {
                     continue;
                 };
 
-                let prefix_to_strip = format!("{}:", self.corpus);
                 let mut doc_id = postings.doc();
                 while doc_id != TERMINATED {
                     if !segment_reader.is_deleted(doc_id) {
@@ -210,9 +209,8 @@ impl Indexer {
 
                         // Skip chunks, as we only want to iterate over the main docs
                         if doc.get_first(schema.field_chunk_id).is_none() {
-                            if let Some(id) = get_text(&doc, schema.field_id).strip_prefix(&prefix_to_strip) {
-                                yield id.to_owned();
-                            }
+                            let id = get_text(&doc, schema.field_id);
+                            yield id.to_owned();
                         }
                     }
                     doc_id = postings.advance();

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
@@ -130,7 +130,7 @@ impl SchedulerGithubGitlabJob {
 
         s.enumerate()
             .map(|(count, (updated_at, doc))| {
-                if (count + 1) % 10 == 0 {
+                if (count + 1) % 50 == 0 {
                     logkit::info!("{} documents indexed", count + 1);
                 }
 


### PR DESCRIPTION
…orpus to the id field