### PR TITLE
refactor(core): extract CodeSearchParams, make it configurable for completion / answer engine

### DIFF
--- a/crates/tabby-common/src/api/code.rs
+++ b/crates/tabby-common/src/api/code.rs
@@ -64,7 +64,7 @@ pub struct CodeSearchQuery {
     pub content: String,
 }
 
-#[derive(Deserialize, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CodeSearchParams {
     pub min_embedding_score: f32,
     pub min_bm25_score: f32,
@@ -84,8 +84,8 @@ impl Default for CodeSearchParams {
             min_bm25_score: 8.0,
             min_rrf_score: 0.028,
 
-            num_to_return: 5,
-            num_to_score: 10,
+            num_to_return: 20,
+            num_to_score: 40,
         }
     }
 }

--- a/crates/tabby-common/src/api/code.rs
+++ b/crates/tabby-common/src/api/code.rs
@@ -66,9 +66,9 @@ pub struct CodeSearchQuery {
 
 #[derive(Deserialize, ToSchema)]
 pub struct CodeSearchParams {
-    pub embedding_score_threshold: f32,
-    pub bm25_score_threshold: f32,
-    pub rrf_score_threshold: f32,
+    pub min_embedding_score: f32,
+    pub min_bm25_score: f32,
+    pub min_rrf_score: f32,
 
     /// At most num_to_return results will be returned.
     pub num_to_return: usize,
@@ -80,9 +80,9 @@ pub struct CodeSearchParams {
 impl Default for CodeSearchParams {
     fn default() -> Self {
         Self {
-            embedding_score_threshold: 0.75,
-            bm25_score_threshold: 8.0,
-            rrf_score_threshold: 0.028,
+            min_embedding_score: 0.75,
+            min_bm25_score: 8.0,
+            min_rrf_score: 0.028,
 
             num_to_return: 5,
             num_to_score: 10,

--- a/crates/tabby-common/src/api/code.rs
+++ b/crates/tabby-common/src/api/code.rs
@@ -64,11 +64,37 @@ pub struct CodeSearchQuery {
     pub content: String,
 }
 
+#[derive(Deserialize, ToSchema)]
+pub struct CodeSearchParams {
+    pub embedding_score_threshold: f32,
+    pub bm25_score_threshold: f32,
+    pub rrf_score_threshold: f32,
+
+    /// At most num_to_return results will be returned.
+    pub num_to_return: usize,
+
+    /// At most num_to_score results will be scored.
+    pub num_to_score: usize,
+}
+
+impl Default for CodeSearchParams {
+    fn default() -> Self {
+        Self {
+            embedding_score_threshold: 0.75,
+            bm25_score_threshold: 8.0,
+            rrf_score_threshold: 0.028,
+
+            num_to_return: 5,
+            num_to_score: 10,
+        }
+    }
+}
+
 #[async_trait]
 pub trait CodeSearch: Send + Sync {
     async fn search_in_language(
         &self,
         query: CodeSearchQuery,
-        limit: usize,
+        params: CodeSearchParams,
     ) -> Result<CodeSearchResponse, CodeSearchError>;
 }

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -314,7 +314,7 @@ impl Default for CompletionConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct AnswerConfig {
     #[serde(default)]
-    code_search_params: CodeSearchParams
+    pub code_search_params: CodeSearchParams
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -9,8 +9,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::{
-    path::repositories_dir,
-    terminal::{HeaderFormat, InfoMessage},
+    api::code::CodeSearchParams, path::repositories_dir, terminal::{HeaderFormat, InfoMessage}
 };
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
@@ -26,6 +25,9 @@ pub struct Config {
 
     #[serde(default)]
     pub completion: CompletionConfig,
+
+    #[serde(default)]
+    pub answer: AnswerConfig,
 }
 
 impl Config {
@@ -286,6 +288,9 @@ pub struct CompletionConfig {
 
     #[serde(default = "default_max_decoding_tokens")]
     pub max_decoding_tokens: usize,
+
+    #[serde(default)]
+    pub code_search_params: CodeSearchParams,
 }
 
 fn default_max_input_length() -> usize {
@@ -301,8 +306,15 @@ impl Default for CompletionConfig {
         Self {
             max_input_length: default_max_input_length(),
             max_decoding_tokens: default_max_decoding_tokens(),
+            code_search_params: CodeSearchParams::default(),
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct AnswerConfig {
+    #[serde(default)]
+    code_search_params: CodeSearchParams
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::{
-    api::code::CodeSearchParams, path::repositories_dir, terminal::{HeaderFormat, InfoMessage}
+    api::code::CodeSearchParams,
+    path::repositories_dir,
+    terminal::{HeaderFormat, InfoMessage},
 };
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
@@ -314,7 +316,7 @@ impl Default for CompletionConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct AnswerConfig {
     #[serde(default)]
-    pub code_search_params: CodeSearchParams
+    pub code_search_params: CodeSearchParams,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -198,7 +198,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
     #[cfg(feature = "ee")]
     if let Some(ws) = &ws {
         let (new_api, new_ui) = ws
-            .attach(api, ui, code, chat, docsearch, |x| {
+            .attach(&config, api, ui, code, chat, docsearch, |x| {
                 Box::new(services::doc::create_serper(x))
             })
             .await;

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -6,7 +6,8 @@ use cached::{CachedAsync, TimedCache};
 use parse_git_url::GitUrl;
 use tabby_common::{
     api::code::{
-        CodeSearch, CodeSearchDocument, CodeSearchError, CodeSearchHit, CodeSearchParams, CodeSearchQuery, CodeSearchResponse, CodeSearchScores
+        CodeSearch, CodeSearchDocument, CodeSearchError, CodeSearchHit, CodeSearchParams,
+        CodeSearchQuery, CodeSearchResponse, CodeSearchScores,
     },
     config::{ConfigAccess, RepositoryConfig},
     index::{
@@ -93,7 +94,8 @@ impl CodeSearchImpl {
             ));
 
             let query = code::code_search_query(&query, embedding_tokens_query);
-            self.search_with_query(reader, &query, params.num_to_score).await?
+            self.search_with_query(reader, &query, params.num_to_score)
+                .await?
         };
 
         let docs_from_bm25 = {
@@ -101,7 +103,8 @@ impl CodeSearchImpl {
             let body_query = code::body_query(&body_tokens);
 
             let query = code::code_search_query(&query, body_query);
-            self.search_with_query(reader, &query, params.num_to_score).await?
+            self.search_with_query(reader, &query, params.num_to_score)
+                .await?
         };
 
         Ok(merge_code_responses_by_rank(

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -155,9 +155,9 @@ fn merge_code_responses_by_rank(
         hits: scored_hits
             .into_iter()
             .filter(|hit| {
-                hit.scores.bm25 > params.bm25_score_threshold
-                    && hit.scores.embedding > params.embedding_score_threshold
-                    && hit.scores.rrf > params.rrf_score_threshold
+                hit.scores.bm25 > params.min_bm25_score
+                    && hit.scores.embedding > params.min_embedding_score
+                    && hit.scores.rrf > params.min_rrf_score
             })
             .take(params.num_to_return)
             .collect(),

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -6,8 +6,7 @@ use cached::{CachedAsync, TimedCache};
 use parse_git_url::GitUrl;
 use tabby_common::{
     api::code::{
-        CodeSearch, CodeSearchDocument, CodeSearchError, CodeSearchHit, CodeSearchQuery,
-        CodeSearchResponse, CodeSearchScores,
+        CodeSearch, CodeSearchDocument, CodeSearchError, CodeSearchHit, CodeSearchParams, CodeSearchQuery, CodeSearchResponse, CodeSearchScores
     },
     config::{ConfigAccess, RepositoryConfig},
     index::{
@@ -64,7 +63,7 @@ impl CodeSearchImpl {
         &self,
         reader: &IndexReader,
         mut query: CodeSearchQuery,
-        limit: usize,
+        params: CodeSearchParams,
     ) -> Result<CodeSearchResponse, CodeSearchError> {
         let mut cache = self.repo_cache.lock().await;
 
@@ -94,7 +93,7 @@ impl CodeSearchImpl {
             ));
 
             let query = code::code_search_query(&query, embedding_tokens_query);
-            self.search_with_query(reader, &query, limit * 2).await?
+            self.search_with_query(reader, &query, params.num_to_score).await?
         };
 
         let docs_from_bm25 = {
@@ -102,26 +101,23 @@ impl CodeSearchImpl {
             let body_query = code::body_query(&body_tokens);
 
             let query = code::code_search_query(&query, body_query);
-            self.search_with_query(reader, &query, limit * 2).await?
+            self.search_with_query(reader, &query, params.num_to_score).await?
         };
 
         Ok(merge_code_responses_by_rank(
+            &params,
             docs_from_embedding,
             docs_from_bm25,
-            limit,
         ))
     }
 }
 
 const RANK_CONSTANT: f32 = 60.0;
-const EMBEDDING_SCORE_THRESHOLD: f32 = 0.75;
-const BM25_SCORE_THRESHOLD: f32 = 8.0;
-const RRF_SCORE_THRESHOLD: f32 = 0.028;
 
 fn merge_code_responses_by_rank(
+    params: &CodeSearchParams,
     embedding_resp: Vec<(f32, TantivyDocument)>,
     bm25_resp: Vec<(f32, TantivyDocument)>,
-    limit: usize,
 ) -> CodeSearchResponse {
     let mut scored_hits: HashMap<String, (CodeSearchScores, TantivyDocument)> = HashMap::default();
 
@@ -137,10 +133,16 @@ fn merge_code_responses_by_rank(
 
     for (rank, bm25, doc) in compute_rank_score(bm25_resp).into_iter() {
         let chunk_id = get_chunk_id(&doc);
-        // Only keep items with embedding score > 0.
         if let Some((score, _)) = scored_hits.get_mut(chunk_id) {
             score.rrf += rank;
             score.bm25 = bm25;
+        } else {
+            let scores = CodeSearchScores {
+                rrf: rank,
+                bm25,
+                ..Default::default()
+            };
+            scored_hits.insert(chunk_id.to_owned(), (scores, doc));
         }
     }
 
@@ -153,11 +155,11 @@ fn merge_code_responses_by_rank(
         hits: scored_hits
             .into_iter()
             .filter(|hit| {
-                hit.scores.bm25 > BM25_SCORE_THRESHOLD
-                    && hit.scores.embedding > EMBEDDING_SCORE_THRESHOLD
-                    && hit.scores.rrf > RRF_SCORE_THRESHOLD
+                hit.scores.bm25 > params.bm25_score_threshold
+                    && hit.scores.embedding > params.embedding_score_threshold
+                    && hit.scores.rrf > params.rrf_score_threshold
             })
-            .take(limit)
+            .take(params.num_to_return)
             .collect(),
     }
 }
@@ -285,10 +287,10 @@ impl CodeSearch for CodeSearchService {
     async fn search_in_language(
         &self,
         query: CodeSearchQuery,
-        limit: usize,
+        params: CodeSearchParams,
     ) -> Result<CodeSearchResponse, CodeSearchError> {
         if let Some(reader) = self.provider.reader().await.as_ref() {
-            self.imp.search_in_language(reader, query, limit).await
+            self.imp.search_in_language(reader, query, params).await
         } else {
             Err(CodeSearchError::NotReady)
         }

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -244,9 +244,13 @@ impl CompletionService {
         prompt_template: Option<String>,
     ) -> Self {
         Self {
-            config,
             engine,
-            prompt_builder: completion_prompt::PromptBuilder::new(prompt_template, Some(code)),
+            prompt_builder: completion_prompt::PromptBuilder::new(
+                &config.code_search_params,
+                prompt_template,
+                Some(code),
+            ),
+            config,
             logger,
         }
     }

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -418,7 +418,7 @@ mod tests {
         async fn search_in_language(
             &self,
             _query: CodeSearchQuery,
-            _limit: usize,
+            _params: CodeSearchParams,
         ) -> Result<CodeSearchResponse, CodeSearchError> {
             Ok(CodeSearchResponse { hits: vec![] })
         }

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -384,6 +384,7 @@ pub async fn create_completion_service_and_chat(
 
 #[cfg(test)]
 mod tests {
+    use api::code::CodeSearchParams;
     use async_stream::stream;
     use async_trait::async_trait;
     use futures::stream::BoxStream;

--- a/crates/tabby/src/services/completion/completion_prompt.rs
+++ b/crates/tabby/src/services/completion/completion_prompt.rs
@@ -274,7 +274,7 @@ mod tests {
         async fn search_in_language(
             &self,
             _query: CodeSearchQuery,
-            _limit: usize,
+            _params: CodeSearchParams,
         ) -> Result<CodeSearchResponse, CodeSearchError> {
             (self.0)()
         }

--- a/crates/tabby/src/services/completion/completion_prompt.rs
+++ b/crates/tabby/src/services/completion/completion_prompt.rs
@@ -252,7 +252,7 @@ mod tests {
         };
 
         // Init prompt builder with prompt rewrite disabled.
-        PromptBuilder::new(prompt_template, None)
+        PromptBuilder::new(&CodeSearchParams::default(), prompt_template, None)
     }
 
     fn make_segment(prefix: String, suffix: Option<String>) -> Segments {
@@ -284,7 +284,7 @@ mod tests {
     async fn test_collect_snippets() {
         // Not ready error from CodeSearch should result in empty snippets, rather than error
         let search = MockCodeSearch(|| Err(CodeSearchError::NotReady));
-        let snippets = collect_snippets(150, &search, "", None, "", "").await;
+        let snippets = collect_snippets(&CodeSearchParams::default(), 150, &search, "", None, "", "").await;
         assert_eq!(snippets, vec![]);
 
         let search = MockCodeSearch(|| {
@@ -292,7 +292,7 @@ mod tests {
                 hits: vec![Default::default()],
             })
         });
-        let snippets = collect_snippets(150, &search, "", None, "", "").await;
+        let snippets = collect_snippets(&CodeSearchParams::default(), 150, &search, "", None, "", "").await;
         assert_eq!(
             snippets,
             vec![Snippet {

--- a/crates/tabby/src/services/completion/completion_prompt.rs
+++ b/crates/tabby/src/services/completion/completion_prompt.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use strfmt::strfmt;
 use tabby_common::{
-    api::code::{CodeSearch, CodeSearchError, CodeSearchQuery},
+    api::code::{CodeSearch, CodeSearchError, CodeSearchParams, CodeSearchQuery},
     languages::get_language,
 };
 use tracing::warn;
@@ -188,9 +188,15 @@ async fn collect_snippets(
         content: content.to_owned(),
     };
 
+    let params = CodeSearchParams {
+        num_to_return: MAX_SNIPPETS_TO_FETCH,
+        num_to_score: MAX_SNIPPETS_TO_FETCH * 2,
+        ..Default::default()
+    };
+
     let mut ret = Vec::new();
 
-    let serp = match code.search_in_language(query, MAX_SNIPPETS_TO_FETCH).await {
+    let serp = match code.search_in_language(query, params).await {
         Ok(serp) => serp,
         Err(CodeSearchError::NotReady) => {
             // Ignore.

--- a/crates/tabby/src/services/completion/completion_prompt.rs
+++ b/crates/tabby/src/services/completion/completion_prompt.rs
@@ -196,7 +196,10 @@ async fn collect_snippets(
 
     let mut ret = Vec::new();
 
-    let serp = match code.search_in_language(query, code_search_params.clone()).await {
+    let serp = match code
+        .search_in_language(query, code_search_params.clone())
+        .await
+    {
         Ok(serp) => serp,
         Err(CodeSearchError::NotReady) => {
             // Ignore.
@@ -284,7 +287,8 @@ mod tests {
     async fn test_collect_snippets() {
         // Not ready error from CodeSearch should result in empty snippets, rather than error
         let search = MockCodeSearch(|| Err(CodeSearchError::NotReady));
-        let snippets = collect_snippets(&CodeSearchParams::default(), 150, &search, "", None, "", "").await;
+        let snippets =
+            collect_snippets(&CodeSearchParams::default(), 150, &search, "", None, "", "").await;
         assert_eq!(snippets, vec![]);
 
         let search = MockCodeSearch(|| {
@@ -292,7 +296,8 @@ mod tests {
                 hits: vec![Default::default()],
             })
         });
-        let snippets = collect_snippets(&CodeSearchParams::default(), 150, &search, "", None, "", "").await;
+        let snippets =
+            collect_snippets(&CodeSearchParams::default(), 150, &search, "", None, "", "").await;
         assert_eq!(
             snippets,
             vec![Snippet {

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -12,7 +12,7 @@ use async_stream::stream;
 use futures::stream::BoxStream;
 use tabby_common::api::{
     answer::{AnswerRequest, AnswerResponseChunk},
-    code::{CodeSearch, CodeSearchError, CodeSearchHit, CodeSearchQuery},
+    code::{CodeSearch, CodeSearchError, CodeSearchHit, CodeSearchQuery, CodeSearchParams},
     doc::{DocSearch, DocSearchError, DocSearchHit},
 };
 use tabby_inference::ChatCompletionStream;
@@ -291,7 +291,14 @@ impl AnswerService {
             language: query.language.clone(),
             content: query.content.clone(),
         };
-        match self.code.search_in_language(query, 20).await {
+
+        let params = CodeSearchParams {
+            num_to_return: 20,
+            num_to_score: 40,
+            ..Default::default()
+        };
+
+        match self.code.search_in_language(query, params).await {
             Ok(docs) => docs.hits,
             Err(err) => {
                 if let CodeSearchError::NotReady = err {

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -10,11 +10,14 @@ use async_openai::{
 };
 use async_stream::stream;
 use futures::stream::BoxStream;
-use tabby_common::{api::{
-    answer::{AnswerRequest, AnswerResponseChunk},
-    code::{CodeSearch, CodeSearchError, CodeSearchHit, CodeSearchParams, CodeSearchQuery},
-    doc::{DocSearch, DocSearchError, DocSearchHit},
-}, config::AnswerConfig};
+use tabby_common::{
+    api::{
+        answer::{AnswerRequest, AnswerResponseChunk},
+        code::{CodeSearch, CodeSearchError, CodeSearchHit, CodeSearchParams, CodeSearchQuery},
+        doc::{DocSearch, DocSearchError, DocSearchHit},
+    },
+    config::AnswerConfig,
+};
 use tabby_inference::ChatCompletionStream;
 use tabby_schema::{
     repository::RepositoryService,
@@ -105,7 +108,7 @@ impl AnswerService {
                     language: code_query.language,
                     content: code_query.content,
                 };
-                self.collect_relevant_code(&code_query).await
+                self.collect_relevant_code(&code_query, &self.config.code_search_params).await
             } else {
                 vec![]
             };
@@ -205,7 +208,7 @@ impl AnswerService {
 
             // 1. Collect relevant code if needed.
             if let Some(code_query) = options.code_query.as_ref() {
-                attachment.code = self.collect_relevant_code(code_query).await.iter()
+                attachment.code = self.collect_relevant_code(code_query, &self.config.code_search_params).await.iter()
                         .map(|x| MessageAttachmentCode{
                             filepath: Some(x.doc.filepath.clone()),
                             content: x.doc.body.clone(),
@@ -287,7 +290,11 @@ impl AnswerService {
         Ok(Box::pin(s))
     }
 
-    async fn collect_relevant_code(&self, query: &CodeQueryInput) -> Vec<CodeSearchHit> {
+    async fn collect_relevant_code(
+        &self,
+        query: &CodeQueryInput,
+        params: &CodeSearchParams,
+    ) -> Vec<CodeSearchHit> {
         let query = CodeSearchQuery {
             git_url: query.git_url.clone(),
             filepath: query.filepath.clone(),
@@ -295,15 +302,7 @@ impl AnswerService {
             content: query.content.clone(),
         };
 
-        let params = CodeSearchParams {
-            num_to_return: 10,
-            num_to_score: 20,
-            min_bm25_score: -1.0,
-            min_embedding_score: 0.5,
-            min_rrf_score: -1.0,
-        };
-
-        match self.code.search_in_language(query, params).await {
+        match self.code.search_in_language(query, params.clone()).await {
             Ok(docs) => docs.hits,
             Err(err) => {
                 if let CodeSearchError::NotReady = err {

--- a/ee/tabby-webserver/src/webserver.rs
+++ b/ee/tabby-webserver/src/webserver.rs
@@ -94,6 +94,7 @@ impl Webserver {
 
     pub async fn attach(
         &self,
+        config: &Config,
         api: Router,
         ui: Router,
         code: Arc<dyn CodeSearch>,
@@ -103,6 +104,7 @@ impl Webserver {
     ) -> (Router, Router) {
         let answer = chat.as_ref().map(|chat| {
             Arc::new(crate::service::answer::create(
+                &config.answer,
                 chat.clone(),
                 code.clone(),
                 docsearch.clone(),


### PR DESCRIPTION
@xxs-wallace 

Example config

```toml
[answer.code_search_params]
num_to_return = 10
num_to_score = 20
min_embedding_score = 0.5
min_rrf_score = -1.0
min_bm25_score = -1.0
```