### PR TITLE
fix(vscode): set postMessage origin to * to silence vscode cross orig…

### DIFF
--- a/clients/vscode/src/chat/WebviewHelper.ts
+++ b/clients/vscode/src/chat/WebviewHelper.ts
@@ -291,7 +291,7 @@ export class WebviewHelper {
                     }
 
                     if (event.data.data) {
-                      chatIframe.contentWindow.postMessage(event.data.data[0], "${endpoint}");
+                      chatIframe.contentWindow.postMessage(event.data.data[0], "*");
                     } else {
                       vscode.postMessage(event.data);
                     }


### PR DESCRIPTION
…in warning in certain version

<img width="894" alt="image" src="https://github.com/user-attachments/assets/86de7db6-a18b-48b9-b47b-ea656bf2fe47">
