### PR TITLE
fix(llama-cpp-server): fix rocm build by setting `GGML_HIPBLAS`

### DIFF
--- a/crates/llama-cpp-server/build.rs
+++ b/crates/llama-cpp-server/build.rs
@@ -48,7 +48,7 @@ fn main() {
         ];
 
         let rocm_root = env::var("ROCM_ROOT").unwrap_or("/opt/rocm".to_string());
-        config.define("LLAMA_HIPBLAS", "ON");
+        config.define("GGML_HIPBLAS", "ON");
         config.define("CMAKE_C_COMPILER", format!("{}/llvm/bin/clang", rocm_root));
         config.define(
             "CMAKE_CXX_COMPILER",


### PR DESCRIPTION
Various `LLAMA_` build flags have been renamed to `GGML_` in llama-cpp-server (See https://github.com/ggerganov/llama.cpp/commit/f3f65429c44bb195a9195bfdc19a30a79709db7b) and need to be renamed in tabby to allow correctly targeting Metal/Rocm/Vulkan.

It appears that this was already done for Cuda.

May be related: https://github.com/TabbyML/tabby/issues/2811