### PR TITLE
feat(eclipse): support to collect additional context used for code completion.

### DIFF
--- a/clients/eclipse/feature/feature.xml
+++ b/clients/eclipse/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.tabbyml.features.tabby4eclipse"
       label="Tabby"
-      version="0.0.1.13"
+      version="0.0.1.14"
       provider-name="com.tabbyml">
 
    <description url="http://www.example.com/description">
@@ -19,6 +19,6 @@
 
    <plugin
          id="com.tabbyml.tabby4eclipse"
-         version="0.0.1.13"/>
+         version="0.0.1.14"/>
 
 </feature>

--- a/clients/eclipse/plugin/META-INF/MANIFEST.MF
+++ b/clients/eclipse/plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tabby Plugin for Eclipse
 Bundle-SymbolicName: com.tabbyml.tabby4eclipse;singleton:=true
-Bundle-Version: 0.0.1.13
+Bundle-Version: 0.0.1.14
 Bundle-Activator: com.tabbyml.tabby4eclipse.Activator
 Bundle-Vendor: com.tabbyml
 Require-Bundle: org.eclipse.ui,

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/chat/ChatView.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/chat/ChatView.java
@@ -52,6 +52,7 @@ import com.tabbyml.tabby4eclipse.lsp.ServerConfigHolder;
 import com.tabbyml.tabby4eclipse.lsp.StatusInfoHolder;
 import com.tabbyml.tabby4eclipse.lsp.protocol.Config;
 import com.tabbyml.tabby4eclipse.lsp.protocol.GitRepository;
+import com.tabbyml.tabby4eclipse.lsp.protocol.GitRepositoryParams;
 import com.tabbyml.tabby4eclipse.lsp.protocol.ILanguageServer;
 import com.tabbyml.tabby4eclipse.lsp.protocol.IStatusService;
 import com.tabbyml.tabby4eclipse.lsp.protocol.StatusInfo;
