### PR TITLE
fix(ui): dedupe thread messages in Answer Engine

### DIFF
--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -70,7 +70,7 @@ import './search.css'
 
 import Link from 'next/link'
 import slugify from '@sindresorhus/slugify'
-import { compact, isEmpty, pick } from 'lodash-es'
+import { compact, isEmpty, pick, uniqBy } from 'lodash-es'
 import { ImperativePanelHandle } from 'react-resizable-panels'
 import { Context } from 'tabby-chat-panel/index'
 import { useQuery } from 'urql'
@@ -254,7 +254,7 @@ export function Search() {
       const messages = threadMessages.threadMessages.edges
         .map(o => o.node)
         .slice()
-      setMessages(prev => [...prev, ...messages])
+      setMessages(prev => uniqBy([...prev, ...messages], 'id'))
     }
 
     if (threadMessages?.threadMessages) {

--- a/ee/tabby-ui/lib/posthog.tsx
+++ b/ee/tabby-ui/lib/posthog.tsx
@@ -31,10 +31,10 @@ function PostHogPageView(): null {
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const isDemoMode = useIsDemoMode()
-  const [postHogInstance, setPostHogInstance] = useState<PostHog | null>(null)
+  const [postHogInstance, setPostHogInstance] = useState<PostHog | undefined>()
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && isDemoMode) {
+    if (typeof window !== 'undefined' && isDemoMode && !postHogInstance) {
       const isInIframe = window.self !== window.top
       if (isInIframe) return
 
@@ -43,11 +43,10 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
         person_profiles: 'identified_only',
         capture_pageview: false
       })
-      setPostHogInstance(postHogInstance || null)
+      setPostHogInstance(postHogInstance || undefined)
     }
   }, [isDemoMode])
 
-  if (!isDemoMode || !postHogInstance) return children
   return (
     <Provider client={postHogInstance}>
       <>


### PR DESCRIPTION
### Changes
1. fix the PostHogProvider to reduce API cancellations caused by children re-renders
2. dedupe thread message
