### PR TITLE
chore(completion): replace CRLF with LF for code completion LLM requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5001,6 +5001,7 @@ dependencies = [
  "llama-cpp-server",
  "nvml-wrapper",
  "openssl",
+ "regex",
  "reqwest",
  "reqwest-eventsource",
  "serde",

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -56,6 +56,7 @@ color-eyre = { version = "0.6.3" }
 reqwest.workspace = true
 async-openai.workspace = true
 spinners = "4.1.1"
+regex.workspace = true
 
 [dependencies.openssl]
 optional = true

--- a/crates/tabby/src/routes/completions.rs
+++ b/crates/tabby/src/routes/completions.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
-use axum::{extract::State, Extension, Json};
+use async_openai::types::Choice;
+use axum::{extract::State, http::request, Extension, Json};
 use axum_extra::{headers, TypedHeader};
 use hyper::StatusCode;
 use tabby_common::axum::{AllowedCodeRepository, MaybeUser};
+use tantivy::Segment;
 use tracing::{instrument, warn};
 
 use crate::services::completion::{CompletionRequest, CompletionResponse, CompletionService};
@@ -36,11 +38,38 @@ pub async fn completions(
 
     let user_agent = user_agent.map(|x| x.0.to_string());
 
+    let mut use_crlf = false;
+    if let Some(segments) = request.segments {
+        let mut new_segments = segments.clone();
+        if segments.prefix.contains("\r\n") {
+            use_crlf = true;
+            new_segments.prefix = segments.prefix.replace("\r\n", "\n");
+        }
+        if let Some(suffix) = segments.suffix {
+            if suffix.contains("\r\n") {
+                use_crlf = true;
+                new_segments.suffix = Some(suffix.replace("\r\n", "\n"));
+            }
+        }
+        request.segments = Some(new_segments);
+    }
+
     match state
         .generate(&request, &allowed_code_repository, user_agent.as_deref())
         .await
     {
-        Ok(resp) => Ok(Json(resp)),
+        Ok(resp) => {
+            if use_crlf {
+                let mut response_crlf = resp.clone();
+                for (index, choice) in resp.choices.iter().enumerate() {
+                    response_crlf.choices[index].text = choice.text.replace("\n", "\r\n");
+                }
+
+                return Ok(Json(response_crlf));
+            }
+
+            Ok(Json(resp))
+        }
         Err(err) => {
             warn!("{}", err);
             Err(StatusCode::BAD_REQUEST)

--- a/crates/tabby/src/routes/completions.rs
+++ b/crates/tabby/src/routes/completions.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
-use async_openai::types::Choice;
-use axum::{extract::State, http::request, Extension, Json};
+use axum::{extract::State, Extension, Json};
 use axum_extra::{headers, TypedHeader};
 use hyper::StatusCode;
 use tabby_common::axum::{AllowedCodeRepository, MaybeUser};
-use tantivy::Segment;
 use tracing::{instrument, warn};
 
 use crate::services::completion::{CompletionRequest, CompletionResponse, CompletionService};

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -1,8 +1,8 @@
 mod completion_prompt;
 
-use regex::Regex;
 use std::sync::Arc;
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tabby_common::{
     api::{

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -338,7 +338,7 @@ impl CompletionService {
             let snippets = self
                 .build_snippets(
                     &language,
-                    &segments,
+                    segments,
                     allowed_code_repository,
                     request.disable_retrieval_augmented_code_completion(),
                 )

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -42,7 +42,7 @@ pub struct CompletionRequest {
     language: Option<String>,
 
     /// When segments are set, the `prompt` is ignored during the inference.
-    segments: Option<Segments>,
+    pub segments: Option<Segments>,
 
     /// A unique identifier representing your end-user, which can help Tabby to monitor & generating
     /// reports.
@@ -105,10 +105,10 @@ fn default_false() -> bool {
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct Segments {
     /// Content that appears before the cursor in the editor window.
-    prefix: String,
+    pub prefix: String,
 
     /// Content that appears after the cursor in the editor window.
-    suffix: Option<String>,
+    pub suffix: Option<String>,
 
     /// The relative path of the file that is being edited.
     /// - When [Segments::git_url] is set, this is the path of the file in the git repository.
@@ -191,7 +191,7 @@ impl From<Declaration> for api::event::Declaration {
 #[derive(Serialize, Deserialize, ToSchema, Clone, Debug)]
 pub struct Choice {
     index: u32,
-    text: String,
+    pub text: String,
 }
 
 impl Choice {
@@ -214,7 +214,7 @@ pub struct Snippet {
 }))]
 pub struct CompletionResponse {
     id: String,
-    choices: Vec<Choice>,
+    pub choices: Vec<Choice>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     debug_data: Option<DebugData>,


### PR DESCRIPTION
fix https://github.com/TabbyML/tabby/issues/3279

## Test

test model: CodeLlama-7B

Tabby command:

```sh
tabby serve --model CodeLlama-7B --device metal --chat-model zwpaper/Qwen2.5-Coder-7B-Instruct
```

test command:

```sh
curl -X 'POST' \
    'http://localhost:8080/v1/completions' \
    -H 'accept: application/json' \
    -H 'Content-Type: application/json' \
    -H 'Authorization: Bearer TOKEN' \
    -d '{
        "language": "java",
        "segments": {
          "prefix": "class MathUtils {\r\n    static double clamp(double value, double min, double max) {\r\n        return math.max(min, math.min(max, value));\r\n    }\r\n\r\n    static double lerp(double a, double b, double t) {\r\n        return a + (b - a) * t;\r\n    }\r\n    \r\n    static int fibonacci(int n) {\r\n        ",
          "suffix": "\r\n    }\r\n}"
        }
     }'
```

## Before
![CleanShot 2024-10-22 at 18 31 25@2x](https://github.com/user-attachments/assets/01072e5f-91b3-458e-8730-027d80db3fbc)

## After
![CleanShot 2024-10-23 at 15 31 00@2x](https://github.com/user-attachments/assets/a68c7664-9ec2-4698-9094-3a4b070b5f2c)