### PR TITLE
chore(answer): improve bullet prefix trimming in answer.rs

### DIFF
--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -314,15 +314,17 @@ Remember, based on the original question and related contexts, suggest three suc
             .expect("Failed to get content from chat completion");
         content
             .lines()
-            .map(remove_bullet_prefix)
+            .map(trim_bullet)
             .filter(|x| !x.is_empty())
             .collect()
     }
 }
 
-fn remove_bullet_prefix(s: &str) -> String {
+fn trim_bullet(s: &str) -> String {
+    let is_bullet = |c: char| c == '-' || c == '*' || c == '.' || c.is_numeric();
     s.trim()
-        .trim_start_matches(|c: char| c == '-' || c == '*' || c == '.' || c.is_numeric())
+        .trim_start_matches(is_bullet)
+        .trim_end_matches(is_bullet)
         .trim()
         .to_owned()
 }


### PR DESCRIPTION
<img width="985" alt="image" src="https://github.com/user-attachments/assets/bbc8e11c-7446-4c48-816c-36b03beb70dd">

Fix cases with bullet suffix.