### PR TITLE
fix(ui): handle Mutation response errors correctly

### DIFF
--- a/ee/tabby-ui/lib/tabby/gql.ts
+++ b/ee/tabby-ui/lib/tabby/gql.ts
@@ -101,6 +101,8 @@ function makeFormErrorHandler<T extends FieldValues>(form: UseFormReturn<T>) {
         }
       } else if (error?.originalError) {
         form.setError('root', error.originalError)
+      } else if (error?.message) {
+        form.setError('root', { message: error.message })
       }
     }
   }


### PR DESCRIPTION
https://github.com/urql-graphql/urql/blob/main/packages/core/src/utils/error.ts#L20-L25

In urql, an error with a `message` and `extensions` will not have the originalError field attached. Need to retrieve error information from the message field of the error

## Screen record
### Before
https://jam.dev/c/eb411cd1-73ba-4b72-a846-98c242820a1b
### After
https://jam.dev/c/06c91c8f-efe0-4d33-b854-dbe7346e6979
