### PR TITLE
chore(webserver): tune user_groups related permissions

### DIFF
--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -690,11 +690,7 @@ type Query {
   threadMessages(threadId: ID!, after: String, before: String, first: Int, last: Int): MessageConnection!
   customWebDocuments(ids: [ID!], after: String, before: String, first: Int, last: Int): CustomDocumentConnection!
   presetWebDocuments(ids: [ID!], after: String, before: String, first: Int, last: Int, isActive: Boolean): PresetDocumentConnection!
-  """
-    List user groups.
-
-    When the requesting user is an admin, all user groups will be returned. Otherwise, they can only see groups they are a member of.
-  """
+  "List user groups."
   userGroups: [UserGroup!]!
   sourceIdAccessPolicies(sourceId: String!): SourceIdAccessPolicy!
 }

--- a/ee/tabby-schema/src/policy.rs
+++ b/ee/tabby-schema/src/policy.rs
@@ -1,4 +1,3 @@
-
 use juniper::ID;
 use tabby_db::DbConn;
 
@@ -132,10 +131,7 @@ impl AccessPolicy {
             "You are not allowed to modify group membership",
         ));
 
-        if !self
-            .is_user_group_admin(user_group_id, &self.user_id)
-            .await
-        {
+        if !self.is_user_group_admin(user_group_id, &self.user_id).await {
             return err;
         }
 

--- a/ee/tabby-schema/src/policy.rs
+++ b/ee/tabby-schema/src/policy.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
 use juniper::ID;
 use tabby_db::DbConn;
 
-use crate::{AsRowid, CoreError, Result};
+use crate::{user_group::UpsertUserGroupMembershipInput, AsRowid, CoreError, Result};
 
 #[derive(Clone)]
 pub struct AccessPolicy {
@@ -82,41 +84,80 @@ impl AccessPolicy {
         Ok(())
     }
 
-    pub async fn check_update_user_group_membership(&self, user_group_id: &ID) -> Result<()> {
-        if !self.is_admin /* Admin can change any user group membership */
-            && !self
-                .is_user_group_admin(user_group_id)
-                .await
-        /* User group admin can change membership within their group */
+    pub async fn check_upsert_user_group_membership(
+        &self,
+        input: &UpsertUserGroupMembershipInput,
+    ) -> Result<()> {
+        if self.is_admin {
+            return Ok(());
+        }
+
+        // User group admin can change membership within their group
+        if !self
+            .is_user_group_admin(&input.user_group_id, &self.user_id)
+            .await
         {
             return Err(CoreError::Forbidden(
                 "You are not allowed to update this user group membership",
             ));
         }
 
+        if input.is_group_admin {
+            return Err(CoreError::Forbidden(
+                "You are not allowed to grant group admin privileges",
+            ));
+        }
+
+        if self
+            .is_user_group_admin(&input.user_group_id, &input.user_id)
+            .await
+        {
+            return Err(CoreError::Forbidden(
+                "You are not allowed to modify group admin privileges",
+            ));
+        }
+
         Ok(())
     }
 
-    pub fn list_user_group_user_id_filter(&self) -> Option<&ID> {
+    pub async fn check_delete_user_group_membership(
+        &self,
+        user_group_id: &ID,
+        user_id: &ID,
+    ) -> Result<()> {
         if self.is_admin {
-            // Admin can list all user groups.
-            None
-        } else {
-            // Non-admin can only list user groups they are a member of.
-            Some(&self.user_id)
+            return Ok(());
         }
+
+        let err = Err(CoreError::Forbidden(
+            "You are not allowed to modify group membership",
+        ));
+
+        if !self
+            .is_user_group_admin(&user_group_id, &self.user_id)
+            .await
+        {
+            return err;
+        }
+
+        // Cannot remove admin from group
+        if self.is_user_group_admin(&user_group_id, &user_id).await {
+            return err;
+        }
+
+        Ok(())
     }
 
-    async fn is_user_group_admin(&self, user_group_id: &ID) -> bool {
-        self.is_user_group_admin_impl(user_group_id)
+    async fn is_user_group_admin(&self, user_group_id: &ID, user_id: &ID) -> bool {
+        self.is_user_group_admin_impl(user_group_id, user_id)
             .await
             .unwrap_or_default()
     }
 
-    async fn is_user_group_admin_impl(&self, user_group_id: &ID) -> Result<bool> {
+    async fn is_user_group_admin_impl(&self, user_group_id: &ID, user_id: &ID) -> Result<bool> {
         let x = self
             .db
-            .list_user_group_memberships(user_group_id.as_rowid()?, Some(self.user_id.as_rowid()?))
+            .list_user_group_memberships(user_group_id.as_rowid()?, Some(user_id.as_rowid()?))
             .await?;
         Ok(x.first().is_some_and(|x| x.is_group_admin))
     }

--- a/ee/tabby-schema/src/policy.rs
+++ b/ee/tabby-schema/src/policy.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 
 use juniper::ID;
 use tabby_db::DbConn;
@@ -134,14 +133,14 @@ impl AccessPolicy {
         ));
 
         if !self
-            .is_user_group_admin(&user_group_id, &self.user_id)
+            .is_user_group_admin(user_group_id, &self.user_id)
             .await
         {
             return err;
         }
 
         // Cannot remove admin from group
-        if self.is_user_group_admin(&user_group_id, &user_id).await {
+        if self.is_user_group_admin(user_group_id, user_id).await {
             return err;
         }
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -631,11 +631,9 @@ impl Query {
     }
 
     /// List user groups.
-    ///
-    /// When the requesting user is an admin, all user groups will be returned. Otherwise, they can only see groups they are a member of.
     async fn user_groups(ctx: &Context) -> Result<Vec<UserGroup>> {
-        let user = check_user(ctx).await?;
-        ctx.locator.user_group().list(&user.policy).await
+        check_user(ctx).await?;
+        ctx.locator.user_group().list().await
     }
 
     async fn source_id_access_policies(
@@ -1085,7 +1083,7 @@ impl Mutation {
     ) -> Result<bool> {
         let user = check_user(ctx).await?;
         user.policy
-            .check_update_user_group_membership(&input.user_group_id)
+            .check_upsert_user_group_membership(&input)
             .await?;
 
         input.validate()?;
@@ -1100,10 +1098,9 @@ impl Mutation {
     ) -> Result<bool> {
         let user = check_user(ctx).await?;
         user.policy
-            .check_update_user_group_membership(&user_group_id)
+            .check_delete_user_group_membership(&user_group_id, &user_id)
             .await?;
 
-        check_admin(ctx).await?;
         ctx.locator
             .user_group()
             .delete_membership(&user_group_id, &user_id)

--- a/ee/tabby-schema/src/schema/user_group.rs
+++ b/ee/tabby-schema/src/schema/user_group.rs
@@ -4,7 +4,7 @@ use juniper::{GraphQLInputObject, GraphQLObject, ID};
 use validator::Validate;
 
 use super::{interface::UserValue, Context};
-use crate::{policy::AccessPolicy, Result};
+use crate::Result;
 
 #[derive(GraphQLObject)]
 #[graphql(context = Context)]

--- a/ee/tabby-schema/src/schema/user_group.rs
+++ b/ee/tabby-schema/src/schema/user_group.rs
@@ -54,10 +54,7 @@ pub struct UpsertUserGroupMembershipInput {
 #[async_trait]
 pub trait UserGroupService: Send + Sync {
     // List user groups.
-    //
-    // * When user is admin, returns all user groups.
-    // * Otherwise, returns user groups that the user is a member of.
-    async fn list(&self, policy: &AccessPolicy) -> Result<Vec<UserGroup>>;
+    async fn list(&self) -> Result<Vec<UserGroup>>;
 
     async fn create(&self, input: &CreateUserGroupInput) -> Result<ID>;
     async fn delete(&self, user_group_id: &ID) -> Result<()>;

--- a/ee/tabby-webserver/src/service/mod.rs
+++ b/ee/tabby-webserver/src/service/mod.rs
@@ -426,6 +426,8 @@ impl UserGroupExt for UserGroup {
             });
         }
 
+        members.sort_by_key(|x| (!x.is_group_admin, x.updated_at));
+
         Ok(UserGroup {
             id: val.id.as_id(),
             name: val.name,

--- a/ee/tabby-webserver/src/service/user_group.rs
+++ b/ee/tabby-webserver/src/service/user_group.rs
@@ -75,10 +75,6 @@ mod tests {
         let user2 = testutils::create_user2(&db).await.as_id();
         let user3 = testutils::create_user3(&db).await.as_id();
 
-        let user1_policy = AccessPolicy::new(db.clone(), &user1, false);
-        let user2_policy = AccessPolicy::new(db.clone(), &user2, false);
-        let user3_policy = AccessPolicy::new(db.clone(), &user3, true);
-
         // Insert test user groups associated with the users
         let user_group1 = svc
             .create(&CreateUserGroupInput {
@@ -119,15 +115,15 @@ mod tests {
         .await
         .unwrap();
 
-        // Test listing user groups as user3 (global admin, returns all groups)
-        let result = svc.list(&user3_policy).await.unwrap();
+        // Test listing user groups as user3
+        let result = svc.list().await.unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, user_group1);
         assert_eq!(result[1].id, user_group2);
 
         // Test listing user groups as user1
-        let result = svc.list(&user1_policy).await.unwrap();
-        assert_eq!(result.len(), 1);
+        let result = svc.list().await.unwrap();
+        assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, user_group1);
         assert_eq!(result[0].members.len(), 2);
         assert_matches!(&result[0].members[0].user, UserValue::UserSecured(user) => {
@@ -138,7 +134,7 @@ mod tests {
         });
 
         // Test listing user groups as user2
-        let result = svc.list(&user2_policy).await.unwrap();
+        let result = svc.list().await.unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, user_group1);
         assert_eq!(result[1].id, user_group2);

--- a/ee/tabby-webserver/src/service/user_group.rs
+++ b/ee/tabby-webserver/src/service/user_group.rs
@@ -16,14 +16,9 @@ struct UserGroupServiceImpl {
 
 #[async_trait::async_trait]
 impl UserGroupService for UserGroupServiceImpl {
-    async fn list(&self, policy: &AccessPolicy) -> Result<Vec<UserGroup>> {
-        let user_id = policy
-            .list_user_group_user_id_filter()
-            .map(AsRowid::as_rowid)
-            .transpose()?;
-
+    async fn list(&self) -> Result<Vec<UserGroup>> {
         let mut user_groups = Vec::new();
-        for x in self.db.list_user_groups(user_id).await? {
+        for x in self.db.list_user_groups(None).await? {
             user_groups.push(UserGroup::new(self.db.clone(), x).await?);
         }
         Ok(user_groups)

--- a/ee/tabby-webserver/src/service/user_group.rs
+++ b/ee/tabby-webserver/src/service/user_group.rs
@@ -1,7 +1,6 @@
 use juniper::ID;
 use tabby_db::DbConn;
 use tabby_schema::{
-    policy::AccessPolicy,
     user_group::{
         CreateUserGroupInput, UpsertUserGroupMembershipInput, UserGroup, UserGroupService,
     },


### PR DESCRIPTION
1. Server admins have full control.
2. Group admins can add users but not modify admin privileges.
3. Group admins can remove non-admin users.
4. `user_groups` is now accessible to all users.
5. user_group.membership is now sorted (admin orders first)