### PR TITLE
fix(tabby-agent): remove code block delimiters from commit message

### DIFF
--- a/clients/tabby-agent/src/AgentConfig.ts
+++ b/clients/tabby-agent/src/AgentConfig.ts
@@ -200,7 +200,7 @@ export const defaultAgentConfig: AgentConfig = {
       maxDiffLength: 3600,
       promptTemplate: generateCommitMessagePrompt,
       responseMatcher:
-        /(?<=(["'`]+)?\s*)(feat|fix|docs|refactor|style|test|build|ci|chore)(\(\w+\))?:.+(?=\s*\1)/gi.toString(),
+        /(?<=(["'`]+)?\s*)(feat|fix|docs|refactor|style|test|build|ci|chore)(\(\S+\))?:.+(?=\s*\1)/gis.toString(),
     },
   },
   logs: {


### PR DESCRIPTION
Solving this issue #3002 by adding one line of code, xd

btw, the commit message for this one was automatically generated by Tabby.