### PR TITLE
feat: Add general IDE info to User-Agent for Tabby clients

### DIFF
--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -71,7 +71,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
   private tryingConnectTimer: ReturnType<typeof setInterval>;
   static readonly submitStatsInterval = 1000 * 60 * 60 * 24; // 24h
   private submitStatsTimer: ReturnType<typeof setInterval>;
-  private clientInfoStr: string = "";
+  private userAgentHeader: string = "";
 
   constructor() {
     super();
@@ -164,7 +164,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
       baseUrl: endpoint,
       headers: {
         Authorization: auth,
-        "User-Agent": this.clientInfoStr,
+        "User-Agent": this.userAgentHeader,
         ...this.config.server.requestHeaders,
       },
       /** dispatcher do not exist in {@link RequestInit} in browser env. */
@@ -396,7 +396,7 @@ export class TabbyAgent extends EventEmitter implements Agent {
       }
     }
     await this.anonymousUsageLogger.init({ dataStore: this.dataStore });
-    this.clientInfoStr = this.clientInfoToString(options.clientProperties?.session);
+    this.userAgentHeader = this.clientInfoToString(options.clientProperties?.session);
     if (options.clientProperties) {
       if (options.clientProperties.session) {
         Object.entries(options.clientProperties.session).forEach(([key, value]) => {

--- a/clients/tabby-agent/src/TabbyAgent.ts
+++ b/clients/tabby-agent/src/TabbyAgent.ts
@@ -46,6 +46,7 @@ import { getLogger, logDestinations, fileLogger } from "./logger";
 import { AnonymousUsageLogger } from "./AnonymousUsageLogger";
 import { loadTlsCaCerts } from "./loadCaCerts";
 import { createProxyForUrl, ProxyConfig } from "./http/proxy";
+import { name as agentName, version as agentVersion } from "../package.json";
 
 export class TabbyAgent extends EventEmitter implements Agent {
   private readonly logger = getLogger("TabbyAgent");
@@ -1023,9 +1024,10 @@ export class TabbyAgent extends EventEmitter implements Agent {
     if (!session) return nodeInfo;
 
     const ide = session["ide"] ? `${session["ide"].name.replace(/ /g, "-")}/${session["ide"].version}` : "";
+    const tabby = `${agentName}/${agentVersion}`;
     const tabbyPlugin = session["tabby_plugin"]
       ? `${session["tabby_plugin"].name}/${session["tabby_plugin"].version}`
       : "";
-    return `${nodeInfo} ${ide} ${tabbyPlugin}`.trim();
+    return `${nodeInfo} ${tabby} ${ide} ${tabbyPlugin}`.trim();
   }
 }


### PR DESCRIPTION
This addresses the remaining part of the issue mentioned in #2581.

- Retrieve client info based on the client configuration during client initialization.

Example User-Agent format:

```
Node.js/v20.9.0 Visual-Studio-Code-desktop/1.91.1 TabbyML.vscode-tabby/1.8.0-dev
```
