### PR TITLE
feat(vscode): adding commit message button in source control title

### DIFF
--- a/clients/vscode/assets/magic-wand.svg
+++ b/clients/vscode/assets/magic-wand.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e85568c25845e096f4730a84a65e32778abd50c6b5fabff0c6cc912af71fbeba
+size 1941

--- a/clients/vscode/assets/magic-wand.svg
+++ b/clients/vscode/assets/magic-wand.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e85568c25845e096f4730a84a65e32778abd50c6b5fabff0c6cc912af71fbeba
-size 1941

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -182,7 +182,7 @@
         },
         {
           "command": "tabby.chat.generateCommitMessage",
-          "when": "tabby.chatEnabled"
+          "when": "false"
         },
         {
           "command": "tabby.chat.edit.start",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -111,9 +111,9 @@
       },
       {
         "command": "tabby.chat.generateCommitMessage",
-        "title": "Generate Commit Message with Tabby Agent",
+        "title": "Generate Commit Message",
         "category": "Tabby",
-        "icon": "assets/logo.png"
+        "icon": "assets/magic-wand.svg"
       },
       {
         "command": "tabby.chat.edit.start",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -111,8 +111,9 @@
       },
       {
         "command": "tabby.chat.generateCommitMessage",
-        "title": "Generate Commit Message",
-        "category": "Tabby"
+        "title": "Generate Commit Message with Tabby Agent",
+        "category": "Tabby",
+        "icon": "assets/logo.png"
       },
       {
         "command": "tabby.chat.edit.start",
@@ -204,6 +205,13 @@
         {
           "submenu": "tabby.submenu",
           "group": "2_tabby"
+        }
+      ],
+      "scm/title": [
+        {
+          "command": "tabby.chat.generateCommitMessage",
+          "when": "tabby.chatEnabled",
+          "group": "navigation"
         }
       ]
     },

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -113,7 +113,7 @@
         "command": "tabby.chat.generateCommitMessage",
         "title": "Generate Commit Message",
         "category": "Tabby",
-        "icon": "assets/magic-wand.svg"
+        "icon": "$(sparkle)"
       },
       {
         "command": "tabby.chat.edit.start",
@@ -211,7 +211,7 @@
         {
           "command": "tabby.chat.generateCommitMessage",
           "when": "tabby.chatEnabled",
-          "group": "navigation"
+          "group": "navigation@-1"
         }
       ]
     },

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -518,7 +518,7 @@ export class Commands {
             { repository: selectedRepo.rootUri.toString() },
             token,
           );
-          if (result) {
+          if (result && selectedRepo.inputBox) {
             selectedRepo.inputBox.value = result.commitMessage;
           }
         },

--- a/clients/vscode/src/Commands.ts
+++ b/clients/vscode/src/Commands.ts
@@ -465,42 +465,43 @@ export class Commands {
       };
       await this.client.chat.resolveEdit({ location, action: "discard" });
     },
-    "chat.generateCommitMessage": async () => {
+    "chat.generateCommitMessage": async (repository?: Repository) => {
       const repos = this.gitProvider.getRepositories() ?? [];
       if (repos.length < 1) {
         window.showInformationMessage("No Git repositories found.");
         return;
       }
-      // Select repo
-      let selectedRepo: Repository | undefined = undefined;
-      if (repos.length == 1) {
-        selectedRepo = repos[0];
-      } else {
-        const selected = await window.showQuickPick(
-          repos
-            .map((repo) => {
-              const repoRoot = repo.rootUri.fsPath;
-              return {
-                label: path.basename(repoRoot),
-                detail: repoRoot,
-                iconPath: new ThemeIcon("repo"),
-                picked: repo.ui.selected,
-                alwaysShow: true,
-                value: repo,
-              };
-            })
-            .sort((a, b) => {
-              if (a.detail.startsWith(b.detail)) {
-                return 1;
-              } else if (b.detail.startsWith(a.detail)) {
-                return -1;
-              } else {
-                return a.label.localeCompare(b.label);
-              }
-            }),
-          { placeHolder: "Select a Git repository" },
-        );
-        selectedRepo = selected?.value;
+      let selectedRepo = repository;
+      if (!selectedRepo) {
+        if (repos.length == 1) {
+          selectedRepo = repos[0];
+        } else {
+          const selected = await window.showQuickPick(
+            repos
+              .map((repo) => {
+                const repoRoot = repo.rootUri.fsPath;
+                return {
+                  label: path.basename(repoRoot),
+                  detail: repoRoot,
+                  iconPath: new ThemeIcon("repo"),
+                  picked: repo.ui.selected,
+                  alwaysShow: true,
+                  value: repo,
+                };
+              })
+              .sort((a, b) => {
+                if (a.detail.startsWith(b.detail)) {
+                  return 1;
+                } else if (b.detail.startsWith(a.detail)) {
+                  return -1;
+                } else {
+                  return a.label.localeCompare(b.label);
+                }
+              }),
+            { placeHolder: "Select a Git repository" },
+          );
+          selectedRepo = selected?.value;
+        }
       }
       if (!selectedRepo) {
         return;


### PR DESCRIPTION
Trying to improve user experience and address issue #2873.

Does not fully support multi-repository situations as there is no built-in feature in VSCode to get the currently selected repository.
Works perfectly in single repository scenarios.
View:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/222526ac-f3ba-4185-8765-0c817bbabcdd">

Next Steps:

Track related VSCode API support in the future.
Consider changing the icon.