### PR TITLE
feat(index): add attributes for origin values

### DIFF
--- a/crates/tabby-index/src/indexer.rs
+++ b/crates/tabby-index/src/indexer.rs
@@ -36,7 +36,7 @@ pub trait IndexAttributeBuilder<T>: Send + Sync {
     async fn build_chunk_attributes(
         &self,
         document: &T,
-    ) -> BoxStream<JoinHandle<(Vec<String>, serde_json::Value)>>;
+    ) -> BoxStream<JoinHandle<(Vec<String>, Vec<u8>, serde_json::Value)>>;
 }
 
 pub struct TantivyDocBuilder<T> {
@@ -100,7 +100,7 @@ impl<T: ToIndexId> TantivyDocBuilder<T> {
                 let source_id = source_id.clone();
 
                 yield tokio::spawn(async move {
-                    let Ok((tokens, chunk_attributes)) = task.await else {
+                    let Ok((tokens, token_values, chunk_attributes)) = task.await else {
                         return None;
                     };
 
@@ -111,6 +111,7 @@ impl<T: ToIndexId> TantivyDocBuilder<T> {
                         schema.field_updated_at => updated_at,
                         schema.field_chunk_id => format!("{}-{}", id, chunk_id),
                         schema.field_chunk_attributes => chunk_attributes,
+                        schema.field_token_values => token_values,
                     };
 
                     for token in tokens {


### PR DESCRIPTION
one of https://github.com/TabbyML/tabby/issues/2633


# Background

We want to sort the result document again with the origin vector to get more accurate result. So we must store the origin vector as attributes values at first.

I will re-sort the result document in next PR.