### PR TITLE
fix(prompt-editor): remove Tailwind CSS imports from styles.css

### DIFF
--- a/ee/tabby-ui/components/prompt-editor/styles.css
+++ b/ee/tabby-ui/components/prompt-editor/styles.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .tiptap:first-child {
   @apply mt-0;
 }


### PR DESCRIPTION
Before:
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/7a9751fd-4137-45e4-b229-4d0cc52cf1ad">


After:

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/4da77c11-b9a0-4a77-8949-8e68a1edfab3">
