### PR TITLE
feat(vscode) vscode config limit recently commands

### DIFF
--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -271,7 +271,7 @@
                   "Manual trigger by pressing `Alt + \\`"
                 ]
               },
-              "numRecentlyCommandsHistory": {
+              "chatEdit.history": {
                 "type": "integer",
                 "default": 20,
                 "description": "The maximum number of recently used commands to keep. Set to 0 to disable recording."

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -270,6 +270,11 @@
                   "Automatic trigger when you stop typing",
                   "Manual trigger by pressing `Alt + \\`"
                 ]
+              },
+              "numRecentlyCommandsHistory": {
+                "type": "integer",
+                "default": 20,
+                "description": "The maximum number of recently used commands to keep. Set to 0 to disable recording."
               }
             }
           }

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -263,7 +263,7 @@ export class Commands {
         },
       };
       //ensure max length
-      const recentlyCommand = this.config.chatEditRecentlyCommand.slice(0, this.config.numRecentlyCommandsHistory);
+      const recentlyCommand = this.config.chatEditRecentlyCommand.slice(0, this.config.chatEditHistory);
       const suggestedCommand: ChatEditCommand[] = [];
       const quickPick = window.createQuickPick<QuickPickItem & { value: string }>();
 
@@ -286,9 +286,7 @@ export class Commands {
             alwaysShow: true,
           });
         }
-        const recentlyCommandToAdd = recentlyCommand
-          .filter((item) => !list.find((i) => i.value === item))
-          .slice(0, this.config.numRecentlyCommandsHistory);
+        const recentlyCommandToAdd = recentlyCommand.filter((item) => !list.find((i) => i.value === item));
         list.push(
           ...recentlyCommandToAdd.map((item) => ({
             label: item,
@@ -333,7 +331,7 @@ export class Commands {
         if (command) {
           const updatedRecentlyCommand = [command]
             .concat(recentlyCommand.filter((item) => item !== command))
-            .slice(0, this.config.numRecentlyCommandsHistory);
+            .slice(0, this.config.chatEditHistory);
           this.config.chatEditRecentlyCommand = updatedRecentlyCommand;
 
           window.withProgress(
@@ -384,7 +382,6 @@ export class Commands {
             recentlyCommand.splice(index, 1);
             this.config.chatEditRecentlyCommand = recentlyCommand;
             updateQuickPickList();
-            window.showInformationMessage(`Removed command: ${item.label}`);
           }
         }
       });

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -294,6 +294,11 @@ export class Commands {
               value: item,
               iconPath: new ThemeIcon("history"),
               description: "History",
+              buttons: [
+                {
+                  iconPath: new ThemeIcon("settings-remove"),
+                },
+              ],
             };
           }),
         );
@@ -365,6 +370,22 @@ export class Commands {
           );
         }
       });
+      //delete chosen command
+      quickPick.onDidTriggerItemButton((event) => {
+        const item = event.item;
+        const button = event.button;
+
+        if (button.iconPath instanceof ThemeIcon && button.iconPath.id === "settings-remove") {
+          const index = recentlyCommand.indexOf(item.value);
+          if (index !== -1) {
+            recentlyCommand.splice(index, 1);
+            this.config.chatEditRecentlyCommand = recentlyCommand;
+            updateQuickPickList();
+            window.showInformationMessage(`Removed command: ${item.label}`);
+          }
+        }
+      });
+
       quickPick.show();
     },
     "chat.edit.stop": async () => {

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -262,21 +262,21 @@ export class Commands {
           },
         },
       };
-      const recentlyCommand = this.config.chatEditRecentlyCommand;
+      //ensure max length
+      const recentlyCommand = this.config.chatEditRecentlyCommand.slice(0, this.config.numRecentlyCommandsHistory);
       const suggestedCommand: ChatEditCommand[] = [];
       const quickPick = window.createQuickPick<QuickPickItem & { value: string }>();
