### PR TITLE
feat: Add general IDE info to User-Agent for Tabby clients

### DIFF
--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -530,6 +530,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
   public async provideCompletions(
     request: CompletionRequest,
     options?: AbortSignalOption,
+    ideInfo?: string,
   ): Promise<CompletionResponse> {
     if (this.status === "notInitialized") {
       throw new Error("Agent is not initialized");
@@ -601,6 +602,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
             context.buildSegments(this.config.completion.prompt),
             undefined,
             signal,
+            ideInfo,
           );
           const completionItem = CompletionItem.createFromResponse(context, response);
           // postprocess: preCache
@@ -631,6 +633,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
               context.buildSegments(this.config.completion.prompt),
               this.config.completion.solution.temperature,
               signal,
+              ideInfo,
             );
             const completionItem = CompletionItem.createFromResponse(context, response);
             // postprocess: preCache
@@ -678,6 +681,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
     segments: TabbyApiComponents["schemas"]["Segments"],
     temperature: number | undefined,
     signal?: AbortSignal,
+    ideInfo?: string,
   ): Promise<TabbyApiComponents["schemas"]["CompletionResponse"]> {
     const requestId = uuid();
     const stats = {
@@ -699,6 +703,9 @@ export class TabbyAgent extends EventEmitter implements Agent {
           temperature,
         },
         signal: this.createAbortSignal({ signal }),
+        headers: {
+          "User-Agent": ideInfo ?? "TabbyAgent: unknown ide",
+        },
       };
       const requestDescription = `POST ${this.config.server.endpoint + requestPath}`;
       this.logger.debug(`Completion request: ${requestDescription}. [${requestId}]`);

--- a/clients/tabby-agent/src/lsp/Server.ts
+++ b/clients/tabby-agent/src/lsp/Server.ts
@@ -18,10 +18,8 @@ import {
   NotebookDocument,
   NotebookDocuments,
   NotebookCell,
-  CompletionParams,
   CompletionTriggerKind,
   CompletionItemKind,
-  InlineCompletionParams,
   InlineCompletionTriggerKind,
 } from "vscode-languageserver";
 import {
@@ -72,6 +70,8 @@ import {
   ReadFileParams,
   LanguageSupportDeclarationRequest,
   LanguageSupportSemanticTokensRangeRequest,
+  CompletionParams,
+  InlineCompletionParams,
 } from "./protocol";
 import { TextDocuments } from "./TextDocuments";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -423,7 +423,11 @@ export class Server {
       if (!result) {
         return null;
       }
-      const response = await this.agent.provideCompletions(result.request, { signal: abortController.signal });
+      const response = await this.agent.provideCompletions(
+        result.request,
+        { signal: abortController.signal },
+        params.ideInfo,
+      );
       return this.toCompletionList(response, params, result.additionalPrefixLength);
     } catch (error) {
       return null;
@@ -444,7 +448,11 @@ export class Server {
       if (!result) {
         return null;
       }
-      const response = await this.agent.provideCompletions(result.request, { signal: abortController.signal });
+      const response = await this.agent.provideCompletions(
+        result.request,
+        { signal: abortController.signal },
+        params.ideInfo,
+      );
       return this.toInlineCompletionList(response, params, result.additionalPrefixLength);
     } catch (error) {
       return null;

--- a/clients/tabby-agent/src/lsp/protocol.ts
+++ b/clients/tabby-agent/src/lsp/protocol.ts
@@ -23,11 +23,9 @@ import {
   CodeLensParams,
   CodeLens as LspCodeLens,
   CompletionRequest as LspCompletionRequest,
-  CompletionParams,
   CompletionList as LspCompletionList,
   CompletionItem as LspCompletionItem,
   InlineCompletionRequest as LspInlineCompletionRequest,
-  InlineCompletionParams,
   InlineCompletionList as LspInlineCompletionList,
   InlineCompletionItem as LspInlineCompletionItem,
   DeclarationParams,
@@ -36,6 +34,11 @@ import {
   SemanticTokensRangeParams,
   SemanticTokens,
   SemanticTokensLegend,
+  CompletionContext,
+  TextDocumentPositionParams,
+  WorkDoneProgressParams,
+  PartialResultParams,
+  InlineCompletionContext,
 } from "vscode-languageserver-protocol";
 
 /**
@@ -490,6 +493,32 @@ export type EventParams = {
   viewId?: string;
   elapsed?: number;
 };
+
+export interface CompletionParams extends TextDocumentPositionParams, WorkDoneProgressParams, PartialResultParams {
+  /**
+   * The completion context. This is only available it the client specifies
+   * to send this using the client capability `textDocument.completion.contextSupport === true`
+   */
+  context?: CompletionContext;
+
+  /**
+   * This is the inline completion ideInfo param. Passing all ide info through LSP.
+   */
+  ideInfo?: string;
+}
+export type InlineCompletionParams = WorkDoneProgressParams &
+  TextDocumentPositionParams & {
+    /**
+     * Additional information about the context in which inline completions were
+     * requested.
+     */
+    context: InlineCompletionContext;
+
+    /**
+     * This is the inline completion ideInfo param. Passing all ide info through LSP.
+     */
+    ideInfo?: string;
+  };
 
 /**
  * [Tabby] DidUpdateServerInfo Notification(⬅️)

--- a/clients/vscode/src/InlineCompletionProvider.ts
+++ b/clients/vscode/src/InlineCompletionProvider.ts
@@ -10,12 +10,12 @@ import {
   Range,
   window,
 } from "vscode";
-import { InlineCompletionParams } from "vscode-languageclient";
-import { InlineCompletionRequest, InlineCompletionList, EventParams } from "tabby-agent";
+import { InlineCompletionRequest, InlineCompletionList, EventParams, InlineCompletionParams } from "tabby-agent";
 import { EventEmitter } from "events";
 import { getLogger } from "./logger";
 import { Client } from "./lsp/Client";
 import { Config } from "./Config";
+import { getCurrentIdeInfo } from "./utils";
 
 interface DisplayedCompletion {
   id: string;
@@ -93,7 +93,10 @@ export class InlineCompletionProvider extends EventEmitter implements InlineComp
         line: position.line,
         character: position.character,
       },
+      ideInfo: getCurrentIdeInfo(),
     };
+    //TODO:test
+    window.showInformationMessage(params.ideInfo ? "IDE: " + params.ideInfo : "IDE: unknown");
     let request: Promise<InlineCompletionList | null> | undefined = undefined;
     try {
       request = this.client.languageClient.sendRequest(InlineCompletionRequest.method, params, token);

--- a/clients/vscode/src/utils.ts
+++ b/clients/vscode/src/utils.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+import * as os from "os";
+
+interface IdeInfo {
+  name: string;
+  version: string;
+  extensionName: string;
+  extensionPublisher: string;
+  extensionVersion: string;
+  osType: string;
+  osRelease: string;
+  platform: string;
+  arch: string;
+}
+
+export function getCurrentIdeInfo(): string {
+  const extension = vscode.extensions.getExtension("TabbyML.vscode-tabby");
+
+  const ideInfo: IdeInfo = {
+    name: "Visual Studio Code",
+    version: vscode.version,
+    extensionName: "Tabby",
+    extensionPublisher: "TabbyML",
+    extensionVersion: extension ? extension.packageJSON.version : "1.8.0-dev", // 使用默认版本，如果无法获取
+    osType: os.type(),
+    osRelease: os.release(),
+    platform: process.platform,
+    arch: process.arch,
+  };
+
+  return JSON.stringify(ideInfo);
+}

--- a/crates/tabby-common/src/api/event.rs
+++ b/crates/tabby-common/src/api/event.rs
@@ -67,6 +67,7 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         segments: Option<Segments>,
         choices: Vec<Choice>,
+        user_agent: String
     },
     ChatCompletion {
         completion_id: String,

--- a/crates/tabby-common/src/api/event.rs
+++ b/crates/tabby-common/src/api/event.rs
@@ -67,7 +67,7 @@ pub enum Event {
         #[serde(skip_serializing_if = "Option::is_none")]
         segments: Option<Segments>,
         choices: Vec<Choice>,
-        user_agent: String
+        user_agent: String,
     },
     ChatCompletion {
         completion_id: String,

--- a/crates/tabby/src/routes/completions.rs
+++ b/crates/tabby/src/routes/completions.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use axum::{extract::State, Json};
-use axum_extra::{TypedHeader, headers};
+use axum_extra::{headers, TypedHeader};
 use hyper::StatusCode;
 use tabby_common::axum::MaybeUser;
 use tracing::{instrument, warn};
@@ -33,7 +33,7 @@ pub async fn completions(
         request.user.replace(user);
     }
     request.user_agent = Some(user_agent.to_string());
-    
+
     match state.generate(&request).await {
         Ok(resp) => Ok(Json(resp)),
         Err(err) => {

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -334,7 +334,10 @@ impl CompletionService {
                     index: 0,
                     text: text.clone(),
                 }],
-                user_agent: request.user_agent.clone().unwrap_or_else(|| "Unknown".to_string()),
+                user_agent: request
+                    .user_agent
+                    .clone()
+                    .unwrap_or_else(|| "Unknown".to_string()),
             },
         );
 
@@ -448,7 +451,7 @@ mod tests {
             debug_options: None,
             temperature: None,
             seed: None,
-            user_agent: None
+            user_agent: None,
         };
 
         let response = completion_service.generate(&request).await.unwrap();

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -52,6 +52,9 @@ pub struct CompletionRequest {
 
     /// The seed used for randomly selecting tokens
     seed: Option<u64>,
+
+    // This is user agent using for store ide version info
+    pub user_agent: Option<String>,
 }
 
 impl CompletionRequest {
@@ -331,6 +334,7 @@ impl CompletionService {
                     index: 0,
                     text: text.clone(),
                 }],
+                user_agent: request.user_agent.clone().unwrap_or_else(|| "Unknown".to_string()),
             },
         );
 
@@ -444,6 +448,7 @@ mod tests {
             debug_options: None,
             temperature: None,
             seed: None,
+            user_agent: None
         };
 
         let response = completion_service.generate(&request).await.unwrap();

--- a/ee/tabby-webserver/src/service/event_logger.rs
+++ b/ee/tabby-webserver/src/service/event_logger.rs
@@ -165,7 +165,7 @@ mod tests {
                 prompt: "testprompt".into(),
                 segments: None,
                 choices: vec![],
-                user_agent: "ide: version test".into()
+                user_agent: "ide: version test".into(),
             },
         );
 
@@ -242,7 +242,7 @@ mod tests {
                 prompt: "testprompt".into(),
                 segments: None,
                 choices: vec![],
-                user_agent: "ide: version unknown".into()
+                user_agent: "ide: version unknown".into(),
             },
         );
 
@@ -257,7 +257,7 @@ mod tests {
                 prompt: "testprompt".into(),
                 segments: None,
                 choices: vec![],
-                user_agent: "ide: version unknown".into()
+                user_agent: "ide: version unknown".into(),
             },
         );
 

--- a/ee/tabby-webserver/src/service/event_logger.rs
+++ b/ee/tabby-webserver/src/service/event_logger.rs
@@ -165,6 +165,7 @@ mod tests {
                 prompt: "testprompt".into(),
                 segments: None,
                 choices: vec![],
+                user_agent: "ide: version test".into()
             },
         );
 
@@ -241,6 +242,7 @@ mod tests {
                 prompt: "testprompt".into(),
                 segments: None,
                 choices: vec![],
+                user_agent: "ide: version unknown".into()
             },
         );
 
@@ -255,6 +257,7 @@ mod tests {
                 prompt: "testprompt".into(),
                 segments: None,
                 choices: vec![],
+                user_agent: "ide: version unknown".into()
             },
         );
 


### PR DESCRIPTION
 This addresses the remaining part of the issue mentioned in #2581.

- Implement a general mechanism to collect IDE and extension information
- Format the collected information as a JSON string
- Set the formatted string as the User-Agent header in API requests

Currently supported IDEs:
- Visual Studio Code
- IntelliJ IDEA


Example User-Agent format:

```json
{
    "name": "Visual Studio Code",
    "version": "1.91.1",
    "extensionName": "Tabby",
    "extensionPublisher": "TabbyML",
    "extensionVersion": "1.8.0-dev",
    "osType": "Darwin",
    "osRelease": "23.5.0",
    "platform": "darwin",
    "arch": "arm64"
}
```

