### PR TITLE
ci(intellij): add release actions.

### DIFF
--- a/.github/workflows/release-intellij.yml
+++ b/.github/workflows/release-intellij.yml
@@ -1,0 +1,140 @@
+name: Release Tabby Plugin for IntelliJ Platform
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "intellij@*"
+
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.ref_name }}
+
+  # If this is enabled it will cancel current running and start latest
+  cancel-in-progress: true
+
+jobs:
+  release-marketplace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Determine Publish Channel
+        env:
+          VERSION_STRING:
+        run: |
+          if [[ ${{ github.ref_name }} =~ intellij@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "PUBLISH_CHANNEL=stable" >> $GITHUB_ENV
+          else
+            echo "PUBLISH_CHANNEL=alpha" >> $GITHUB_ENV
+          fi
+
+      - name: Check Publish Channel
+        run: echo "Publish Channel is ${{ env.PUBLISH_CHANNEL }}"
+
+      - name: Publish Plugin to Marketplace
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.INTELLIJ_PLUGIN_CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.INTELLIJ_PLUGIN_PRIVATE_KEY }}
+          PUBLISH_TOKEN: ${{ secrets.INTELLIJ_PLUGIN_PUBLISH_TOKEN }}
+          PUBLISH_CHANNEL: ${{ env.PUBLISH_CHANNEL }}
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          arguments: publishPlugin
+          build-root-directory: clients/intellij
+
+  release-github:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Signed Plugin
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.INTELLIJ_PLUGIN_CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.INTELLIJ_PLUGIN_PRIVATE_KEY }}
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          arguments: signPlugin
+          build-root-directory: clients/intellij
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          prerelease: true
+          tag: ${{ github.ref_name }}
+          removeArtifacts: true
+          artifacts: "clients/intellij/build/distributions/intellij-tabby-signed.zip"

--- a/.github/workflows/test-intellij.yml
+++ b/.github/workflows/test-intellij.yml
@@ -17,11 +17,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CERTIFICATE_CHAIN: ${{ secrets.INTELLIJ_PLUGIN_CERTIFICATE_CHAIN }}
-      PRIVATE_KEY: ${{ secrets.INTELLIJ_PLUGIN_PRIVATE_KEY }}
-      PRIVATE_KEY_PASSWORD: ${{ secrets.INTELLIJ_PLUGIN_PRIVATE_KEY_PASSWORD }}
-    
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,8 +34,8 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 9
           run_install: false
@@ -50,8 +45,8 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -66,11 +61,3 @@ jobs:
         with:
           arguments: buildPlugin
           build-root-directory: clients/intellij
-          
-      - name: Upload Plugin
-        uses: actions/upload-artifact@v4
-        with:
-          retention-days: 1
-          name: artifacts
-          path: |
-            clients/intellij/build/distributions/intellij-tabby.zip

--- a/clients/intellij/build.gradle.kts
+++ b/clients/intellij/build.gradle.kts
@@ -59,7 +59,6 @@ tasks {
     signing {
       certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
       privateKey.set(System.getenv("PRIVATE_KEY"))
-      password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
     }
     publishing {
       token.set(System.getenv("PUBLISH_TOKEN"))


### PR DESCRIPTION
This PR create a workflow for release Tabby Plugin for IntelliJ Platform, which will be triggered on tag `intellij@*`.  
The workflow contains two jobs:
- `release-marketplace`: run `publishPlugin` task to upload zip to marketplace
- `release-github`: build and upload zip to create a github release