### PR TITLE
chore(u): correct error message for expired thread

### DIFF
--- a/ee/tabby-ui/components/chat/chat.tsx
+++ b/ee/tabby-ui/components/chat/chat.tsx
@@ -511,7 +511,7 @@ function formatThreadRunErrorMessage(error: ExtendedCombinedError | undefined) {
   if (
     some(error.graphQLErrors, o => o.extensions?.code === ERROR_CODE_NOT_FOUND)
   ) {
-    return `The thread has expired, please click ${"'"}clear${"'"} and then retry.`
+    return `The thread has expired, please click ${"'"}Clear${"'"} and try again.`
   }
 
   return error.message || 'Failed to fetch'


### PR DESCRIPTION
## Screenshot
<img width="511" alt="image" src="https://github.com/user-attachments/assets/36d2300b-4072-4f4d-bca4-a830b2fd81d4">
