### PR TITLE
fix: Switching Between Tabby Chat Panel and Active Editor Using Ctrl + L

### DIFF
--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -21,6 +21,14 @@ export interface FetcherOptions {
 
 export interface InitRequest {
   fetcherOptions: FetcherOptions
+  focusKey: FocusKeybinding
+}
+export interface FocusKeybinding {
+  key: string
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  altKey: boolean
 }
 
 export interface ErrorMessage {
@@ -45,6 +53,7 @@ export interface ClientApi {
   refresh: () => Promise<void>
   onSubmitMessage?: (msg: string, relevantContext?: Context[]) => Promise<void>
   onApplyInEditor?: (content: string) => void
+  focusOnEditor: () => void
 }
 
 export interface ChatMessage {

--- a/clients/vscode/src/chat/ChatViewProvider.ts
+++ b/clients/vscode/src/chat/ChatViewProvider.ts
@@ -260,7 +260,6 @@ export class ChatViewProvider implements WebviewViewProvider {
           return;
         }
         case "keydown": {
-          getLogger().info("dd");
           if (
             typeof message.key === "string" &&
             message.key.toLowerCase() === "l" &&
@@ -272,7 +271,6 @@ export class ChatViewProvider implements WebviewViewProvider {
               commands.executeCommand("workbench.action.focusFirstEditorGroup");
             }
           }
-
           return;
         }
       }

--- a/clients/vscode/src/chat/chatPanel.ts
+++ b/clients/vscode/src/chat/chatPanel.ts
@@ -32,6 +32,7 @@ export function createClient(webview: WebviewView, api: ClientApi): ServerApi {
       refresh: api.refresh,
       onSubmitMessage: api.onSubmitMessage,
       onApplyInEditor: api.onApplyInEditor,
+      focusOnEditor: api.focusOnEditor,
     },
   });
 }

--- a/clients/vscode/src/util/KeyBindingParser.ts
+++ b/clients/vscode/src/util/KeyBindingParser.ts
@@ -1,0 +1,35 @@
+import { FocusKeybinding } from "tabby-chat-panel/index";
+
+export function parseKeybinding(keybinding: string): FocusKeybinding {
+  const keybindingParts = keybinding.toLowerCase().split("+");
+  const focusKeybinding: FocusKeybinding = {
+    key: "",
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+  };
+
+  keybindingParts.forEach((part) => {
+    switch (part) {
+      case "ctrl":
+      case "control":
+      case "cmd":
+      case "meta":
+        focusKeybinding.ctrlKey = true;
+        focusKeybinding.metaKey = true;
+        break;
+      case "shift":
+        focusKeybinding.shiftKey = true;
+        break;
+      case "alt":
+        focusKeybinding.altKey = true;
+        break;
+      default:
+        focusKeybinding.key = part;
+        break;
+    }
+  });
+
+  return focusKeybinding;
+}

--- a/clients/vscode/tsconfig.json
+++ b/clients/vscode/tsconfig.json
@@ -11,7 +11,8 @@
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": false,
     "noUnusedParameters": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
   "include": ["./src/"]
 }

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -137,6 +137,17 @@ export default function ChatPage() {
       } else if ((event.ctrlKey || event.metaKey) && event.code === 'KeyA') {
         document.execCommand('selectAll')
       }
+      const message = {
+        action: 'keydown',
+        key: event.key,
+        code: event.code,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey
+      }
+
+      parent.postMessage(message, '*')
     }
 
     window.addEventListener('keydown', onKeyDown)


### PR DESCRIPTION
This PR addresses issue #3032:

- [x] Shift focus from the chat panel to the active editor.
- [ ] When the chat panel is open, shifting focus from the active editor to the chat panel should focus on the chat panel inbox.

Demo for now
https://jam.dev/c/c40ad69e-da2a-4548-b9ba-3c9c7f88eed1