### PR TITLE
chore: add http prefix for tabby server let address clickable

### DIFF
--- a/crates/tabby/src/routes/mod.rs
+++ b/crates/tabby/src/routes/mod.rs
@@ -39,7 +39,7 @@ pub async fn run_app(api: Router, ui: Option<Router>, host: IpAddr, port: u16) {
    ╚═╝   ╚═╝  ╚═╝╚═════╝ ╚═════╝    ╚═╝   
 
 📄 Version {version}
-🚀 Listening at {address}
+🚀 Listening at http://{address}
 "#
     );
     let listener = tokio::net::TcpListener::bind(address).await.unwrap();


### PR DESCRIPTION
when the url have the `http://` prefix, we can click it in the terminal while holding command