### PR TITLE
fix(ui): add styles to MessageMarkdown component

### DIFF
--- a/ee/tabby-ui/app/search/components/search.css
+++ b/ee/tabby-ui/app/search/components/search.css
@@ -1,7 +1,3 @@
 .text-area-autosize::-webkit-scrollbar {
   display: none;
 }
-
-li > * {
-  vertical-align: top;
-}

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -23,6 +23,8 @@ import {
 } from '@/components/ui/hover-card'
 import { MemoizedReactMarkdown } from '@/components/markdown'
 
+import './style.css'
+
 type RelevantDocItem = {
   type: 'doc'
   data: AttachmentDocItem
@@ -148,7 +150,7 @@ export function MessageMarkdown({
       }}
     >
       <MemoizedReactMarkdown
-        className="prose max-w-none break-words dark:prose-invert prose-p:leading-relaxed prose-pre:mt-1 prose-pre:p-0"
+        className="message-markdown prose max-w-none break-words dark:prose-invert prose-p:leading-relaxed prose-pre:mt-1 prose-pre:p-0"
         remarkPlugins={[remarkGfm, remarkMath]}
         components={{
           p({ children }) {

--- a/ee/tabby-ui/components/message-markdown/style.css
+++ b/ee/tabby-ui/components/message-markdown/style.css
@@ -1,0 +1,3 @@
+.message-markdown li > * {
+  vertical-align: top;
+}


### PR DESCRIPTION
### Screenshot
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/224687a2-48a7-4252-8c45-975dd91b90d7">
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/e3053ed6-a5e7-418d-9a14-ed5770322231">
