### PR TITLE
fix(llama-cpp-server): fix vulkan build by setting GGML_VULKAN

### DIFF
--- a/crates/llama-cpp-server/build.rs
+++ b/crates/llama-cpp-server/build.rs
@@ -57,7 +57,7 @@ fn main() {
         config.define("AMDGPU_TARGETS", amd_gpu_targets.join(";"));
     }
     if cfg!(feature = "vulkan") {
-        config.define("LLAMA_VULKAN", "ON");
+        config.define("GGML_VULKAN", "ON");
     }
 
     let out = config.build();


### PR DESCRIPTION
Similarly to #2835 the VULKAN flag was also renamed to GGML_VULKAN in llama.cpp. This fixes setting this flag inside llama-cpp-server.

This fixes #2810  