@@ -234,8 +235,9 @@ public class ChatView extends ViewPart {
 			} else {
 				// Load main
 				Config.ServerConfig config = serverConfigHolder.getConfig().getServer();
-				if (force || currentConfig == null || currentConfig.getEndpoint() != config.getEndpoint()
-						|| currentConfig.getToken() != config.getToken()) {
+				if (config != null
+						&& (force || currentConfig == null || currentConfig.getEndpoint() != config.getEndpoint()
+								|| currentConfig.getToken() != config.getToken())) {
 					showMessage("Connecting to Tabby server...");
 					showChatPanel(false);
 					currentConfig = config;
@@ -504,7 +506,8 @@ public class ChatView extends ViewPart {
 		IFile file = ResourceUtil.getFile(activeTextEditor.getEditorInput());
 		URI fileUri = file.getLocationURI();
 		if (file != null) {
-			GitRepository gitInfo = GitProvider.getRepository(fileUri);
+			GitRepository gitInfo = GitProvider.getInstance()
+					.getRepository(new GitRepositoryParams(fileUri.toString()));
 			IProject project = file.getProject();
 			if (gitInfo != null) {
 				try {

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/ConnectionProvider.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/ConnectionProvider.java
@@ -112,6 +112,8 @@ public class ConnectionProvider extends ProcessStreamConnectionProvider {
 		TabbyClientCapabilities tabbyClientCapabilities = new TabbyClientCapabilities();
 		tabbyClientCapabilities.setConfigDidChangeListener(true);
 		tabbyClientCapabilities.setStatusDidChangeListener(true);
+		tabbyClientCapabilities.setGitProvider(true);
+		tabbyClientCapabilities.setLanguageSupport(false);
 
 		ClientCapabilities clientCapabilities = new ClientCapabilities();
 		clientCapabilities.setTextDocument(textDocumentClientCapabilities);

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/ConnectionProvider.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/ConnectionProvider.java
@@ -112,8 +112,9 @@ public class ConnectionProvider extends ProcessStreamConnectionProvider {
 		TabbyClientCapabilities tabbyClientCapabilities = new TabbyClientCapabilities();
 		tabbyClientCapabilities.setConfigDidChangeListener(true);
 		tabbyClientCapabilities.setStatusDidChangeListener(true);
+		tabbyClientCapabilities.setWorkspaceFileSystem(true);
 		tabbyClientCapabilities.setGitProvider(true);
-		tabbyClientCapabilities.setLanguageSupport(false);
+		tabbyClientCapabilities.setLanguageSupport(true);
 
 		ClientCapabilities clientCapabilities = new ClientCapabilities();
 		clientCapabilities.setTextDocument(textDocumentClientCapabilities);

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/LanguageClientImpl.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/LanguageClientImpl.java
@@ -1,10 +1,21 @@
 package com.tabbyml.tabby4eclipse.lsp;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.SemanticTokensRangeParams;
+import org.eclipse.lsp4j.DeclarationParams;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 
+import com.tabbyml.tabby4eclipse.git.GitProvider;
 import com.tabbyml.tabby4eclipse.lsp.protocol.Config;
+import com.tabbyml.tabby4eclipse.lsp.protocol.GitDiffParams;
+import com.tabbyml.tabby4eclipse.lsp.protocol.GitDiffResult;
+import com.tabbyml.tabby4eclipse.lsp.protocol.GitRepository;
+import com.tabbyml.tabby4eclipse.lsp.protocol.GitRepositoryParams;
+import com.tabbyml.tabby4eclipse.lsp.protocol.SemanticTokensRangeResult;
 import com.tabbyml.tabby4eclipse.lsp.protocol.StatusInfo;
 
 public class LanguageClientImpl extends org.eclipse.lsp4e.LanguageClientImpl {
@@ -12,9 +23,35 @@ public class LanguageClientImpl extends org.eclipse.lsp4e.LanguageClientImpl {
 	void statusDidChange(StatusInfo params) {
 		StatusInfoHolder.getInstance().setStatusInfo(params);
 	}
-	
+
 	@JsonNotification("tabby/config/didChange")
 	void statusDidChange(Config params) {
 		ServerConfigHolder.getInstance().setConfig(params);
+	}
+
+	@JsonRequest("tabby/git/repository")
+	CompletableFuture<GitRepository> gitRepository(GitRepositoryParams params) {
+		CompletableFuture<GitRepository> future = new CompletableFuture<>();
+		GitRepository result = GitProvider.getInstance().getRepository(params);
+		future.complete(result);
+		return future;
+	}
+
+	@JsonRequest("tabby/git/diff")
+	CompletableFuture<GitDiffResult> gitDiff(GitDiffParams params) {
+		CompletableFuture<GitDiffResult> future = new CompletableFuture<>();
+		GitDiffResult result = GitProvider.getInstance().getDiff(params);
+		future.complete(result);
+		return future;
+	}
+
+	@JsonRequest("tabby/languageSupport/textDocument/declaration")
+	CompletableFuture<List<LocationLink>> languageSupportDeclaration(DeclarationParams params) {
+		return null;
+	}
+
+	@JsonRequest("tabby/languageSupport/textDocument/semanticTokens/range")
+	CompletableFuture<SemanticTokensRangeResult> languageSupportSemanticTokensRange(SemanticTokensRangeParams params) {
+		return null;
 	}
 }

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/LanguageSupportProvider.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/LanguageSupportProvider.java
@@ -1,0 +1,87 @@
+package com.tabbyml.tabby4eclipse.lsp;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.net.URI;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4j.DeclarationParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+import org.eclipse.lsp4j.SemanticTokensRangeParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.tabbyml.tabby4eclipse.Logger;
+import com.tabbyml.tabby4eclipse.lsp.protocol.SemanticTokensRangeResult;
+
+public class LanguageSupportProvider {
+	public static LanguageSupportProvider getInstance() {
+		return LazyHolder.INSTANCE;
+	}
+
+	private static class LazyHolder {
+		private static final LanguageSupportProvider INSTANCE = new LanguageSupportProvider();
+	}
+
+	private Logger logger = new Logger("LanguageSupportProvider");
+
+	CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> languageSupportDeclaration(
+			DeclarationParams params) {
+		try {
+			URI uri = new URI(params.getTextDocument().getUri());
+			IDocument document = LSPEclipseUtils.getDocument(uri);
+
+			CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> future = LanguageServers
+					.forDocument(document).withFilter((serverCapabilities) -> {
+						return serverCapabilities.getDeclarationProvider() != null;
+					}).computeFirst((wrapper, server) -> {
+						return server.getTextDocumentService().declaration(params);
+					}).thenApply((result) -> {
+						if (result.isPresent()) {
+							return result.get();
+						} else {
+							return null;
+						}
+					});
+			return future;
+		} catch (Exception e) {
+			logger.error("Error while processing languageSupport/declaration.", e);
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	CompletableFuture<SemanticTokensRangeResult> languageSupportSemanticTokensRange(SemanticTokensRangeParams params) {
+		try {
+			URI uri = new URI(params.getTextDocument().getUri());
+			IDocument document = LSPEclipseUtils.getDocument(uri);
+
+			CompletableFuture<SemanticTokensRangeResult> future = LanguageServers.forDocument(document)
+					.withFilter((serverCapabilities) -> {
+						return serverCapabilities.getSelectionRangeProvider() != null;
+					}).computeFirst((wrapper, server) -> {
+						return server.getTextDocumentService().semanticTokensRange(params).thenApply((tokens) -> {
+							SemanticTokensRangeResult result = new SemanticTokensRangeResult();
+							SemanticTokensLegend legend = wrapper.getServerCapabilities().getSemanticTokensProvider()
+									.getLegend();
+							result.setLegend(legend);
+							result.setTokens(tokens);
+							return result;
+						});
+					}).thenApply((result) -> {
+						if (result.isPresent()) {
+							return result.get();
+						} else {
+							return null;
+						}
+					});
+			return future;
+		} catch (Exception e) {
+			logger.error("Error while processing languageSupport/semanticTokens/range.", e);
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+}

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/GitDiffParams.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/GitDiffParams.java
@@ -1,0 +1,35 @@
+package com.tabbyml.tabby4eclipse.lsp.protocol;
+
+public class GitDiffParams {
+	private String repository;
+	private boolean cached;
+
+	public GitDiffParams() {
+	}
+
+	public GitDiffParams(String repository) {
+		this.repository = repository;
+		this.cached = false;
+	}
+
+	public GitDiffParams(String repository, boolean cached) {
+		this.repository = repository;
+		this.cached = cached;
+	}
+
+	public String getRepository() {
+		return repository;
+	}
+
+	public void setRepository(String repository) {
+		this.repository = repository;
+	}
+
+	public boolean getCached() {
+		return cached;
+	}
+
+	public void setCached(boolean cached) {
+		this.cached = cached;
+	}
+}

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/GitDiffResult.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/GitDiffResult.java
@@ -1,0 +1,20 @@
+package com.tabbyml.tabby4eclipse.lsp.protocol;
+
+public class GitDiffResult {
+	private String diff;
+
+	public GitDiffResult() {
+	}
+
+	public GitDiffResult(String diff) {
+		this.diff = diff;
+	}
+
+	public String getDiff() {
+		return diff;
+	}
+
+	public void setDiff(String diff) {
+		this.diff = diff;
+	}
+}

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/GitRepositoryParams.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/GitRepositoryParams.java
@@ -1,0 +1,17 @@
+package com.tabbyml.tabby4eclipse.lsp.protocol;
+
+public class GitRepositoryParams {
+	private String uri;
+
+	public GitRepositoryParams(String uri) {
+		this.uri = uri;
+	}
+
+	public String getUri() {
+		return uri;
+	}
+
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+}

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/ReadFileParams.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/ReadFileParams.java
@@ -1,0 +1,37 @@
+package com.tabbyml.tabby4eclipse.lsp.protocol;
+
+import org.eclipse.lsp4j.Range;
+
+public class ReadFileParams {
+	private String uri;
+	private String format;
+	private Range range;
+
+	public ReadFileParams(String uri) {
+		this.uri = uri;
+	}
+
+	public String getUri() {
+		return uri;
+	}
+
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+	public String getFormat() {
+		return format;
+	}
+
+	public void setFormat(String format) {
+		this.format = format;
+	}
+
+	public Range getRange() {
+		return range;
+	}
+
+	public void setRange(Range range) {
+		this.range = range;
+	}
+}

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/ReadFileResult.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/ReadFileResult.java
@@ -1,0 +1,20 @@
+package com.tabbyml.tabby4eclipse.lsp.protocol;
+
+public class ReadFileResult {
+	private String text;
+
+	public ReadFileResult() {
+	}
+
+	public ReadFileResult(String text) {
+		this.text = text;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+}

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/SemanticTokensRangeResult.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/lsp/protocol/SemanticTokensRangeResult.java
@@ -1,0 +1,28 @@
+package com.tabbyml.tabby4eclipse.lsp.protocol;
+
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+
+public class SemanticTokensRangeResult {
+	private SemanticTokensLegend legend;
+	private SemanticTokens tokens;
+
+	public SemanticTokensRangeResult() {
+	}
+
+	public SemanticTokensLegend getLegend() {
+		return legend;
+	}
+
+	public void setLegend(SemanticTokensLegend legend) {
+		this.legend = legend;
+	}
+
+	public SemanticTokens getTokens() {
+		return tokens;
+	}
+
+	public void setTokens(SemanticTokens tokens) {
+		this.tokens = tokens;
+	}
+}


### PR DESCRIPTION
1. Added support to collect git context from the eclipse plugin, powered by org.eclipse.jgit.

2. Added support to collect declaration code snippets for code completion, requiring an activated language server connected to org.eclipse.lsp4e.
    Tested in the environment with eclipse-corrosion installed, providing Rust LSP support based on org.eclipse.lsp4e.
    A example completion request:
    ```
      "segments": {
        "prefix": "fn main() {\n    println!(\"Hello, world!\");\n\tp",
        "suffix": "\n}\n",
        "filepath": "src/main.rs",
        "declarations": [
          {
            "filepath": "file:///home/icy/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/macros.rs",
            "body": "/// Prints to the standard output, with a newline.\n///\n/// On all platforms, the newline is the LINE FEED character (`\\n`/`U+000A`) alone\n/// (no additional CARRIAGE RETURN (`\\r`/`U+000D`)).\n///\n/// This macro uses the same syntax as [`format!`], but writes to the standard output instead.\n/// See [`std::fmt`] for more information.\n///\n/// The `println!` macro will lock the standard output on each call. If you call\n"
          }
        ],
        "relevant_snippets_from_changed_files": []
      }
    ```
