### PR TITLE
docs: mention server configuration options in Homebrew quick-start

### DIFF
--- a/website/docs/quick-start/installation/apple.md
+++ b/website/docs/quick-start/installation/apple.md
@@ -15,3 +15,5 @@ tabby serve --device metal --model StarCoder-1B --chat-model Qwen2-1.5B-Instruct
 ```
 
 The compute power of M1/M2 is limited and is likely to be sufficient only for individual usage. If you require a shared instance for a team, we recommend considering Docker hosting with CUDA or ROCm. You can find more information about Docker [here](../docker).
+
+If you want to host your server on a different port than the default 8080, supply the `--port` option. Run `tabby serve --help` to learn about all possible options.


### PR DESCRIPTION
I had another development server running on 8080 and wanted to change my TabbyML server port resolve a resulting collision.

I struggled a bit to find documentation on how to do this, landing here https://github.com/TabbyML/tabby/blob/ddbbafa17f4505f533f5fc348b87424b99e8c868/crates/tabby/src/serve.rs#L92 before I realized I could just ask for `--help` from the command.

I imagine more developers may already have something else running on 8080, so maybe this note here makes sense?