### PR TITLE
style(search): adjust vertical alignment in list items (align to top)

### DIFF
--- a/ee/tabby-ui/app/search/components/search.css
+++ b/ee/tabby-ui/app/search/components/search.css
@@ -1,3 +1,7 @@
 .text-area-autosize::-webkit-scrollbar {
   display: none;
 }
+
+li > * {
+  vertical-align: top;
+}


### PR DESCRIPTION
Before:
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/32a3c77f-f02f-4141-9d52-90f6e72a3464">


After:

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/f04c1f7a-3a3d-403f-8079-c34e8bcdfbe5">