+
       const updateQuickPickList = () => {
         const input = quickPick.value;
         const list: (QuickPickItem & { value: string })[] = [];
         list.push(
-          ...suggestedCommand.map((item) => {
-            return {
-              label: item.label,
-              value: item.command,
-              iconPath: item.source === "preset" ? new ThemeIcon("edit") : new ThemeIcon("spark"),
-              description: item.source === "preset" ? item.command : "Suggested",
-            };
-          }),
+          ...suggestedCommand.map((item) => ({
+            label: item.label,
+            value: item.command,
+            iconPath: item.source === "preset" ? new ThemeIcon("edit") : new ThemeIcon("spark"),
+            description: item.source === "preset" ? item.command : "Suggested",
+          })),
         );
         if (list.length > 0) {
           list.push({
@@ -286,21 +286,21 @@ export class Commands {
             alwaysShow: true,
           });
         }
-        const recentlyCommandToAdd = recentlyCommand.filter((item) => !list.find((i) => i.value === item));
+        const recentlyCommandToAdd = recentlyCommand
+          .filter((item) => !list.find((i) => i.value === item))
+          .slice(0, this.config.numRecentlyCommandsHistory);
         list.push(
-          ...recentlyCommandToAdd.map((item) => {
-            return {
-              label: item,
-              value: item,
-              iconPath: new ThemeIcon("history"),
-              description: "History",
-              buttons: [
-                {
-                  iconPath: new ThemeIcon("settings-remove"),
-                },
-              ],
-            };
-          }),
+          ...recentlyCommandToAdd.map((item) => ({
+            label: item,
+            value: item,
+            iconPath: new ThemeIcon("history"),
+            description: "History",
+            buttons: [
+              {
+                iconPath: new ThemeIcon("settings-remove"),
+              },
+            ],
+          })),
         );
         if (input.length > 0 && !list.find((i) => i.value === input)) {
           list.unshift({
@@ -313,12 +313,14 @@ export class Commands {
         }
         quickPick.items = list;
       };
+
       const fetchingSuggestedCommandCancellationTokenSource = new CancellationTokenSource();
       this.client.chat.provideEditCommands(
         { location: editLocation },
         { commands: suggestedCommand, callback: () => updateQuickPickList() },
         fetchingSuggestedCommandCancellationTokenSource.token,
       );
+
       quickPick.placeholder = "Enter the command for editing";
       quickPick.matchOnDescription = true;
       quickPick.onDidChangeValue(() => updateQuickPickList());
@@ -329,9 +331,11 @@ export class Commands {
         quickPick.hide();
         const command = quickPick.selectedItems[0]?.value;
         if (command) {
-          this.config.chatEditRecentlyCommand = [command]
+          const updatedRecentlyCommand = [command]
             .concat(recentlyCommand.filter((item) => item !== command))
-            .slice(0, 20);
+            .slice(0, this.config.numRecentlyCommandsHistory);
+          this.config.chatEditRecentlyCommand = updatedRecentlyCommand;
+
           window.withProgress(
             {
               location: ProgressLocation.Notification,
@@ -370,11 +374,10 @@ export class Commands {
           );
         }
       });
-      //delete chosen command
+
       quickPick.onDidTriggerItemButton((event) => {
         const item = event.item;
         const button = event.button;
-
         if (button.iconPath instanceof ThemeIcon && button.iconPath.id === "settings-remove") {
           const index = recentlyCommand.indexOf(item.value);
           if (index !== -1) {

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -4,6 +4,7 @@ import { ClientProvidedConfig } from "tabby-agent";
 
 interface AdvancedSettings {
   "inlineCompletion.triggerMode"?: "automatic" | "manual";
+  numRecentlyCommandsHistory?: number;
 }
 
 export class Config extends EventEmitter {
@@ -57,6 +58,28 @@ export class Config extends EventEmitter {
       const advancedSettings = this.workspace.get("settings.advanced", {}) as AdvancedSettings;
       const updatedValue = { ...advancedSettings, "inlineCompletion.triggerMode": value };
       this.workspace.update("settings.advanced", updatedValue, ConfigurationTarget.Global);
+      this.emit("updated");
+    }
+  }
+
+  get numRecentlyCommandsHistory(): number {
+    const advancedSettings = this.workspace.get("settings.advanced", {}) as AdvancedSettings;
+    const numHistory =
+      advancedSettings.numRecentlyCommandsHistory === undefined ? 20 : advancedSettings.numRecentlyCommandsHistory;
+    if (numHistory < 0) {
+      return 20;
+    } else if (numHistory === 0) {
+      return 0;
+    } else {
+      return numHistory;
+    }
+  }
+
+  set numRecentlyCommandsHistory(value: number) {
+    if (value != this.numRecentlyCommandsHistory) {
+      const advancedSettings = this.workspace.get("settings.advanced", {}) as AdvancedSettings;
+      const updateValue = { ...advancedSettings, numRecentlyCommandsHistory: value };
+      this.workspace.update("settings.advanced", updateValue, ConfigurationTarget.Global);
       this.emit("updated");
     }
   }

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -4,7 +4,7 @@ import { ClientProvidedConfig } from "tabby-agent";
 
 interface AdvancedSettings {
   "inlineCompletion.triggerMode"?: "automatic" | "manual";
-  numRecentlyCommandsHistory?: number;
+  "chatEdit.history"?: number;
 }
 
 export class Config extends EventEmitter {
@@ -62,10 +62,9 @@ export class Config extends EventEmitter {
     }
   }
 
-  get numRecentlyCommandsHistory(): number {
+  get chatEditHistory(): number {
     const advancedSettings = this.workspace.get("settings.advanced", {}) as AdvancedSettings;
-    const numHistory =
-      advancedSettings.numRecentlyCommandsHistory === undefined ? 20 : advancedSettings.numRecentlyCommandsHistory;
+    const numHistory = advancedSettings["chatEdit.history"] === undefined ? 20 : advancedSettings["chatEdit.history"];
     if (numHistory < 0) {
       return 20;
     } else if (numHistory === 0) {
@@ -75,10 +74,10 @@ export class Config extends EventEmitter {
     }
   }
 
-  set numRecentlyCommandsHistory(value: number) {
-    if (value != this.numRecentlyCommandsHistory) {
+  set chatEditHistory(value: number) {
+    if (value != this.chatEditHistory) {
       const advancedSettings = this.workspace.get("settings.advanced", {}) as AdvancedSettings;
-      const updateValue = { ...advancedSettings, numRecentlyCommandsHistory: value };
+      const updateValue = { ...advancedSettings, "chatEdit.history": value };
       this.workspace.update("settings.advanced", updateValue, ConfigurationTarget.Global);
       this.emit("updated");
     }


### PR DESCRIPTION
This PR is relate issue #2673
- Fixes #2673 


This PR addresses two main issues:

- Managing the recentlyCommand list length:
   - Ensures that the list of recently used commands does not exceed the maximum number configured by the user.

- Adding a delete button:
   - Adds a delete button to the right of each recentlyCommand, allowing users to remove unwanted commands easily.
   
    <img width="601" alt="image" src="https://github.com/user-attachments/assets/1758075e-0fa5-4393-970e-355dafa17a13">
