### PR TITLE
feat: backup db before running migration SQLs

### DIFF
--- a/ee/tabby-db/src/lib.rs
+++ b/ee/tabby-db/src/lib.rs
@@ -175,7 +175,7 @@ impl DbConn {
 
         let today = Utc::now().date_naive().format("%Y%m%d").to_string();
         let backup_file = db_file.with_file_name(
-            db_file_name.replace(".sqlite", format!(".backup-{}.sqlite", today).as_str())
+            db_file_name.replace(".sqlite", format!(".backup-{}.sqlite", today).as_str()),
         );
 
         tokio::fs::copy(db_file, &backup_file).await?;


### PR DESCRIPTION
For closing https://github.com/TabbyML/tabby/issues/3023

The backup file following format of `[dev-]db.backup-${date}.sqlite`

Tested locally

<img width="533" alt="Screenshot 2024-09-14 122312" src="https://github.com/user-attachments/assets/882294d0-6e4a-4a96-a05e-716a0fe57820">
