### PR TITLE
chore(vscode): update command palette to pass modal flag correctly

### DIFF
--- a/clients/vscode/src/CommandPalette.ts
+++ b/clients/vscode/src/CommandPalette.ts
@@ -117,7 +117,7 @@ export default class CommandPalette {
           item.description = "Completion requests appear to take too much time.";
           break;
       }
-      item.command = () => this.issues.showHelpMessage();
+      item.command = () => this.issues.showHelpMessage(undefined, true);
     } else if (agentStatus === "ready") {
       item.label = "Ready";
       item.iconPath = new ThemeIcon("check");

--- a/clients/vscode/src/Issues.ts
+++ b/clients/vscode/src/Issues.ts
@@ -43,7 +43,8 @@ export class Issues extends EventEmitter {
     return await this.client.agent.fetchIssueDetail({ name: issue, helpMessageFormat: "plaintext" });
   }
 
-  async showHelpMessage(issue?: IssueName | undefined, modal = false) {
+  // FIXME(meng): Remove codepath for `modal = false`, which is no longer used.
+  async showHelpMessage(issue?: IssueName | undefined, modal = true) {
     const name = issue ?? this.first;
     if (!name) {
       return;


### PR DESCRIPTION
- Modified the command in CommandPalette.ts to pass `true` for the modal flag when calling `showHelpMessage`.
- Updated Issues.ts to always use `modal = true` and marked the `modal = false` codepath as deprecated for future removal.