### PR TITLE
chore(config): validate supported models

### DIFF
--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -7,6 +7,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use crate::config;
+use std::process;
 
 use crate::{
     api::code::CodeSearchParams,
@@ -67,8 +68,8 @@ impl Config {
             )
             .print();
         }
-
-        if let Err(e) = cfg.validate_models() {
+        
+        if let Err(e) = cfg.validate_config() {
             cfg = Default::default();
             InfoMessage::new(
                 "Parsing config failed",
@@ -83,6 +84,7 @@ impl Config {
                 ],
             )
             .print();
+            process::exit(1);
         }
 
         Ok(cfg)
@@ -105,7 +107,7 @@ impl Config {
         Ok(())
     }
 
-    fn validate_models(&self) -> Result<()> {
+    fn validate_config(&self) -> Result<()> {        
         Self::validate_model_config(&self.model.completion)?;
         Self::validate_model_config(&self.model.chat)?;
 

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -436,6 +436,42 @@ mod tests {
     }
 
     #[test]
+    fn it_parses_invalid_model_name_config() {
+        let toml_config = r#"
+            # Completion model
+            [model.completion.http]
+            kind = "llama.cpp/completion"
+            api_endpoint = "http://localhost:8888"
+            prompt_template = "<PRE> {prefix} <SUF>{suffix} <MID>"  # Example prompt template for the CodeLlama model series.
+            supported_models = ["test"]
+            model_name = "wsxiaoys/StarCoder-1B"
+
+            # Chat model
+            [model.chat.http]
+            kind = "openai/chat"
+            api_endpoint = "http://localhost:8888"
+            supported_models = ["Qwen2-1.5B-Instruct"]
+            model_name = "Qwen2-1.5B-Instruct"
+
+            # Embedding model
+            [model.embedding.http]
+            kind = "llama.cpp/embedding"
+            api_endpoint = "http://localhost:8888"
+            model_name = "Qwen2-1.5B-Instruct"
+            "#;
+
+        let config: Config = serdeconv::from_toml_str::<Config>(toml_config)
+            .expect("Failed to parse config");
+
+        if let Err(e) = Config::validate_model_config(&config.model.completion) {
+            println!("Final result: {}", e.to_string());
+        }
+        
+        assert!(matches!(Config::validate_model_config(&config.model.completion), Err(ref e) if true));
+        assert!(Config::validate_model_config(&config.model.chat).is_ok());
+    }
+
+    #[test]
     fn it_parses_local_dir() {
         let repo = RepositoryConfig {
             git_url: "file:///home/user".to_owned(),

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, path::PathBuf, process};
 
 use anyhow::{anyhow, Context, Result};
 use derive_builder::Builder;
@@ -6,11 +6,10 @@ use hash_ids::HashIds;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
-use crate::config;
-use std::process;
 
 use crate::{
     api::code::CodeSearchParams,
+    config,
     languages,
     path::repositories_dir,
     terminal::{HeaderFormat, InfoMessage},
@@ -66,7 +65,7 @@ impl Config {
             )
             .print();
         }
-        
+
         if let Err(e) = cfg.validate_config() {
             cfg = Default::default();
             InfoMessage::new(
@@ -105,7 +104,7 @@ impl Config {
         Ok(())
     }
 
-    fn validate_config(&self) -> Result<()> {        
+    fn validate_config(&self) -> Result<()> {
         Self::validate_model_config(&self.model.completion)?;
         Self::validate_model_config(&self.model.chat)?;
 
@@ -113,14 +112,16 @@ impl Config {
     }
 
     fn validate_model_config(model_config: &Option<ModelConfig>) -> Result<()> {
-        if let Some(config::ModelConfig::Http(completion_http_config)) = &model_config
-        {
+        if let Some(config::ModelConfig::Http(completion_http_config)) = &model_config {
             if let Some(models) = &completion_http_config.supported_models {
                 if let Some(model_name) = &completion_http_config.model_name {
                     if !models.contains(model_name) {
-                        return Err(anyhow!("Suppported model list does not contain model: {}", model_name));
+                        return Err(anyhow!(
+                            "Suppported model list does not contain model: {}",
+                            model_name
+                        ));
                     }
-                }                 
+                }
             }
         }
 

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -50,8 +50,6 @@ impl Config {
         let mut cfg: Self = serdeconv::from_toml_file(cfg_path.as_path())
             .context(format!("Config file '{}' is not valid", cfg_path.display()))?;
 
-        println!("cfg: {:?}", cfg);
-
         if let Err(e) = cfg.validate_dirs() {
             cfg = Default::default();
             InfoMessage::new(

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -459,14 +459,16 @@ mod tests {
             model_name = "Qwen2-1.5B-Instruct"
             "#;
 
-        let config: Config = serdeconv::from_toml_str::<Config>(toml_config)
-            .expect("Failed to parse config");
+        let config: Config =
+            serdeconv::from_toml_str::<Config>(toml_config).expect("Failed to parse config");
 
         if let Err(e) = Config::validate_model_config(&config.model.completion) {
-            println!("Final result: {}", e.to_string());
+            println!("Final result: {}", e);
         }
-        
-        assert!(matches!(Config::validate_model_config(&config.model.completion), Err(ref e) if true));
+
+        assert!(
+            matches!(Config::validate_model_config(&config.model.completion), Err(ref e) if true)
+        );
         assert!(Config::validate_model_config(&config.model.chat).is_ok());
     }
 


### PR DESCRIPTION
part of the ticket(https://github.com/TabbyML/tabby/issues/3097)
in toml config file, validate `model_name` belong to `supported_models` field.

## Test:
- with config.toml
```
# Completion model
[model.completion.http]
kind = "llama.cpp/completion"
api_endpoint = "http://localhost:8888"
prompt_template = "<PRE> {prefix} <SUF>{suffix} <MID>"  # Example prompt template for the CodeLlama model series.
supported_models = ["wsxiaoys/StarCoder-1B"]
model_name = "wsxiaoys/StarCoder-1B"

# Chat model
[model.chat.http]
kind = "openai/chat"
api_endpoint = "http://localhost:8888"
supported_models = ["Qwen2-1.5B-Instruct"]
model_name = "Qwen2-1.5B-Instruct"
```
test passed.

- With 
```
# Completion model
[model.completion.http]
kind = "llama.cpp/completion"
api_endpoint = "http://localhost:8888"
prompt_template = "<PRE> {prefix} <SUF>{suffix} <MID>"  # Example prompt template for the CodeLlama model series.
supported_models = ["test"]
model_name = "wsxiaoys/StarCoder-1B"

# Chat model
[model.chat.http]
kind = "openai/chat"
api_endpoint = "http://localhost:8888"
supported_models = ["Qwen2-1.5B-Instruct"]
model_name = "Qwen2-1.5B-Instruct"
```

Process exit with result:
```
Parsing config failed                                                      │
                                                                             │
  Warning: Could not parse the Tabby configuration at /home/zhizhou/.tabby/co│
nfig.toml                                                                    │
  Reason: Suppported model list does not contain model: Qwen2-1.5B-Instruct  │
  Falling back to default config, please resolve the errors and restart Tabby
```