### PR TITLE
feat(email): support self-signed smtp cert from env

### DIFF
--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -105,12 +105,6 @@ pub enum CoreError {
     #[error("SMTP is not configured")]
     EmailNotConfigured,
 
-    #[error("SMTP cert is invalid")]
-    EmailInvalidCert,
-
-    #[error("SMTP cert is invalid")]
-    EmailInvalidCertPath(#[from] std::io::Error),
-
     #[error("{0}")]
     InvalidLicense(&'static str),
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -105,6 +105,12 @@ pub enum CoreError {
     #[error("SMTP is not configured")]
     EmailNotConfigured,
 
+    #[error("SMTP cert is invalid")]
+    EmailInvalidCert,
+
+    #[error("SMTP cert is invalid")]
+    EmailInvalidCertPath(#[from] std::io::Error),
+
     #[error("{0}")]
     InvalidLicense(&'static str),
 

--- a/ee/tabby-webserver/src/service/email/mod.rs
+++ b/ee/tabby-webserver/src/service/email/mod.rs
@@ -49,15 +49,15 @@ fn make_smtp_builder(
 ) -> Result<AsyncSmtpTransportBuilder> {
     let mut tls_parameters = TlsParameters::builder(host.into());
 
-    if let Ok(cert_path) = std::env::var("TABBY_EMAIL_CERT_PATH") {
-        let cert = Certificate::from_pem(&std::fs::read(cert_path)?)
-            .map_err(|_| CoreError::EmailInvalidCert)?;
+    if let Ok(cert_string) = std::env::var("TABBY_WEBSERVER_EMAIL_CERT") {
+        let cert = Certificate::from_pem(cert_string.as_bytes())
+            .map_err(|e| CoreError::Other(e.into()))?;
         tls_parameters = tls_parameters.add_root_certificate(cert);
     }
 
     let tls_parameters = tls_parameters
         .build()
-        .map_err(|_| CoreError::EmailInvalidCert)?;
+        .map_err(|e| CoreError::Other(e.into()))?;
 
     let builder = match encryption {
         Encryption::StartTls => AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(host)

--- a/ee/tabby-webserver/src/service/email/mod.rs
+++ b/ee/tabby-webserver/src/service/email/mod.rs
@@ -6,7 +6,7 @@ use lettre::{
     message::{header::ContentType, Mailbox, MessageBuilder},
     transport::smtp::{
         authentication::{Credentials, Mechanism},
-        client::{Tls, TlsParameters},
+        client::{Certificate, Tls, TlsParameters},
         AsyncSmtpTransportBuilder,
     },
     Address, AsyncSmtpTransport, AsyncTransport, Tokio1Executor,
@@ -45,8 +45,19 @@ fn make_smtp_builder(
     host: &str,
     port: u16,
     encryption: Encryption,
+    cert_pem: Option<String>,
 ) -> Result<AsyncSmtpTransportBuilder> {
-    let tls_parameters = TlsParameters::new(host.into()).map_err(anyhow::Error::new)?;
+    let mut tls_parameters = TlsParameters::builder(host.into());
+
+    if let Ok(cert_path) = std::env::var("TABBY_EMAIL_CERT_PATH") {
+        let cert = Certificate::from_pem(&std::fs::read(cert_path)?)
+            .map_err(|_| CoreError::EmailInvalidCert)?;
+        tls_parameters = tls_parameters.add_root_certificate(cert);
+    }
+
+    let tls_parameters = tls_parameters
+        .build()
+        .map_err(|_| CoreError::EmailInvalidCert)?;
 
     let builder = match encryption {
         Encryption::StartTls => AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(host)
@@ -86,7 +97,7 @@ impl EmailServiceImpl {
     ) -> Result<()> {
         let mut smtp_server = self.smtp_server.write().await;
 
-        let mut builder = make_smtp_builder(host, port as u16, encryption)?;
+        let mut builder = make_smtp_builder(host, port as u16, encryption, None)?;
         let mechanism = auth_mechanism(auth_method);
         if !mechanism.is_empty() {
             builder = builder


### PR DESCRIPTION
split from https://github.com/TabbyML/tabby/pull/2952, support self-signed cert for smtp by reading a cert path from `TABBY_EMAIL_CERT_PATH` env.

this only supports Linux, NOT macOS, because macOS has some more pedantic requirements for self-signed cert.
We may need to dive deeper into the self-signed cert part for macOS support. ref: https://github.com/sfackler/rust-native-tls/issues/210 

fix https://github.com/TabbyML/tabby/issues/2437