### PR TITLE
feat(eclipse): support partially accept inline completion.

### DIFF
--- a/clients/eclipse/feature/feature.xml
+++ b/clients/eclipse/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.tabbyml.features.tabby4eclipse"
       label="Tabby"
-      version="0.0.2.25"
+      version="0.0.2.26"
       provider-name="com.tabbyml">
 
    <description url="http://www.example.com/description">
@@ -19,6 +19,6 @@
 
    <plugin
          id="com.tabbyml.tabby4eclipse"
-         version="0.0.2.25"/>
+         version="0.0.2.26"/>
 
 </feature>

--- a/clients/eclipse/plugin/META-INF/MANIFEST.MF
+++ b/clients/eclipse/plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tabby Plugin for Eclipse
 Bundle-SymbolicName: com.tabbyml.tabby4eclipse;singleton:=true
-Bundle-Version: 0.0.2.25
+Bundle-Version: 0.0.2.26
 Bundle-Activator: com.tabbyml.tabby4eclipse.Activator
 Bundle-Vendor: com.tabbyml
 Require-Bundle: org.eclipse.ui,

--- a/clients/eclipse/plugin/plugin.xml
+++ b/clients/eclipse/plugin/plugin.xml
@@ -132,6 +132,16 @@
 		</command>
 		<command
 			categoryId="com.tabbyml.tabby4eclipse.commands.inlineCompletion"
+			name="Accept Next Line of Inline Completion"
+			id="com.tabbyml.tabby4eclipse.commands.inlineCompletion.acceptNextLine">
+		</command>
+		<command
+			categoryId="com.tabbyml.tabby4eclipse.commands.inlineCompletion"
+			name="Accept Next Word of Inline Completion"
+			id="com.tabbyml.tabby4eclipse.commands.inlineCompletion.acceptNextWord">
+		</command>
+		<command
+			categoryId="com.tabbyml.tabby4eclipse.commands.inlineCompletion"
 			name="Dismiss Inline Completion"
 			id="com.tabbyml.tabby4eclipse.commands.inlineCompletion.dismiss">
 		</command>
@@ -204,6 +214,14 @@
 			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.accept">
 		</handler>
 		<handler
+			class="com.tabbyml.tabby4eclipse.commands.inlineCompletion.AcceptNextLine"
+			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.acceptNextLine">
+		</handler>
+		<handler
+			class="com.tabbyml.tabby4eclipse.commands.inlineCompletion.AcceptNextWord"
+			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.acceptNextWord">
+		</handler>
+		<handler
 			class="com.tabbyml.tabby4eclipse.commands.inlineCompletion.Dismiss"
 			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.dismiss">
 		</handler>
@@ -241,6 +259,15 @@
 		</handler>
 	</extension>
 
+	<extension point="org.eclipse.ui.contexts">
+		<context
+			id="com.tabbyml.tabby4eclipse.inlineCompletionVisible"
+			name="Inline Completion Visible"
+			description="Tabby inline completion is visible."
+			parentId="org.eclipse.ui.textEditorScope">
+		</context>
+	</extension>
+
 	<extension point="org.eclipse.ui.bindings">
 		<key
 			commandId="com.tabbyml.tabby4eclipse.commands.chat.toggleChatView"
@@ -256,25 +283,37 @@
 		</key>
 		<key
 			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.previous"
-			contextId="org.eclipse.ui.textEditorScope"
+			contextId="com.tabbyml.tabby4eclipse.inlineCompletionVisible"
 			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
 			sequence="M3+[">
 		</key>
 		<key
 			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.next"
-			contextId="org.eclipse.ui.textEditorScope"
+			contextId="com.tabbyml.tabby4eclipse.inlineCompletionVisible"
 			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
 			sequence="M3+]">
 		</key>
 		<key
 			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.accept"
-			contextId="org.eclipse.ui.textEditorScope"
+			contextId="com.tabbyml.tabby4eclipse.inlineCompletionVisible"
 			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
 			sequence="TAB">
 		</key>
 		<key
+			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.acceptNextLine"
+			contextId="com.tabbyml.tabby4eclipse.inlineCompletionVisible"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+			sequence="M1+TAB">
+		</key>
+		<key
+			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.acceptNextWord"
+			contextId="com.tabbyml.tabby4eclipse.inlineCompletionVisible"
+			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+			sequence="M1+ARROW_RIGHT">
+		</key>
+		<key
 			commandId="com.tabbyml.tabby4eclipse.commands.inlineCompletion.dismiss"
-			contextId="org.eclipse.ui.textEditorScope"
+			contextId="com.tabbyml.tabby4eclipse.inlineCompletionVisible"
 			schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
 			sequence="ESC">
 		</key>

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/commands/inlineCompletion/AcceptNextLine.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/commands/inlineCompletion/AcceptNextLine.java
@@ -8,13 +8,13 @@ import com.tabbyml.tabby4eclipse.Logger;
 import com.tabbyml.tabby4eclipse.inlineCompletion.IInlineCompletionService.AcceptType;
 import com.tabbyml.tabby4eclipse.inlineCompletion.InlineCompletionService;
 
