### PR TITLE
feat(index): BREAKING: change source_id definition to make it across corpus

### DIFF
--- a/crates/tabby-common/src/api/code.rs
+++ b/crates/tabby-common/src/api/code.rs
@@ -62,6 +62,26 @@ pub struct CodeSearchQuery {
     pub filepath: Option<String>,
     pub language: Option<String>,
     pub content: String,
+
+    #[serde(skip)]
+    pub source_id: String,
+}
+
+impl CodeSearchQuery {
+    pub fn new(
+        git_url: String,
+        filepath: Option<String>,
+        language: Option<String>,
+        content: String,
+    ) -> Self {
+        Self {
+            git_url,
+            filepath,
+            language,
+            content,
+            source_id: String::default(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -327,19 +327,11 @@ pub struct CodeRepository {
     pub source_id: String,
 }
 
-impl From<RepositoryConfig> for CodeRepository {
-    fn from(config: RepositoryConfig) -> Self {
-        Self::new(&config.git_url)
-    }
-}
-
 impl CodeRepository {
-    pub fn new(git_url: &str) -> Self {
+    pub fn new(git_url: &str, source_id: &str) -> Self {
         Self {
             git_url: git_url.to_owned(),
-
-            // FIXME(meng): This is a temporary solution to use git_url as source_id, we shall migrate this by pass source_id as parameter.
-            source_id: RepositoryConfig::canonicalize_url(git_url),
+            source_id: source_id.to_owned(),
         }
     }
 
@@ -373,7 +365,8 @@ impl CodeRepositoryAccess for StaticCodeRepositoryAccess {
         Ok(Config::load()?
             .repositories
             .into_iter()
-            .map(CodeRepository::from)
+            .enumerate()
+            .map(|(i, repo)| CodeRepository::new(&repo.git_url, &config_index_to_id(i)))
             .collect())
     }
 }

--- a/crates/tabby-common/src/index/code/mod.rs
+++ b/crates/tabby-common/src/index/code/mod.rs
@@ -65,10 +65,11 @@ pub fn code_search_query(
     // language / git_url / filepath field shouldn't contribute to the score, mark them to 0.0.
     let mut subqueries = vec![
         (Occur::Must, chunk_tokens_query),
+        (Occur::Must, schema.corpus_query(corpus::CODE)),
         (
             Occur::Must,
             Box::new(ConstScoreQuery::new(
-                Box::new(schema.source_query(corpus::CODE, &query.git_url)),
+                Box::new(schema.source_id_query(&query.source_id)),
                 0.0,
             )),
         ),

--- a/crates/tabby-common/src/index/mod.rs
+++ b/crates/tabby-common/src/index/mod.rs
@@ -62,7 +62,7 @@ impl IndexSchema {
         let mut builder = Schema::builder();
 
         let field_corpus = builder.add_text_field("corpus", STRING | FAST);
-        let field_source_id = builder.add_text_field("source_id", STRING | FAST);
+        let field_source_id = builder.add_text_field("source_id_v2", STRING | FAST);
         let field_id = builder.add_text_field("id", STRING | STORED);
 
         let field_updated_at = builder.add_date_field(FIELD_UPDATED_AT, INDEXED);

--- a/crates/tabby-common/src/index/mod.rs
+++ b/crates/tabby-common/src/index/mod.rs
@@ -71,6 +71,8 @@ const FIELD_UPDATED_AT: &str = "updated_at";
 pub mod corpus {
     pub const CODE: &str = "code";
     pub const WEB: &str = "web";
+
+    pub const ALL: [&str; 2] = [CODE, WEB];
 }
 
 impl IndexSchema {

--- a/crates/tabby-common/src/index/mod.rs
+++ b/crates/tabby-common/src/index/mod.rs
@@ -67,12 +67,11 @@ pub struct IndexSchema {
 
 const FIELD_CHUNK_ID: &str = "chunk_id";
 const FIELD_UPDATED_AT: &str = "updated_at";
+pub const FIELD_SOURCE_ID: &str = "source_id_v2";
 
 pub mod corpus {
     pub const CODE: &str = "code";
     pub const WEB: &str = "web";
-
-    pub const ALL: [&str; 2] = [CODE, WEB];
 }
 
 impl IndexSchema {
@@ -84,7 +83,7 @@ impl IndexSchema {
         let mut builder = Schema::builder();
 
         let field_corpus = builder.add_text_field("corpus", STRING | FAST);
-        let field_source_id = builder.add_text_field("source_id_v2", STRING | FAST);
+        let field_source_id = builder.add_text_field(FIELD_SOURCE_ID, STRING | FAST);
         let field_id = builder.add_text_field("id", STRING | STORED);
 
         let field_updated_at = builder.add_date_field(FIELD_UPDATED_AT, INDEXED);
@@ -121,18 +120,11 @@ impl IndexSchema {
         }
     }
 
-    pub fn source_query(&self, corpus: &str, source_id: &str) -> impl Query {
-        let source_id_query = TermQuery::new(
+    pub fn source_id_query(&self, source_id: &str) -> impl Query {
+        TermQuery::new(
             Term::from_field_text(self.field_source_id, source_id),
             tantivy::schema::IndexRecordOption::Basic,
-        );
-
-        BooleanQuery::new(vec![
-            // Must match the corpus
-            (Occur::Must, self.corpus_query(corpus)),
-            // Must match the source id
-            (Occur::Must, Box::new(source_id_query)),
-        ])
+        )
     }
 
     /// Build a query to find the document with the given `doc_id`.

--- a/crates/tabby-common/src/index/mod.rs
+++ b/crates/tabby-common/src/index/mod.rs
@@ -13,6 +13,26 @@ use tantivy::{
     DateTime, Term,
 };
 
+/// On a high level, the index schema is structured as follows:
+///
+///           +----------------+
+///           |     corpus     | <--- A group of documents, each document has a unique
+///           +----------------+      identifier (id) within the corpus.
+///                   |
+///                   v
+///           +----------------+
+///           |    document    | <--- A document is a group of chunks, each document has a
+///           |      (id)      |      unique identifier (id) across corpus, document's
+///           +----------------+      attributes are stored but not indexed.
+///                   |
+///                   v
+///           +----------------+
+///           |     chunk      | <--- Each chunk has a unique identifier (chunk_id) within
+///           |   (chunk_id)   |      the document. Chunk is the unit being retrieved during
+///           +----------------+      the search process.
+///
+/// Across the corpus, there is a concept of source_id, which identifies a group of documents.
+/// It is usually used to identify the source of the document, such as a Github connection or a web document crawl.
 pub struct IndexSchema {
     pub schema: Schema,
 
@@ -21,7 +41,7 @@ pub struct IndexSchema {
     /// See ./doc or ./code as an example
     pub field_corpus: Field,
 
-    /// Unique identifier (within corpus) for a group of documents.
+    /// Unique identifier (across corpus) for a group of documents.
     pub field_source_id: Field,
 
     /// Unique identifier (within corpus) for the document, each document could have multiple chunks indexed.

--- a/crates/tabby-index/src/code/index.rs
+++ b/crates/tabby-index/src/code/index.rs
@@ -106,6 +106,8 @@ async fn add_changed_documents(
                 continue;
             }
 
+            logkit::debug!("Indexing file: {}", file.path().display());
+
             let (_, s) = builder.build(code).await;
             for await task in s {
                 yield task;

--- a/crates/tabby-index/src/code/index.rs
+++ b/crates/tabby-index/src/code/index.rs
@@ -106,8 +106,6 @@ async fn add_changed_documents(
                 continue;
             }
 
-            logkit::debug!("Indexing file: {}", file.path().display());
-
             let (_, s) = builder.build(code).await;
             for await task in s {
                 yield task;

--- a/crates/tabby-index/src/code/intelligence.rs
+++ b/crates/tabby-index/src/code/intelligence.rs
@@ -246,7 +246,7 @@ mod tests {
     use std::path::PathBuf;
 
     use serial_test::serial;
-    use tabby_common::path::set_tabby_root;
+    use tabby_common::{config::config_index_to_id, path::set_tabby_root};
     use tracing_test::traced_test;
 
     use super::*;
@@ -258,7 +258,7 @@ mod tests {
     }
 
     fn get_repository_config() -> CodeRepository {
-        CodeRepository::new("https://github.com/TabbyML/tabby")
+        CodeRepository::new("https://github.com/TabbyML/tabby", &config_index_to_id(0))
     }
 
     fn get_rust_source_file() -> PathBuf {

--- a/crates/tabby-index/src/lib.rs
+++ b/crates/tabby-index/src/lib.rs
@@ -18,8 +18,7 @@ pub mod public {
     };
 
     pub fn run_index_garbage_collection(active_sources: Vec<String>) -> anyhow::Result<()> {
-        let corpus_list = [corpus::WEB, corpus::CODE];
-        for corpus in corpus_list.iter() {
+        for corpus in corpus::ALL.iter() {
             let indexer = Indexer::new(corpus);
             indexer.garbage_collect(&active_sources)?;
             indexer.commit();

--- a/crates/tabby-index/src/lib.rs
+++ b/crates/tabby-index/src/lib.rs
@@ -6,11 +6,12 @@ mod indexer;
 mod tantivy_utils;
 
 use indexer::{IndexAttributeBuilder, Indexer};
-use tabby_common::index::corpus;
 
 mod doc;
 
 pub mod public {
+    use indexer::IndexGarbageCollector;
+
     use super::*;
     pub use super::{
         code::CodeIndexer,
@@ -18,12 +19,9 @@ pub mod public {
     };
 
     pub fn run_index_garbage_collection(active_sources: Vec<String>) -> anyhow::Result<()> {
-        for corpus in corpus::ALL.iter() {
-            let indexer = Indexer::new(corpus);
-            indexer.garbage_collect(&active_sources)?;
-            indexer.commit();
-        }
-
+        let index_garbage_collector = IndexGarbageCollector::new();
+        index_garbage_collector.garbage_collect(&active_sources)?;
+        index_garbage_collector.commit(); 
         Ok(())
     }
 }

--- a/crates/tabby-index/src/lib.rs
+++ b/crates/tabby-index/src/lib.rs
@@ -17,16 +17,9 @@ pub mod public {
         doc::public::{DocIndexer, WebDocument},
     };
 
-    pub fn run_index_garbage_collection(
-        active_sources: Vec<(String, String)>,
-    ) -> anyhow::Result<()> {
+    pub fn run_index_garbage_collection(active_sources: Vec<String>) -> anyhow::Result<()> {
         let corpus_list = [corpus::WEB, corpus::CODE];
         for corpus in corpus_list.iter() {
-            let active_sources: Vec<_> = active_sources
-                .iter()
-                .filter(|(c, _)| c == corpus)
-                .map(|(_, source_id)| source_id.to_owned())
-                .collect();
             let indexer = Indexer::new(corpus);
             indexer.garbage_collect(&active_sources)?;
             indexer.commit();

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -314,7 +314,7 @@ mod tests {
             let expect = &candidates[0];
             assert_eq!(
                 closest_match($query, &candidates),
-                Some(expect.git_url.as_ref())
+                Some(expect.source_id.as_ref())
             );
         };
     }

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -308,7 +308,8 @@ mod tests {
         ($query:literal, $candidates:expr) => {
             let candidates: Vec<_> = $candidates
                 .into_iter()
-                .map(|x| CodeRepository::new(&x))
+                .enumerate()
+                .map(|(i, x)| CodeRepository::new(&x, &tabby_common::config::config_index_to_id(i)))
                 .collect();
             let expect = &candidates[0];
             assert_eq!(
@@ -322,7 +323,8 @@ mod tests {
         ($query:literal, $candidates:expr) => {
             let candidates: Vec<_> = $candidates
                 .into_iter()
-                .map(|x| CodeRepository::new(&x))
+                .enumerate()
+                .map(|(i, x)| CodeRepository::new(&x, &tabby_common::config::config_index_to_id(i)))
                 .collect();
             assert_eq!(closest_match($query, &candidates), None);
         };

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -75,16 +75,16 @@ impl CodeSearchImpl {
             })
             .await?;
 
-        let Some(git_url) = closest_match(&query.git_url, repos.iter()) else {
+        let Some(source_id) = closest_match(&query.git_url, repos.iter()) else {
             return Ok(CodeSearchResponse::default());
         };
 
         debug!(
-            "query.git_url: {:?}, matched git_url: {:?}",
-            query.git_url, git_url
+            "query.git_url: {:?}, matched source_id: {:?}",
+            query.git_url, source_id
         );
 
-        query.git_url = RepositoryConfig::canonicalize_url(git_url);
+        query.source_id = source_id.to_owned();
 
         let docs_from_embedding = {
             let embedding = self.embedding.embed(&query.content).await?;
@@ -256,7 +256,7 @@ fn closest_match<'a>(
         .filter(|elem| GitUrl::parse(&elem.git_url).is_ok_and(|x| x.name == git_search.name))
         // If there're multiple matches, we pick the one with highest alphabetical order
         .min_by_key(|elem| elem.canonical_git_url())
-        .map(|x| x.git_url.as_str())
+        .map(|x| x.source_id.as_str())
 }
 
 struct CodeSearchService {

--- a/crates/tabby/src/services/completion/completion_prompt.rs
+++ b/crates/tabby/src/services/completion/completion_prompt.rs
@@ -187,12 +187,12 @@ async fn collect_snippets(
     language: &str,
     content: &str,
 ) -> Vec<Snippet> {
-    let query = CodeSearchQuery {
-        git_url: git_url.to_owned(),
-        filepath: filepath.map(|x| x.to_owned()),
-        language: Some(language.to_owned()),
-        content: content.to_owned(),
-    };
+    let query = CodeSearchQuery::new(
+        git_url.to_owned(),
+        filepath.map(|x| x.to_owned()),
+        Some(language.to_owned()),
+        content.to_owned(),
+    );
 
     let mut ret = Vec::new();
 

--- a/ee/tabby-schema/src/dao.rs
+++ b/ee/tabby-schema/src/dao.rs
@@ -9,14 +9,13 @@ use tabby_db::{
 
 use crate::{
     integration::{Integration, IntegrationKind, IntegrationStatus},
-    repository::{ProvidedRepository, RepositoryKind},
+    repository::{RepositoryKind},
     schema::{
         auth::{self, OAuthCredential, OAuthProvider},
         email::{AuthMethod, EmailSetting, Encryption},
         job,
         repository::{
-            GithubProvidedRepository, GithubRepositoryProvider, GitlabProvidedRepository,
-            GitlabRepositoryProvider, RepositoryProviderStatus,
+            GithubRepositoryProvider, GitlabRepositoryProvider, RepositoryProviderStatus,
         },
         setting::{NetworkSetting, SecuritySetting},
         user_event::{EventKind, UserEvent},
@@ -155,20 +154,6 @@ impl From<IntegrationKind> for RepositoryKind {
     }
 }
 
-impl From<ProvidedRepository> for GithubProvidedRepository {
-    fn from(value: ProvidedRepository) -> Self {
-        Self {
-            id: value.id,
-            vendor_id: value.vendor_id,
-            github_repository_provider_id: value.integration_id,
-            name: value.display_name,
-            git_url: value.git_url,
-            active: value.active,
-            refs: value.refs,
-        }
-    }
-}
-
 impl From<Integration> for GithubRepositoryProvider {
     fn from(value: Integration) -> Self {
         Self {
@@ -199,20 +184,6 @@ impl From<IntegrationStatus> for RepositoryProviderStatus {
             IntegrationStatus::Ready => Self::Ready,
             IntegrationStatus::Pending => Self::Pending,
             IntegrationStatus::Failed => Self::Failed,
-        }
-    }
-}
-
-impl From<ProvidedRepository> for GitlabProvidedRepository {
-    fn from(value: ProvidedRepository) -> Self {
-        Self {
-            id: value.id,
-            vendor_id: value.vendor_id,
-            gitlab_repository_provider_id: value.integration_id,
-            name: value.display_name,
-            git_url: value.git_url,
-            active: value.active,
-            refs: value.refs,
         }
     }
 }

--- a/ee/tabby-schema/src/schema/repository/git.rs
+++ b/ee/tabby-schema/src/schema/repository/git.rs
@@ -32,6 +32,16 @@ pub struct GitRepository {
     pub job_info: JobInfo,
 }
 
+impl GitRepository {
+    pub fn source_id(&self) -> String {
+        Self::format_source_id(&self.id)
+    }
+
+    pub fn format_source_id(id: &ID) -> String {
+        format!("git:{}", id)
+    }
+}
+
 impl NodeType for GitRepository {
     type Cursor = String;
 

--- a/ee/tabby-schema/src/schema/repository/mod.rs
+++ b/ee/tabby-schema/src/schema/repository/mod.rs
@@ -39,6 +39,10 @@ pub enum RepositoryKind {
 #[derive(GraphQLObject, Debug)]
 pub struct Repository {
     pub id: ID,
+
+    #[graphql(skip)]
+    pub source_id: String,
+
     pub name: String,
     pub kind: RepositoryKind,
 
@@ -58,91 +62,10 @@ pub struct GitReference {
 impl From<GitRepository> for Repository {
     fn from(value: GitRepository) -> Self {
         Self {
+            source_id: value.source_id(),
             id: value.id,
             name: value.name,
             kind: RepositoryKind::Git,
-            dir: RepositoryConfig::resolve_dir(&value.git_url),
-            git_url: RepositoryConfig::canonicalize_url(&value.git_url),
-            refs: value.refs,
-        }
-    }
-}
-
-#[derive(GraphQLObject, Debug)]
-#[graphql(context = Context)]
-pub struct GithubProvidedRepository {
-    pub id: ID,
-    pub vendor_id: String,
-    pub github_repository_provider_id: ID,
-    pub name: String,
-    pub git_url: String,
-    pub active: bool,
-    pub refs: Vec<GitReference>,
-}
-
-impl NodeType for GithubProvidedRepository {
-    type Cursor = String;
-
-    fn cursor(&self) -> Self::Cursor {
-        self.id.to_string()
-    }
-
-    fn connection_type_name() -> &'static str {
-        "GithubProvidedRepositoryConnection"
-    }
-
-    fn edge_type_name() -> &'static str {
-        "GithubProvidedRepositoryEdge"
-    }
-}
-
-#[derive(GraphQLObject, Debug)]
-#[graphql(context = Context)]
-pub struct GitlabProvidedRepository {
-    pub id: ID,
-    pub vendor_id: String,
-    pub gitlab_repository_provider_id: ID,
-    pub name: String,
-    pub git_url: String,
-    pub active: bool,
-    pub refs: Vec<GitReference>,
-}
-
-impl NodeType for GitlabProvidedRepository {
-    type Cursor = String;
-
-    fn cursor(&self) -> Self::Cursor {
-        self.id.to_string()
-    }
-
-    fn connection_type_name() -> &'static str {
-        "GitlabProvidedRepositoryConnection"
-    }
-
-    fn edge_type_name() -> &'static str {
-        "GitlabProvidedRepositoryEdge"
-    }
-}
-
-impl From<GithubProvidedRepository> for Repository {
-    fn from(value: GithubProvidedRepository) -> Self {
-        Self {
-            id: value.id,
-            name: value.name,
-            kind: RepositoryKind::Github,
-            dir: RepositoryConfig::resolve_dir(&value.git_url),
-            git_url: RepositoryConfig::canonicalize_url(&value.git_url),
-            refs: value.refs,
-        }
-    }
-}
-
-impl From<GitlabProvidedRepository> for Repository {
-    fn from(value: GitlabProvidedRepository) -> Self {
-        Self {
-            id: value.id,
-            name: value.name,
-            kind: RepositoryKind::Gitlab,
             dir: RepositoryConfig::resolve_dir(&value.git_url),
             git_url: RepositoryConfig::canonicalize_url(&value.git_url),
             refs: value.refs,
@@ -299,8 +222,7 @@ pub trait RepositoryService: Send + Sync {
     fn git(&self) -> Arc<dyn GitRepositoryService>;
     fn third_party(&self) -> Arc<dyn ThirdPartyRepositoryService>;
 
-    async fn list_all_repository_urls(&self) -> Result<Vec<CodeRepository>>;
-    async fn list_all_sources(&self) -> Result<Vec<(String, String)>>;
+    async fn list_all_code_repository(&self) -> Result<Vec<CodeRepository>>;
 
     async fn resolve_web_source_id_by_git_url(&self, git_url: &str) -> Result<String>;
 }

--- a/ee/tabby-schema/src/schema/repository/mod.rs
+++ b/ee/tabby-schema/src/schema/repository/mod.rs
@@ -224,5 +224,5 @@ pub trait RepositoryService: Send + Sync {
 
     async fn list_all_code_repository(&self) -> Result<Vec<CodeRepository>>;
 
-    async fn resolve_web_source_id_by_git_url(&self, git_url: &str) -> Result<String>;
+    async fn resolve_source_id_by_git_url(&self, git_url: &str) -> Result<String>;
 }

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -295,12 +295,12 @@ impl AnswerService {
         params: &CodeSearchParams,
         override_params: Option<&CodeSearchParamsOverrideInput>,
     ) -> Vec<CodeSearchHit> {
-        let query = CodeSearchQuery {
-            git_url: input.git_url.clone(),
-            filepath: input.filepath.clone(),
-            language: input.language.clone(),
-            content: input.content.clone(),
-        };
+        let query = CodeSearchQuery::new(
+            input.git_url.clone(),
+            input.filepath.clone(),
+            input.language.clone(),
+            input.content.clone(),
+        );
 
         let mut params = params.clone();
         override_params
@@ -340,7 +340,7 @@ impl AnswerService {
             if let Some(git_url) = code_query_git_url {
                 if let Ok(git_source_id) = self
                     .repository
-                    .resolve_web_source_id_by_git_url(git_url)
+                    .resolve_source_id_by_git_url(git_url)
                     .await
                 {
                     source_ids.push(git_source_id);

--- a/ee/tabby-webserver/src/service/background_job/git.rs
+++ b/ee/tabby-webserver/src/service/background_job/git.rs
@@ -49,7 +49,7 @@ impl SchedulerGitJob {
 
         let repositories: Vec<_> = repositories
             .into_iter()
-            .map(|repo| CodeRepository::new(&repo.git_url))
+            .map(|repo| CodeRepository::new(&repo.git_url, &repo.source_id))
             .collect();
 
         let mut code = CodeIndexer::default();

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
@@ -102,8 +102,11 @@ impl SchedulerGithubGitlabJob {
             repository.display_name
         );
         let mut code = CodeIndexer::default();
-        code.refresh(embedding.clone(), &CodeRepository::new(&authenticated_url))
-            .await;
+        code.refresh(
+            embedding.clone(),
+            &CodeRepository::new(&authenticated_url, &repository.source_id()),
+        )
+        .await;
 
         logkit::info!(
             "Indexing documents for repository {}",

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -159,7 +159,7 @@ impl RepositoryService for RepositoryServiceImpl {
         Ok(ret)
     }
 
-    async fn resolve_web_source_id_by_git_url(&self, git_url: &str) -> Result<String> {
+    async fn resolve_source_id_by_git_url(&self, git_url: &str) -> Result<String> {
         let git_url = RepositoryConfig::canonicalize_url(git_url);
 
         // Only third_party repositories with a git_url could generates a web source (e.g Issues, PRs)

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -8,7 +8,6 @@ use futures::StreamExt;
 use juniper::ID;
 use tabby_common::{
     config::{config_id_to_index, config_index_to_id, CodeRepository, Config, RepositoryConfig},
-    index::corpus,
 };
 use tabby_db::DbConn;
 use tabby_schema::{
@@ -43,13 +42,13 @@ pub fn create(
 
 #[async_trait]
 impl RepositoryService for RepositoryServiceImpl {
-    async fn list_all_repository_urls(&self) -> Result<Vec<CodeRepository>> {
+    async fn list_all_code_repository(&self) -> Result<Vec<CodeRepository>> {
         let mut repos: Vec<CodeRepository> = self
             .git
             .list(None, None, None, None)
             .await?
             .into_iter()
-            .map(|repo| CodeRepository::new(&repo.git_url))
+            .map(|repo| CodeRepository::new(&repo.git_url, &repo.source_id()))
             .collect();
 
         repos.extend(
@@ -60,25 +59,6 @@ impl RepositoryService for RepositoryServiceImpl {
         );
 
         Ok(repos)
-    }
-
-    async fn list_all_sources(&self) -> Result<Vec<(String, String)>> {
-        let mut sources: Vec<_> = self
-            .list_all_repository_urls()
-            .await?
-            .into_iter()
-            .map(|config| (corpus::CODE.into(), config.canonical_git_url()))
-            .collect();
-
-        sources.extend(
-            self.third_party()
-                .list_repositories_with_filter(None, None, Some(true), None, None, None, None)
-                .await?
-                .into_iter()
-                .map(|repo| (corpus::WEB.into(), repo.source_id())),
-        );
-
-        Ok(sources)
     }
 
     fn git(&self) -> Arc<dyn GitRepositoryService> {
@@ -232,6 +212,7 @@ fn list_refs(git_url: &str) -> Vec<tabby_git::GitReference> {
 
 fn to_repository(kind: RepositoryKind, repo: ProvidedRepository) -> Repository {
     Repository {
+        source_id: repo.source_id(),
         id: repo.id,
         name: repo.display_name,
         kind,
@@ -250,6 +231,7 @@ fn to_repository(kind: RepositoryKind, repo: ProvidedRepository) -> Repository {
 fn repository_config_to_repository(index: usize, config: &RepositoryConfig) -> Result<Repository> {
     Ok(Repository {
         id: ID::new(config_index_to_id(index)),
+        source_id: config_index_to_id(index),
         name: config.display_name(),
         kind: RepositoryKind::Git,
         dir: config.dir(),
@@ -285,7 +267,7 @@ mod tests {
             .unwrap();
 
         // FIXME(boxbeam): add repo with github service once there's syncing logic.
-        let repos = service.list_all_repository_urls().await.unwrap();
+        let repos = service.list_all_code_repository().await.unwrap();
         assert_eq!(repos.len(), 1);
     }
 }

--- a/ee/tabby-webserver/src/service/repository/third_party.rs
+++ b/ee/tabby-webserver/src/service/repository/third_party.rs
@@ -240,7 +240,7 @@ impl ThirdPartyRepositoryService for ThirdPartyRepositoryServiceImpl {
                 let url = integration
                     .kind
                     .format_authenticated_url(&repository.git_url, &integration.access_token)?;
-                urls.push(CodeRepository::new(&url));
+                urls.push(CodeRepository::new(&url, &repository.source_id()));
             }
         }
 


### PR DESCRIPTION
1. We change the definition of `source_id` in index to be across corpus.
2. We set source_id for code corpus as format of `git:$id`, `provided_repository:$id`, `config:$id`, ...