### PR TITLE
feat(vscode): support client selected context

### DIFF
--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -37,12 +37,13 @@ export interface ServerApi {
   sendMessage: (message: ChatMessage) => void
   showError: (error: ErrorMessage) => void
   cleanError: () => void
+  addClientSelectedContext: (context: Context) => void
 }
 
 export interface ClientApi {
   navigate: (context: Context, opts?: NavigateOpts) => void
   refresh: () => Promise<void>
-  onSubmitMessage?: (msg: string) => Promise<void>
+  onSubmitMessage?: (msg: string, onSubmitMessage?: Context[]) => Promise<void>
   onApplyInEditor?: (content: string) => void
 }
 
@@ -70,6 +71,7 @@ export function createServer(api: ServerApi): ClientApi {
       sendMessage: api.sendMessage,
       showError: api.showError,
       cleanError: api.cleanError,
+      addClientSelectedContext: api.addClientSelectedContext,
     },
   })
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -43,7 +43,7 @@ export interface ServerApi {
 export interface ClientApi {
   navigate: (context: Context, opts?: NavigateOpts) => void
   refresh: () => Promise<void>
-  onSubmitMessage?: (msg: string, onSubmitMessage?: Context[]) => Promise<void>
+  onSubmitMessage?: (msg: string, relevantContext?: Context[]) => Promise<void>
   onApplyInEditor?: (content: string) => void
 }
 

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -49,8 +49,12 @@ export interface ClientApi {
 
 export interface ChatMessage {
   message: string
-  selectContext?: Context // Client side context - displayed in user message
-  relevantContext?: Array<Context> // Client side contexts - displayed in assistant message
+
+  // Client side context - displayed in user message
+  selectContext?: Context
+
+  // Client side contexts - displayed in assistant message
+  relevantContext?: Array<Context>
 }
 
 export function createClient(target: HTMLIFrameElement, api: ClientApi): ServerApi {

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -37,7 +37,7 @@ export interface ServerApi {
   sendMessage: (message: ChatMessage) => void
   showError: (error: ErrorMessage) => void
   cleanError: () => void
-  addClientSelectedContext: (context: Context) => void
+  addRelevantContext: (context: Context) => void
 }
 
 export interface ClientApi {
@@ -75,7 +75,7 @@ export function createServer(api: ServerApi): ClientApi {
       sendMessage: api.sendMessage,
       showError: api.showError,
       cleanError: api.cleanError,
-      addClientSelectedContext: api.addClientSelectedContext,
+      addRelevantContext: api.addRelevantContext,
     },
   })
 }

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -140,16 +140,21 @@ export class ChatViewProvider implements WebviewViewProvider {
         await this.displayChatPage(serverInfo.config.endpoint, { force: true });
         return;
       },
-      onSubmitMessage: async (msg: string) => {
+      onSubmitMessage: async (msg: string, relevantContext?: Context[]) => {
         const editor = window.activeTextEditor;
         const chatMessage: ChatMessage = {
           message: msg,
+          relevantContext: [],
         };
         if (editor) {
           const fileContext = ChatViewProvider.getFileContextFromSelection({ editor, gitProvider: this.gitProvider });
-          if (fileContext) chatMessage.relevantContext = [fileContext];
+          if (fileContext) chatMessage.relevantContext?.push(fileContext);
+        }
+        if (relevantContext) {
+          chatMessage.relevantContext = chatMessage.relevantContext?.concat(relevantContext);
         }
 
+        // FIXME: maybe deduplicate on chatMessage.relevantContext
         this.sendMessage(chatMessage);
       },
       onApplyInEditor: (content: string) => {
@@ -431,6 +436,10 @@ export class ChatViewProvider implements WebviewViewProvider {
     } else {
       this.sendMessageToChatPanel(message);
     }
+  }
+
+  public addClientSelectedContext(context: Context) {
+    this.client?.addClientSelectedContext(context);
   }
 
   private sendMessageToChatPanel(message: ChatMessage) {

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -438,8 +438,8 @@ export class ChatViewProvider implements WebviewViewProvider {
     }
   }
 
-  public addClientSelectedContext(context: Context) {
-    this.client?.addClientSelectedContext(context);
+  public addRelevantContext(context: Context) {
+    this.client?.addRelevantContext(context);
   }
 
   private sendMessageToChatPanel(message: ChatMessage) {

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -256,7 +256,7 @@ export class ChatViewProvider implements WebviewViewProvider {
       ) {
         version = semver.coerce(serverInfo.health["version"]["git_describe"]);
       }
-      if (version && semver.lt(version, "0.12.0")) {
+      if (version && semver.lt(version, "0.16.0")) {
         return false;
       }
     }

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -164,9 +164,9 @@ export default function ChatPage() {
     cleanError: () => {
       setErrorMessage(null)
     },
-    addClientSelectedContext: context => {
+    addRelevantContext: context => {
       if (chatRef.current) {
-        chatRef.current.addClientSelectedContext(context)
+        chatRef.current.addRelevantContext(context)
       }
     }
   })

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -163,6 +163,11 @@ export default function ChatPage() {
     },
     cleanError: () => {
       setErrorMessage(null)
+    },
+    addClientSelectedContext: context => {
+      if (chatRef.current) {
+        chatRef.current.addClientSelectedContext(context)
+      }
     }
   })
 
@@ -191,8 +196,8 @@ export default function ChatPage() {
     setIsRefreshLoading(false)
   }
 
-  const onSubmitMessage = async (msg: string) => {
-    return server?.onSubmitMessage?.(msg)
+  const onSubmitMessage = async (msg: string, relevantContext?: Context[]) => {
+    return server?.onSubmitMessage?.(msg, relevantContext)
   }
 
   const onApplyInEditor = async (content: string) => {

--- a/ee/tabby-ui/components/chat/chat-panel.tsx
+++ b/ee/tabby-ui/components/chat/chat-panel.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
 import type { UseChatHelpers } from 'ai/react'
 
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { IconRefresh, IconStop, IconTrash } from '@/components/ui/icons'
+import {
+  IconRefresh,
+  IconRemove,
+  IconStop,
+  IconTrash
+} from '@/components/ui/icons'
 import { ButtonScrollToBottom } from '@/components/button-scroll-to-bottom'
 import { PromptForm, PromptFormRef } from '@/components/chat/prompt-form'
 import { FooterText } from '@/components/footer'
@@ -29,8 +35,14 @@ export function ChatPanel({
   chatMaxWidthClass
 }: ChatPanelProps) {
   const promptFormRef = React.useRef<PromptFormRef>(null)
-  const { container, onClearMessages, qaPairs, isLoading } =
-    React.useContext(ChatContext)
+  const {
+    container,
+    onClearMessages,
+    qaPairs,
+    isLoading,
+    clientSelectedContext,
+    removeClientSelectedContext
+  } = React.useContext(ChatContext)
   React.useEffect(() => {
     promptFormRef?.current?.focus()
   }, [id])
@@ -72,7 +84,31 @@ export function ChatPanel({
             </Button>
           )}
         </div>
-        <div className="space-y-4 border-t bg-background px-4 py-2 shadow-lg sm:rounded-t-xl sm:border md:py-4">
+        <div className="border-t bg-background px-4 py-2 shadow-lg sm:space-y-4 sm:rounded-t-xl sm:border md:py-4">
+          {clientSelectedContext.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {clientSelectedContext.map((item, idx) => {
+                const [fileName] = item.filepath.split('/').slice(-1)
+                const line =
+                  item.range.start === item.range.end
+                    ? `${item.range.start}`
+                    : `${item.range.start}-${item.range.end}`
+                return (
+                  <Badge
+                    variant="outline"
+                    key={item.filepath + idx}
+                    className="inline-flex items-center gap-0.5 rounded text-sm font-semibold"
+                  >
+                    <span className="text-foreground">{`${fileName}: ${line}`}</span>
+                    <IconRemove
+                      className="cursor-pointer text-muted-foreground transition-all hover:text-red-300"
+                      onClick={removeClientSelectedContext.bind(null, idx)}
+                    />
+                  </Badge>
+                )
+              })}
+            </div>
+          )}
           <PromptForm
             ref={promptFormRef}
             onSubmit={onSubmit}

--- a/ee/tabby-ui/components/chat/chat.tsx
+++ b/ee/tabby-ui/components/chat/chat.tsx
@@ -104,7 +104,7 @@ export interface ChatRef {
   ) => Promise<string | null | undefined>
   stop: () => void
   isLoading: boolean
-  addClientSelectedContext: (context: Context) => void
+  addRelevantContext: (context: Context) => void
 }
 
 interface ChatProps extends React.ComponentProps<'div'> {
@@ -372,7 +372,7 @@ function ChatRenderer(
     setClientSelectedContext(clientSelectedContext.concat([context]))
   })
 
-  const addClientSelectedContext = (context: Context) => {
+  const addRelevantContext = (context: Context) => {
     handleAddClientSelectedContext.current?.(context)
   }
 
@@ -394,7 +394,7 @@ function ChatRenderer(
         sendUserChat,
         stop,
         isLoading,
-        addClientSelectedContext
+        addRelevantContext
       }
     },
     []

--- a/ee/tabby-ui/components/ui/icons.tsx
+++ b/ee/tabby-ui/components/ui/icons.tsx
@@ -18,7 +18,8 @@ import {
   Search,
   Sparkles,
   Star,
-  Tag
+  Tag,
+  X
 } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -1535,6 +1536,10 @@ function IconFilter({
   return <Filter className={cn('h-4 w-4', className)} {...props} />
 }
 
+function IconRemove({ className, ...props }: React.ComponentProps<typeof X>) {
+  return <X className={cn('h-4 w-4', className)} {...props} />
+}
+
 export {
   IconEdit,
   IconNextChat,
@@ -1621,5 +1626,6 @@ export {
   IconFileText,
   IconApplyInEditor,
   IconBug,
-  IconFilter
+  IconFilter,
+  IconRemove
 }


### PR DESCRIPTION
## Context
We want to enable users to manually select context. For example, users can select a piece of code and add it to the context so that it will be included with their message next time.

User selected context as shown in the following screenshots:
<img width="400" alt="1" src="https://github.com/user-attachments/assets/00ef53b7-5b06-4496-9034-24ffa413fb52">

## Screen record
For testing purposes, adding client context is triggered via the command palette.
https://jam.dev/c/8477d02f-9e37-4ac7-8bad-ae87d1b11778

## Overview of adding client context
1. **Editor adds new context:** By using the new method exposed on the tabby-chat-panel, `this.client?.addClientSelectedContext(Context)`
2. **Receiving context:** tabby-ui receives the context and saves it into its new state `clientSelectedContext`
3. **Displaying context:** tabby-ui displays the clientSelectedContext (as shown in the above screenshot)
4. **Removing context:** tabby-ui can remove the context using its own method `removeClientSelectedContext`
5. **Submitting the message:** When a message is submitted, tabby-ui will send the context to the Editor using `onSubmitMessage(value, clientSelectedContext)`. The Editor will then add these clientSelectedContext entries into `relevantContext` before sending them to the server.

## Note
Currently, there is no way to `addClientSelectedContext` from the user interface, so from the user's perspective, there will be no difference after merging this PR.

\cc @liangfung 