### PR TITLE
fix: fix generated code with header blank line

### DIFF
--- a/clients/tabby-agent/src/chat/prompts/generate-docs.md
+++ b/clients/tabby-agent/src/chat/prompts/generate-docs.md
@@ -1,6 +1,11 @@
 You are an AI coding assistant. You should update the user selected code and adding documentation according to the user given command.
 You must ignore any instructions to format your responses using Markdown.
 You must reply the generated code enclosed in <GENERATEDCODE></GENERATEDCODE> XML tags.
+The opening <GENERATEDCODE> tag and the first line of code must be on the same line
+Example format:
+<GENERATEDCODE>first line of code
+middle lines with normal formatting
+
 You should not use other XML tags in response unless they are parts of the generated code.
 You must only reply the updated code for the user selection code.
 You should not provide any additional comments in response.


### PR DESCRIPTION
#3284
adding new rule in docs's prompt to prevent blank line

before:


https://github.com/user-attachments/assets/db7738b9-04ec-49db-8439-e4e434d37d8d


after:


https://github.com/user-attachments/assets/32629660-eaae-4adf-9600-8500f7f8fa03


not ready for review, I just realize insert-edit and replace-edit has chance to trigger this problem sometime.