### PR TITLE
fix(ui): correct the copied content from assistant messages

### DIFF
--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -840,17 +840,15 @@ function AnswerBlock({
       })
       .trim()
     const docCitations =
-      answer.attachment?.doc
-        .map((doc, idx) => `[${idx + 1}] ${doc.link}`)
+      answer.attachment?.doc?.map((doc, idx) => `[${idx + 1}] ${doc.link}`)
         .join('\n') ?? ''
     const docCitationLen = answer.attachment?.doc?.length ?? 0
     const codeCitations =
-      answer.attachment?.code
-        .map((code, idx) => {
-          const lineRangeText = getRangeTextFromAttachmentCode(code)
-          const filenameText = compact([code.filepath, lineRangeText]).join(':')
-          return `[${idx + docCitationLen + 1}] ${filenameText}`
-        })
+      answer.attachment?.code?.map((code, idx) => {
+        const lineRangeText = getRangeTextFromAttachmentCode(code)
+        const filenameText = compact([code.filepath, lineRangeText]).join(':')
+        return `[${idx + docCitationLen + 1}] ${filenameText}`
+      })
         .join('\n') ?? ''
     const citations = docCitations + codeCitations
 
@@ -861,7 +859,7 @@ function AnswerBlock({
 
   const totalHeightInRem = answer.attachment?.doc?.length
     ? Math.ceil(answer.attachment.doc.length / 4) * SOURCE_CARD_STYLE.expand +
-      0.5 * Math.floor(answer.attachment.doc.length / 4)
+    0.5 * Math.floor(answer.attachment.doc.length / 4)
     : 0
 
   const relevantCodeContexts: RelevantCodeContext[] = useMemo(() => {

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -840,15 +840,17 @@ function AnswerBlock({
       })
       .trim()
     const docCitations =
-      answer.attachment?.doc?.map((doc, idx) => `[${idx + 1}] ${doc.link}`)
+      answer.attachment?.doc
+        ?.map((doc, idx) => `[${idx + 1}] ${doc.link}`)
         .join('\n') ?? ''
     const docCitationLen = answer.attachment?.doc?.length ?? 0
     const codeCitations =
-      answer.attachment?.code?.map((code, idx) => {
-        const lineRangeText = getRangeTextFromAttachmentCode(code)
-        const filenameText = compact([code.filepath, lineRangeText]).join(':')
-        return `[${idx + docCitationLen + 1}] ${filenameText}`
-      })
+      answer.attachment?.code
+        ?.map((code, idx) => {
+          const lineRangeText = getRangeTextFromAttachmentCode(code)
+          const filenameText = compact([code.filepath, lineRangeText]).join(':')
+          return `[${idx + docCitationLen + 1}] ${filenameText}`
+        })
         .join('\n') ?? ''
     const citations = docCitations + codeCitations
 
@@ -859,7 +861,7 @@ function AnswerBlock({
 
   const totalHeightInRem = answer.attachment?.doc?.length
     ? Math.ceil(answer.attachment.doc.length / 4) * SOURCE_CARD_STYLE.expand +
-    0.5 * Math.floor(answer.attachment.doc.length / 4)
+      0.5 * Math.floor(answer.attachment.doc.length / 4)
     : 0
 
   const relevantCodeContexts: RelevantCodeContext[] = useMemo(() => {

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -27,7 +27,12 @@ import {
   AttachmentDocItem,
   RelevantCodeContext
 } from '@/lib/types'
-import { cn, formatLineHashForCodeBrowser } from '@/lib/utils'
+import {
+  cn,
+  formatLineHashForCodeBrowser,
+  getRangeFromAttachmentCode,
+  getRangeTextFromAttachmentCode
+} from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
   IconBlocks,
@@ -104,7 +109,6 @@ type ConversationMessage = Omit<
 > & {
   threadId?: string
   threadRelevantQuestions?: Maybe<string[]>
-  // isLoading?: boolean
   error?: string
   attachment?: {
     code: Array<AttachmentCodeItem>
@@ -830,7 +834,6 @@ function AnswerBlock({
     number | undefined
   >(undefined)
   const getCopyContent = (answer: ConversationMessage) => {
-    // FIXME copy code
     if (isEmpty(answer?.attachment?.doc)) return answer.content
 
     const citationMatchRegex = /\[\[?citation:\s*\d+\]?\]/g
@@ -840,9 +843,21 @@ function AnswerBlock({
         return `[${citationNumberMatch}]`
       })
       .trim()
-    const citations = answer.attachment?.doc
-      .map((relevent, idx) => `[${idx + 1}] ${relevent.link}`)
-      .join('\n')
+    const docCitations =
+      answer.attachment?.doc
+        .map((doc, idx) => `[${idx + 1}] ${doc.link}`)
+        .join('\n') ?? ''
+    const docCitationLen = answer.attachment?.doc?.length ?? 0
+    const codeCitations =
+      answer.attachment?.code
+        .map((code, idx) => {
+          const lineRangeText = getRangeTextFromAttachmentCode(code)
+          const filenameText = compact([code.filepath, lineRangeText]).join(':')
+          return `[${idx + docCitationLen + 1}] ${filenameText}`
+        })
+        .join('\n') ?? ''
+    const citations = docCitations + codeCitations
+
     return `${content}\n\nCitations:\n${citations}`
   }
 
@@ -856,15 +871,13 @@ function AnswerBlock({
   const relevantCodeContexts: RelevantCodeContext[] = useMemo(() => {
     return (
       answer?.attachment?.code?.map(code => {
-        const start_line = code?.startLine ?? 0
-        const lineCount = code.content.split('\n').length
-        const end_line = start_line + lineCount - 1
+        const { startLine, endLine } = getRangeFromAttachmentCode(code)
 
         return {
           kind: 'file',
           range: {
-            start: start_line,
-            end: end_line
+            start: startLine,
+            end: endLine
           },
           filepath: code.filepath,
           content: code.content,
@@ -907,9 +920,7 @@ function AnswerBlock({
   }
 
   const openCodeBrowserTab = (code: MessageAttachmentCode) => {
-    const start_line = code?.startLine ?? 0
-    const lineCount = code.content.split('\n').length
-    const end_line = start_line + lineCount - 1
+    const { startLine, endLine } = getRangeFromAttachmentCode(code)
 
     if (!code.filepath) return
     const url = new URL(`${window.location.origin}/files`)
@@ -919,8 +930,8 @@ function AnswerBlock({
     url.search = searchParams.toString()
 
     const lineHash = formatLineHashForCodeBrowser({
-      start: start_line,
-      end: end_line
+      start: startLine,
+      end: endLine
     })
     if (lineHash) {
       url.hash = lineHash

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -4,10 +4,9 @@
 import React, { useMemo } from 'react'
 import Image from 'next/image'
 import tabbyLogo from '@/assets/tabby.png'
-import { compact, concat, isNil } from 'lodash-es'
+import { compact, isEmpty, isNil } from 'lodash-es'
 import type { Context } from 'tabby-chat-panel'
 
-import { MessageAttachmentCode } from '@/lib/gql/generates/graphql'
 import { useMe } from '@/lib/hooks/use-me'
 import { filename2prism } from '@/lib/language-utils'
 import {
@@ -16,7 +15,11 @@ import {
   QuestionAnswerPair,
   UserMessage
 } from '@/lib/types/chat'
-import { cn, formatLineHashForCodeBrowser } from '@/lib/utils'
+import {
+  cn,
+  getRangeFromAttachmentCode,
+  getRangeTextFromAttachmentCode
+} from '@/lib/utils'
 
 import { CopyButton } from '../copy-button'
 import { ErrorMessageBlock, MessageMarkdown } from '../message-markdown'
@@ -217,6 +220,7 @@ interface AssistantMessageActionProps {
   userMessageId: string
   message: AssistantMessage
   enableRegenerating?: boolean
+  attachmentCode?: Array<AttachmentCodeItem>
 }
 
 function AssistantMessageCard(props: AssistantMessageCardProps) {
@@ -235,15 +239,13 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
   const serverCode: Array<Context> = React.useMemo(() => {
     return (
       message?.relevant_code?.map(code => {
-        const start_line = code?.startLine ?? 0
-        const lineCount = code.content.split('\n').length
-        const end_line = start_line + lineCount - 1
+        const { startLine, endLine } = getRangeFromAttachmentCode(code)
 
         return {
           kind: 'file',
           range: {
-            start: start_line,
-            end: end_line
+            start: startLine,
+            end: endLine
           },
           filepath: code.filepath,
           content: code.content,
@@ -263,14 +265,28 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
   const attachmentDocsLen = 0
 
   const attachmentCode: Array<AttachmentCodeItem> = useMemo(() => {
-    return concat(clientCode, serverCode).map(o => ({
-      content: o.content,
-      filepath: o.filepath,
-      gitUrl: o.git_url,
-      startLine: o.range.start,
-      // FIXME
-      language: ''
-    }))
+    const formatedClientAttachmentCode =
+      clientCode?.map(o => ({
+        content: o.content,
+        filepath: o.filepath,
+        gitUrl: o.git_url,
+        startLine: o.range.start,
+        language: filename2prism(o.filepath ?? '')[0],
+        isClient: true
+      })) ?? []
+    const formatedServerAttachmentCode =
+      serverCode?.map(o => ({
+        content: o.content,
+        filepath: o.filepath,
+        gitUrl: o.git_url,
+        startLine: o.range.start,
+        language: filename2prism(o.filepath ?? '')[0],
+        isClient: false
+      })) ?? []
+    return compact([
+      ...formatedClientAttachmentCode,
+      ...formatedServerAttachmentCode
+    ])
   }, [clientCode, serverCode])
 
   const onCodeCitationMouseEnter = (index: number) => {
@@ -281,31 +297,21 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
     setRelevantCodeHighlightIndex(undefined)
   }
 
-  const openCodeBrowserTab = (code: MessageAttachmentCode) => {
-    const start_line = code?.startLine ?? 0
-    const lineCount = code.content.split('\n').length
-    const end_line = start_line + lineCount - 1
-
-    if (!code.filepath) return
-    const url = new URL(`${window.location.origin}/files`)
-    const searchParams = new URLSearchParams()
-    searchParams.append('redirect_filepath', code.filepath)
-    searchParams.append('redirect_git_url', code.gitUrl)
-    url.search = searchParams.toString()
-
-    const lineHash = formatLineHashForCodeBrowser({
-      start: start_line,
-      end: end_line
-    })
-    if (lineHash) {
-      url.hash = lineHash
+  const onCodeCitationClick = (code: AttachmentCodeItem) => {
+    const { startLine, endLine } = getRangeFromAttachmentCode(code)
+    const ctx: Context = {
+      git_url: code.gitUrl,
+      content: code.content,
+      filepath: code.filepath,
+      kind: 'file',
+      range: {
+        start: startLine,
+        end: endLine
+      }
     }
-
-    window.open(url.toString())
-  }
-
-  const onCodeCitationClick = (code: MessageAttachmentCode) => {
-    openCodeBrowserTab(code)
+    onNavigateToContext?.(ctx, {
+      openInEditor: client === 'vscode' && code.isClient
+    })
   }
 
   return (
@@ -328,6 +334,7 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
             message={message}
             userMessageId={userMessageId}
             enableRegenerating={enableRegenerating}
+            attachmentCode={attachmentCode}
           />
         </div>
       </div>
@@ -353,8 +360,7 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
               onApplyInEditor={onApplyInEditor}
               onCopyContent={onCopyContent}
               attachmentCode={attachmentCode}
-              // FIXME
-              // onCodeCitationClick={onCodeCitationClick}
+              onCodeCitationClick={onCodeCitationClick}
               onCodeCitationMouseEnter={onCodeCitationMouseEnter}
               onCodeCitationMouseLeave={onCodeCitationMouseLeave}
             />
@@ -365,11 +371,39 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
           <AssistantMessageCardActions
             message={message}
             userMessageId={userMessageId}
+            enableRegenerating={enableRegenerating}
+            attachmentCode={attachmentCode}
           />
         </div>
       </div>
     </div>
   )
+}
+
+function getCopyContent(
+  content: string,
+  attachmentCode?: Array<AttachmentCodeItem>
+) {
+  if (!attachmentCode || isEmpty(attachmentCode)) return content
+
+  const citationMatchRegex = /\[\[?citation:\s*\d+\]?\]/g
+  const parsedContent = content
+    .replace(citationMatchRegex, match => {
+      const citationNumberMatch = match?.match(/\d+/)
+      return `[${citationNumberMatch}]`
+    })
+    .trim()
+
+  const codeCitations =
+    attachmentCode
+      .map((code, idx) => {
+        const lineRangeText = getRangeTextFromAttachmentCode(code)
+        const filenameText = compact([code.filepath, lineRangeText]).join(':')
+        return `[${idx + 1}] ${filenameText}`
+      })
+      .join('\n') ?? ''
+
+  return `${parsedContent}\n\nCitations:\n${codeCitations}`
 }
 
 function AssistantMessageCardActions(props: AssistantMessageActionProps) {
@@ -378,7 +412,11 @@ function AssistantMessageCardActions(props: AssistantMessageActionProps) {
     isLoading: isGenerating,
     onCopyContent
   } = React.useContext(ChatContext)
-  const { message, userMessageId, enableRegenerating } = props
+  const { message, userMessageId, enableRegenerating, attachmentCode } = props
+  const copyContent = useMemo(() => {
+    return getCopyContent(message.message, attachmentCode)
+  }, [message.message, attachmentCode])
+
   return (
     <ChatMessageActionsWrapper>
       {!isGenerating && enableRegenerating && (
@@ -391,7 +429,7 @@ function AssistantMessageCardActions(props: AssistantMessageActionProps) {
           <span className="sr-only">Regenerate message</span>
         </Button>
       )}
-      <CopyButton value={message.message} onCopyContent={onCopyContent} />
+      <CopyButton value={copyContent} onCopyContent={onCopyContent} />
     </ChatMessageActionsWrapper>
   )
 }

--- a/ee/tabby-ui/components/message-markdown.tsx
+++ b/ee/tabby-ui/components/message-markdown.tsx
@@ -30,6 +30,7 @@ type RelevantDocItem = {
 type RelevantCodeItem = {
   type: 'code'
   data: AttachmentCodeItem
+  isClient?: boolean
 }
 
 type MessageAttachments = Array<RelevantDocItem | RelevantCodeItem>

--- a/ee/tabby-ui/lib/types/chat.ts
+++ b/ee/tabby-ui/lib/types/chat.ts
@@ -86,6 +86,7 @@ export interface RelevantCodeContext extends Context {
 
 // for rendering, including scores
 export type AttachmentCodeItem = MessageAttachmentCode & {
+  isClient?: boolean
   extra?: { scores?: MessageCodeSearchHit['scores'] }
 }
 // for rendering, including score

--- a/ee/tabby-ui/lib/utils.ts
+++ b/ee/tabby-ui/lib/utils.ts
@@ -3,6 +3,8 @@ import { compact, isNil } from 'lodash-es'
 import { customAlphabet } from 'nanoid'
 import { twMerge } from 'tailwind-merge'
 
+import { AttachmentCodeItem } from './types'
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
@@ -98,4 +100,22 @@ export function formatLineHashForCodeBrowser(
       typeof num === 'number' && !isNaN(num) ? `L${num}` : undefined
     )
   ).join('-')
+}
+
+export function getRangeFromAttachmentCode(code: AttachmentCodeItem) {
+  const startLine = code?.startLine ?? 0
+  const lineCount = code?.content.split('\n').length
+  const endLine = startLine + lineCount - 1
+
+  return {
+    startLine,
+    endLine,
+    isValid: !!startLine,
+    isMultiLine: !!startLine && startLine <= endLine
+  }
+}
+
+export function getRangeTextFromAttachmentCode(code: AttachmentCodeItem) {
+  const { startLine, endLine } = getRangeFromAttachmentCode(code)
+  return formatLineHashForCodeBrowser({ start: startLine, end: endLine })
 }


### PR DESCRIPTION
### Background
When copying an assistant message, if the message content includes a citation pointing to an attachmentCode, the copied value is not correctly formatted

### Screen record
https://jam.dev/c/27b21e4c-0c3f-4d49-9dbb-94d7b4e52950