### PR TITLE
fix(vscode): improve rendering logic

### DIFF
--- a/clients/vscode/assets/chat-panel.css
+++ b/clients/vscode/assets/chat-panel.css
@@ -15,3 +15,34 @@ iframe {
   width: 100%;
   height: 100vh;
 }
+
+/* Static content page */
+.static-content {
+  padding: 0.65rem 1.2rem;
+}
+
+.static-content .avatar {
+  display: flex;
+  align-items: center;
+}
+
+.static-content .avatar img {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+  border-radius: 100%;
+  margin-right: 0.4rem;
+  padding: 0.2rem;
+  border: 1px solid var(--vscode-editorWidget-border);
+  background-color: rgb(232, 226, 210);
+}
+
+.static-content .title {
+  margin: 0.45rem 0 0;
+  font-size: 0.85rem;
+}
+
+.static-content p {
+  line-height: 1.45;
+  margin: 0.45rem 0;
+}

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -190,16 +190,16 @@ export class ChatViewProvider implements WebviewViewProvider {
     } else {
       this.displayDisconnectedContent();
     }
-    
+
     this.agent.on("didChangeStatus", async (status) => {
-      if (status !== 'disconnected') {
+      if (status !== "disconnected") {
         const serverInfo = await this.agent.fetchServerInfo();
-        this.initializeChatPage(serverInfo.config.endpoint); 
+        this.initializeChatPage(serverInfo.config.endpoint);
         this.refreshChatPage();
       } else if (this.isChatPageInitialized) {
         this.displayDisconnectedContent();
       }
-    }); 
+    });
 
     this.agent.on("didUpdateServerInfo", () => {
       this.refreshChatPage();
@@ -217,7 +217,7 @@ export class ChatViewProvider implements WebviewViewProvider {
         case "rendered": {
           setTimeout(() => {
             this.refreshChatPage();
-          }, 300)
+          }, 300);
           return;
         }
         case "copy": {
@@ -287,17 +287,17 @@ export class ChatViewProvider implements WebviewViewProvider {
     }
   }
 
-    private async initializeChatPage(endpoint: string, opts?: { force: boolean }) {
-      if (!endpoint) return
-      if (this.isChatPageInitialized && !opts?.force) return;
+  private async initializeChatPage(endpoint: string, opts?: { force: boolean }) {
+    if (!endpoint) return;
+    if (this.isChatPageInitialized && !opts?.force) return;
 
-      if (this.webview) {
-        this.isChatPageInitialized = true;
-        const styleUri = this.webview?.webview.asWebviewUri(
-          Uri.joinPath(this.context.extensionUri, "assets", "chat-panel.css"),
-        );
+    if (this.webview) {
+      this.isChatPageInitialized = true;
+      const styleUri = this.webview?.webview.asWebviewUri(
+        Uri.joinPath(this.context.extensionUri, "assets", "chat-panel.css"),
+      );
 
-        this.webview.webview.html = `
+      this.webview.webview.html = `
         <!DOCTYPE html>
         <html lang="en">
           <!--hash: ${hashObject({ renderDate: new Date().toString() })}-->
@@ -390,7 +390,9 @@ export class ChatViewProvider implements WebviewViewProvider {
     if (this.webview) {
       this.isChatPageInitialized = false;
 
-      const logoUri = this.webview?.webview.asWebviewUri(Uri.joinPath(this.context.extensionUri, "assets", "tabby.png"));
+      const logoUri = this.webview?.webview.asWebviewUri(
+        Uri.joinPath(this.context.extensionUri, "assets", "tabby.png"),
+      );
       const styleUri = this.webview?.webview.asWebviewUri(
         Uri.joinPath(this.context.extensionUri, "assets", "chat-panel.css"),
       );
@@ -409,13 +411,12 @@ export class ChatViewProvider implements WebviewViewProvider {
                 <p>Tabby</p>
               </div>
               <h4 class='title'>Welcome to Tabby Chat!</h4>
-              <p>Before you can start chatting, please take a moment to set up your credentials to connect to the Tabby server.</p>
+              <p>To start chatting, please set up your Tabby server. Ensure that your Tabby server is properly configured and connected.</p>
             </main>
           </body>
         </html>
       `;
     }
-    
   }
 
   public getWebview() {


### PR DESCRIPTION
### Main fix
#### 1. Empty chat panel when server down
**Issue**: When the server instance is not up, the chat panel is currently empty.
**After Fix:** Display a message.

<img width="350" alt="Screenshot 2024-07-16 15 52 08" src="https://github.com/user-attachments/assets/7c2a9e67-8772-4102-9078-7eff14f7a3d8">

<img width="350" alt="Screenshot 2024-07-16 15 52 24" src="https://github.com/user-attachments/assets/7ec389c7-b3ff-4714-b870-0d815fdd9048">

#### 2. Rendering issue on rapid refresh
**Issue**: Quickly clicking the refresh button sometimes prevents correct rendering.
**After Fix**: https://jam.dev/c/c6533855-1109-4ba8-9010-b78a5d984eb1


### Note
* This PR needs to be cherry-picked for VSCode 1.8.0
* Tested other 1.8.0 chat-panel features as well
* Testing backend version: `0.14.0-rc.0`