### PR TITLE
refactor(crawler): add timeout for crawler job

### DIFF
--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -1,7 +1,7 @@
+use std::{sync::Arc, time::Duration};
+
 use chrono::Utc;
 use futures::StreamExt;
-use std::sync::Arc;
-use std::time::Duration;
 use tabby_crawler::crawl_pipeline;
 use tabby_index::public::{DocIndexer, WebDocument};
 use tabby_inference::Embedding;

--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -8,7 +8,7 @@ use tabby_inference::Embedding;
 
 use super::helper::Job;
 
-const CRAWLER_TIMEOUT_SECS: u64 = 3600;
+const CRAWLER_TIMEOUT_SECS: u64 = 7200;
 
 pub struct WebCrawlerJob {
     source_id: String,

--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -69,10 +69,14 @@ impl WebCrawlerJob {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::Ordering;
-    use std::sync::atomic::{AtomicBool, AtomicUsize};
-    use std::sync::Arc;
-    use std::time::Duration;
+    use std::{
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
     use tokio::time::Instant;
 
     async fn run(count: Arc<AtomicUsize>, finished: Arc<AtomicBool>) -> tabby_schema::Result<()> {
@@ -96,6 +100,6 @@ mod tests {
         .await
         .is_err());
         assert!(count.load(Ordering::Acquire) > 1);
-        assert_eq!(finished.load(Ordering::Acquire), false);
+        assert!(!finished.load(Ordering::Acquire));
     }
 }


### PR DESCRIPTION
add timeout to prevent one job block the whole background loop