### PR TITLE
fix(ui): truncate text in answer page

### DIFF
--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -92,6 +92,10 @@
   max-width: none !important;
 }
 
+.prose {
+  overflow-wrap: anywhere;
+}
+
 .dialog-without-close-btn > button {
   display: none;
 }


### PR DESCRIPTION
#### Before
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/420ef7ca-2879-426d-8987-efc01d482b0d">

#### After
<img width="991" alt="image" src="https://github.com/user-attachments/assets/1fa96e45-3b2c-4df4-bf86-e3dc74ba3946">
