### PR TITLE
fix(vscode): set excludeFiles to undefined so by default ignored file…

### DIFF
--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -99,7 +99,7 @@ export class ChatViewProvider implements WebviewViewProvider {
     this.client = createClient(webviewView, {
       navigate: async (context: Context, opts?: NavigateOpts) => {
         if (opts?.openInEditor) {
-          const files = await workspace.findFiles(context.filepath, null, 1);
+          const files = await workspace.findFiles(context.filepath, undefined, 1);
           if (files[0]) {
             const document = await workspace.openTextDocument(files[0].path);
             const newEditor = await window.showTextDocument(document, {


### PR DESCRIPTION
…s are applied

This shall reduce the slowness when clicking local file context in sidebar.


```typescript
/**
 * Find files across all {@link workspace.workspaceFolders workspace folders} in the workspace.
 *
 * @example
 * findFiles('**​/*.js', '**​/node_modules/**', 10)
 *
 * @param include A {@link GlobPattern glob pattern} that defines the files to search for. The glob pattern
 * will be matched against the file paths of resulting matches relative to their workspace. Use a {@link RelativePattern relative pattern}
 * to restrict the search results to a {@link WorkspaceFolder workspace folder}.
 * @param exclude  A {@link GlobPattern glob pattern} that defines files and folders to exclude. The glob pattern
 * will be matched against the file paths of resulting matches relative to their workspace. When `undefined`, default file-excludes (e.g. the `files.exclude`-setting
 * but not `search.exclude`) will apply. When `null`, no excludes will apply.
 * @param maxResults An upper-bound for the result.
 * @param token A token that can be used to signal cancellation to the underlying search engine.
 * @returns A thenable that resolves to an array of resource identifiers. Will return no results if no
 * {@link workspace.workspaceFolders workspace folders} are opened.
 */
export function findFiles(include: GlobPattern, exclude?: GlobPattern | null, maxResults?: number, token?: CancellationToken): Thenable<Uri[]>;
```

cc @liangfung 