### PR TITLE
feat(auth): support  login as impersonate user

### DIFF
--- a/ee/tabby-db/src/users.rs
+++ b/ee/tabby-db/src/users.rs
@@ -8,7 +8,7 @@ use super::DbConn;
 use crate::SQLXResultExt;
 
 #[allow(unused)]
-#[derive(FromRow)]
+#[derive(FromRow, Clone)]
 pub struct UserDAO {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/ee/tabby-db/src/users.rs
+++ b/ee/tabby-db/src/users.rs
@@ -8,7 +8,7 @@ use super::DbConn;
 use crate::SQLXResultExt;
 
 #[allow(unused)]
-#[derive(FromRow, Clone)]
+#[derive(FromRow)]
 pub struct UserDAO {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -67,9 +67,9 @@ fn create_impl(
     if let Ok(value) = std::env::var("TABBY_OWNER_IMPERSONATE_OVERRIDE") {
         let words: Vec<&str> = value.split(':').collect();
         if words.len() == 2 {
-            let password_encrypted = password_hash(words[1]).expect("can not encrypt passworkd");
+            let password_encrypted = password_hash(words[1]).expect("can not encrypt password");
             impersonate_user = Some(ImpersonateUserCredential {
-                // impersonate user is owner use, so use 1 as id.
+                // The first user registered is the owner user, so we set id = 1 to impersonate the owner user.
                 id: 1,
                 email: words[0].to_string(),
                 password_encrypted,


### PR DESCRIPTION
Allow impersonate as owner user. 
Developer can set email/password with environment variable TABBY_OWNER_IMPERSONATE_OVERRIDE 