-public class Accept extends AbstractHandler {
-	private Logger logger = new Logger("Commands.InlineCompletion.Accept");
+public class AcceptNextLine extends AbstractHandler {
+	private Logger logger = new Logger("Commands.InlineCompletion.AcceptNextLine");
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		logger.debug("Accept the current inline completion.");
-		InlineCompletionService.getInstance().accept(AcceptType.FULL_COMPLETION);
+		logger.debug("Accept next line of the current inline completion.");
+		InlineCompletionService.getInstance().accept(AcceptType.NEXT_LINE);
 		return null;
 	}
 

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/commands/inlineCompletion/AcceptNextWord.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/commands/inlineCompletion/AcceptNextWord.java
@@ -8,13 +8,13 @@ import com.tabbyml.tabby4eclipse.Logger;
 import com.tabbyml.tabby4eclipse.inlineCompletion.IInlineCompletionService.AcceptType;
 import com.tabbyml.tabby4eclipse.inlineCompletion.InlineCompletionService;
 
-public class Accept extends AbstractHandler {
-	private Logger logger = new Logger("Commands.InlineCompletion.Accept");
+public class AcceptNextWord extends AbstractHandler {
+	private Logger logger = new Logger("Commands.InlineCompletion.AcceptNextLine");
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		logger.debug("Accept the current inline completion.");
-		InlineCompletionService.getInstance().accept(AcceptType.FULL_COMPLETION);
+		logger.debug("Accept next word of the current inline completion.");
+		InlineCompletionService.getInstance().accept(AcceptType.NEXT_WORD);
 		return null;
 	}
 

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/editor/EditorUtils.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/editor/EditorUtils.java
@@ -17,6 +17,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import com.tabbyml.tabby4eclipse.chat.ChatMessage.FileContext;
@@ -65,6 +66,10 @@ public class EditorUtils {
 
 	public static Display getDisplay(ITextEditor textEditor) {
 		return getStyledTextWidget(textEditor).getDisplay();
+	}
+
+	public static IContextService getContextService(ITextEditor textEditor) {
+		return textEditor.getSite().getService(IContextService.class);
 	}
 
 	public static void asyncExec(Runnable runnable) {
@@ -127,7 +132,7 @@ public class EditorUtils {
 			throw new IllegalStateException("Failed to get current offset in document.");
 		});
 	}
-	
+
 	public static String getSelectedText() {
 		ITextEditor editor = getActiveTextEditor();
 		if (editor != null) {
@@ -135,7 +140,7 @@ public class EditorUtils {
 		}
 		return null;
 	}
-	
+
 	public static String getSelectedText(ITextEditor textEditor) {
 		ISelection selection = textEditor.getSelectionProvider().getSelection();
 		if (selection instanceof ITextSelection textSelection) {

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/inlineCompletion/IInlineCompletionService.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/inlineCompletion/IInlineCompletionService.java
@@ -42,10 +42,16 @@ public interface IInlineCompletionService {
 	 */
 	public void previous();
 
+	enum AcceptType {
+		FULL_COMPLETION, NEXT_LINE, NEXT_WORD,
+	}
+
 	/**
 	 * Accept the current completion item ghost text.
+	 * 
+	 * @param type the type of completion to accept.
 	 */
-	public void accept();
+	public void accept(AcceptType type);
 
 	/**
 	 * Dismiss the current completion item ghost text.

--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/inlineCompletion/InlineCompletionService.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/inlineCompletion/InlineCompletionService.java
@@ -3,6 +3,8 @@ package com.tabbyml.tabby4eclipse.inlineCompletion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -12,6 +14,8 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.ui.contexts.IContextActivation;
+import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 import com.tabbyml.tabby4eclipse.Logger;
@@ -34,9 +38,12 @@ public class InlineCompletionService implements IInlineCompletionService {
 		private static final IInlineCompletionService INSTANCE = new InlineCompletionService();
 	}
 
+	private static final String INLINE_COMPLETION_VISIBLE_CONTEXT_ID = "com.tabbyml.tabby4eclipse.inlineCompletionVisible";
+
 	private Logger logger = new Logger("InlineCompletionService");
 	private InlineCompletionRenderer renderer = new InlineCompletionRenderer();
 	private InlineCompletionContext current;
+	private IContextActivation inlineCompletionVisibleContext;
 
 	@Override
 	public boolean isCompletionItemVisible() {
@@ -76,6 +83,7 @@ public class InlineCompletionService implements IInlineCompletionService {
 		logger.info("Provide inline completion for TextEditor " + textEditor.getTitle() + " at offset " + offset
 				+ " with modification stamp " + modificationStamp);
 		renderer.hide();
+		deactivateInlineCompletionVisibleContext(textEditor);
 		if (current != null) {
 			if (current.job != null && !current.job.isDone()) {
 				logger.info("Cancel the current job due to new request.");
@@ -105,6 +113,7 @@ public class InlineCompletionService implements IInlineCompletionService {
 				InlineCompletionList list = request.convertInlineCompletionList(completionList);
 				current.response = new InlineCompletionContext.Response(list);
 				renderer.show(textViewer, current.response.getActiveCompletionItem());
+				activateInlineCompletionVisibleContext(textEditor);
 				EventParams eventParams = buildTelemetryEventParams(EventParams.Type.VIEW);
 				postTelemetryEvent(eventParams);
 			} catch (BadLocationException e) {
@@ -191,7 +200,7 @@ public class InlineCompletionService implements IInlineCompletionService {
 	}
 
 	@Override
-	public void accept() {
+	public void accept(AcceptType acceptType) {
 		ITextEditor textEditor = EditorUtils.getActiveTextEditor();
 		logger.info("Accept inline completion in TextEditor " + textEditor.toString());
 		if (current == null || current.request == null || current.response == null) {
@@ -199,23 +208,47 @@ public class InlineCompletionService implements IInlineCompletionService {
 		}
 		int offset = current.request.offset;
 		InlineCompletionItem item = current.response.getActiveCompletionItem();
-		EventParams eventParams = buildTelemetryEventParams(EventParams.Type.SELECT);
+		EventParams eventParams = buildTelemetryEventParams(EventParams.Type.SELECT,
+				acceptType == AcceptType.FULL_COMPLETION ? null : "line");
 
 		renderer.hide();
+		deactivateInlineCompletionVisibleContext(textEditor);
 		current = null;
 
 		int prefixReplaceLength = item.getReplaceRange().getPrefixLength();
 		int suffixReplaceLength = item.getReplaceRange().getSuffixLength();
 		String text = item.getInsertText().substring(prefixReplaceLength);
-		if (text.isEmpty()) {
+		String textToInsert;
+
+		if (acceptType == AcceptType.NEXT_WORD) {
+			Pattern pattern = Pattern.compile("\\w+|\\W+");
+			Matcher matcher = pattern.matcher(text);
+			if (matcher.find()) {
+				textToInsert = matcher.group();
+			} else {
+				textToInsert = text;
+			}
+		} else if (acceptType == AcceptType.NEXT_LINE) {
+			List<String> lines = List.of(text.split("\n"));
+			String line = lines.get(0);
+			if (text.isEmpty() && lines.size() > 1) {
+				line += "\n";
+				line += lines.get(1);
+			}
+			textToInsert = line;
+		} else {
+			textToInsert = text;
+		}
+
+		if (textToInsert.isEmpty()) {
 			return;
 		}
 
 		IDocument document = EditorUtils.getDocument(textEditor);
 		EditorUtils.syncExec(textEditor, () -> {
 			try {
-				document.replace(offset, suffixReplaceLength, text);
-				ITextSelection selection = new TextSelection(offset + text.length(), 0);
+				document.replace(offset, suffixReplaceLength, textToInsert);
+				ITextSelection selection = new TextSelection(offset + textToInsert.length(), 0);
 				textEditor.getSelectionProvider().setSelection(selection);
 				postTelemetryEvent(eventParams);
 			} catch (BadLocationException e) {
@@ -230,6 +263,8 @@ public class InlineCompletionService implements IInlineCompletionService {
 			logger.info("Dismiss inline completion.");
 			EventParams eventParams = buildTelemetryEventParams(EventParams.Type.DISMISS);
 			renderer.hide();
+			ITextEditor textEditor = EditorUtils.getActiveTextEditor();
+			deactivateInlineCompletionVisibleContext(textEditor);
 			postTelemetryEvent(eventParams);
 		}
 		if (current != null) {
@@ -266,6 +301,22 @@ public class InlineCompletionService implements IInlineCompletionService {
 				telemetryService.event(params);
 				return null;
 			});
+		}
+	}
+
+	private void activateInlineCompletionVisibleContext(ITextEditor editor) {
+		IContextService contextService = EditorUtils.getContextService(editor);
+		if (contextService != null) {
+			logger.debug("Activating inline completion visible context.");
+			inlineCompletionVisibleContext = contextService.activateContext(INLINE_COMPLETION_VISIBLE_CONTEXT_ID);
+		}
+	}
+
+	private void deactivateInlineCompletionVisibleContext(ITextEditor editor) {
+		IContextService contextService = EditorUtils.getContextService(editor);
+		if (contextService != null && inlineCompletionVisibleContext != null) {
+			logger.debug("Deactivating inline completion visible context.");
+			contextService.deactivateContext(inlineCompletionVisibleContext);
 		}
 	}
 


### PR DESCRIPTION
Changes:
- Support using `Ctrl+Right` to accept next word of completion and using `Ctrl+Tab` to accept next line of completion.