### PR TITLE
feat(graphQL): add model check for chat, completion, embedding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5211,6 +5211,7 @@ name = "tabby-schema"
 version = "0.19.0-dev.0"
 dependencies = [
  "anyhow",
+ "async-openai",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -5224,6 +5225,7 @@ dependencies = [
  "strum 0.24.1",
  "tabby-common",
  "tabby-db",
+ "tabby-inference",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -167,7 +167,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
     ));
 
     let model = &config.model;
-    let (completion, chat) = create_completion_service_and_chat(
+    let (completion, code_generate, chat) = create_completion_service_and_chat(
         &config.completion,
         code.clone(),
         logger.clone(),
@@ -193,9 +193,16 @@ pub async fn main(config: &Config, args: &ServeArgs) {
     #[cfg(feature = "ee")]
     if let Some(ws) = &ws {
         let (new_api, new_ui) = ws
-            .attach(&config, api, ui, code, chat, docsearch, |x| {
-                Box::new(services::doc::create_serper(x))
-            })
+            .attach(
+                &config,
+                api,
+                ui,
+                code,
+                chat,
+                code_generate,
+                docsearch,
+                |x| Box::new(services::doc::create_serper(x)),
+            )
             .await;
         api = new_api;
         ui = new_ui;

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -167,7 +167,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
     ));
 
     let model = &config.model;
-    let (completion, code_generate, chat) = create_completion_service_and_chat(
+    let (completion, completion_stream, chat) = create_completion_service_and_chat(
         &config.completion,
         code.clone(),
         logger.clone(),
@@ -199,7 +199,7 @@ pub async fn main(config: &Config, args: &ServeArgs) {
                 ui,
                 code,
                 chat,
-                code_generate,
+                completion_stream,
                 docsearch,
                 |x| Box::new(services::doc::create_serper(x)),
             )

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -16,6 +16,7 @@ use tabby_common::{
 };
 use tabby_inference::{
     ChatCompletionStream, CodeGeneration, CodeGenerationOptions, CodeGenerationOptionsBuilder,
+    CompletionStream,
 };
 use thiserror::Error;
 use utoipa::ToSchema;
@@ -424,10 +425,10 @@ pub async fn create_completion_service_and_chat(
     chat: Option<ModelConfig>,
 ) -> (
     Option<CompletionService>,
-    Option<Arc<CodeGeneration>>,
+    Option<Arc<dyn CompletionStream>>,
     Option<Arc<dyn ChatCompletionStream>>,
 ) {
-    let (code_generation, prompt, chat) =
+    let (code_generation, completion_stream, chat, prompt) =
         model::load_code_generation_and_chat(completion, chat).await;
 
     let completion = code_generation.clone().map(|code_generation| {
@@ -442,7 +443,7 @@ pub async fn create_completion_service_and_chat(
         )
     });
 
-    (completion, code_generation, chat)
+    (completion, completion_stream, chat)
 }
 
 #[cfg(test)]

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -424,12 +424,13 @@ pub async fn create_completion_service_and_chat(
     chat: Option<ModelConfig>,
 ) -> (
     Option<CompletionService>,
+    Option<Arc<CodeGeneration>>,
     Option<Arc<dyn ChatCompletionStream>>,
 ) {
     let (code_generation, prompt, chat) =
         model::load_code_generation_and_chat(completion, chat).await;
 
-    let completion = code_generation.map(|code_generation| {
+    let completion = code_generation.clone().map(|code_generation| {
         CompletionService::new(
             config.to_owned(),
             code_generation.clone(),
@@ -441,7 +442,7 @@ pub async fn create_completion_service_and_chat(
         )
     });
 
-    (completion, chat)
+    (completion, code_generation, chat)
 }
 
 #[cfg(test)]

--- a/crates/tabby/src/services/model/mod.rs
+++ b/crates/tabby/src/services/model/mod.rs
@@ -15,13 +15,16 @@ pub async fn load_code_generation_and_chat(
     chat_model: Option<ModelConfig>,
 ) -> (
     Option<Arc<CodeGeneration>>,
-    Option<PromptInfo>,
+    Option<Arc<dyn CompletionStream>>,
     Option<Arc<dyn ChatCompletionStream>>,
+    Option<PromptInfo>,
 ) {
     let (engine, prompt_info, chat) =
         load_completion_and_chat(completion_model.clone(), chat_model).await;
-    let code = engine.map(|engine| Arc::new(CodeGeneration::new(engine, completion_model)));
-    (code, prompt_info, chat)
+    let code = engine
+        .clone()
+        .map(|engine| Arc::new(CodeGeneration::new(engine, completion_model)));
+    (code, engine, chat, prompt_info)
 }
 
 async fn load_completion_and_chat(

--- a/ee/tabby-schema/Cargo.toml
+++ b/ee/tabby-schema/Cargo.toml
@@ -10,6 +10,7 @@ schema-language = ["juniper/schema-language"]
 
 [dependencies]
 anyhow.workspace = true
+async-openai.workspace = true
 async-trait.workspace = true
 axum = { workspace = true }
 base64 = "0.22.0"
@@ -21,6 +22,7 @@ serde.workspace = true
 strum.workspace = true
 tabby-db = { path = "../../ee/tabby-db" }
 tabby-common = { path = "../../crates/tabby-common" }
+tabby-inference = { path = "../../crates/tabby-inference" }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "process"] }
 tracing.workspace = true

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -529,7 +529,8 @@ type MessageEdge {
 }
 
 type ModelBackendHealthInfo {
-  latency: Int!
+  "Latency in milliseconds."
+  latencyMs: Int!
 }
 
 type Mutation {

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -522,6 +522,12 @@ type MessageEdge {
   cursor: String!
 }
 
+type ModelHealth {
+  completion: Boolean!
+  chat: Boolean!
+  embeddings: Boolean!
+}
+
 type Mutation {
   resetRegistrationToken: String!
   requestInvitationEmail(input: RequestInvitationInput!): Invitation!
@@ -693,6 +699,7 @@ type Query {
   "List user groups."
   userGroups: [UserGroup!]!
   sourceIdAccessPolicies(sourceId: String!): SourceIdAccessPolicy!
+  testModelConnection: ModelHealth!
 }
 
 type RefreshTokenResponse {

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -528,7 +528,7 @@ type MessageEdge {
   cursor: String!
 }
 
-type ModelHealthResponse {
+type ModelBackendHealthInfo {
   latency: Int!
 }
 
@@ -703,7 +703,7 @@ type Query {
   "List user groups."
   userGroups: [UserGroup!]!
   sourceIdAccessPolicies(sourceId: String!): SourceIdAccessPolicy!
-  testModelConnection(backend: ModelHealthBackend!): ModelHealthResponse!
+  testModelConnection(backend: ModelHealthBackend!): ModelBackendHealthInfo!
 }
 
 type RefreshTokenResponse {

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -528,6 +528,10 @@ type MessageEdge {
   cursor: String!
 }
 
+type ModelHealthResponse {
+  latency: Int!
+}
+
 type Mutation {
   resetRegistrationToken: String!
   requestInvitationEmail(input: RequestInvitationInput!): Invitation!
@@ -699,7 +703,7 @@ type Query {
   "List user groups."
   userGroups: [UserGroup!]!
   sourceIdAccessPolicies(sourceId: String!): SourceIdAccessPolicy!
-  testModelConnection(backend: ModelHealthBackend!): Int!
+  testModelConnection(backend: ModelHealthBackend!): ModelHealthResponse!
 }
 
 type RefreshTokenResponse {

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -73,6 +73,12 @@ enum LicenseType {
   ENTERPRISE
 }
 
+enum ModelHealthBackend {
+  CHAT
+  COMPLETION
+  EMBEDDING
+}
+
 enum OAuthProvider {
   GITHUB
   GOOGLE
@@ -522,12 +528,6 @@ type MessageEdge {
   cursor: String!
 }
 
-type ModelHealth {
-  completion: Boolean!
-  chat: Boolean!
-  embeddings: Boolean!
-}
-
 type Mutation {
   resetRegistrationToken: String!
   requestInvitationEmail(input: RequestInvitationInput!): Invitation!
@@ -699,7 +699,7 @@ type Query {
   "List user groups."
   userGroups: [UserGroup!]!
   sourceIdAccessPolicies(sourceId: String!): SourceIdAccessPolicy!
-  testModelConnection: ModelHealth!
+  testModelConnection(backend: ModelHealthBackend!): Int!
 }
 
 type RefreshTokenResponse {

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -685,11 +685,7 @@ impl Query {
                         .build()
                         .expect("Failed to build completion options");
 
-                    if !completion
-                        .generate("hello Tabby", options)
-                        .await
-                        .is_empty()
-                    {
+                    if !completion.generate("hello Tabby", options).await.is_empty() {
                         return Ok(start.elapsed().as_millis() as i32);
                     }
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -16,8 +16,7 @@ pub mod user_group;
 pub mod web_documents;
 pub mod worker;
 
-use std::sync::Arc;
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 
 use access_policy::{AccessPolicyService, SourceIdAccessPolicy};
 use async_openai::types::CreateChatCompletionRequest;
@@ -687,37 +686,37 @@ impl Query {
                         .expect("Failed to build completion options");
 
                     if !completion
-                        .generate("hello Tabby".into(), options)
+                        .generate("hello Tabby", options)
                         .await
                         .is_empty()
                     {
                         return Ok(start.elapsed().as_millis() as i32);
                     }
 
-                    return Err(CoreError::Other(anyhow::anyhow!(
+                    Err(CoreError::Other(anyhow::anyhow!(
                         "Failed to connect to the completion model"
-                    )));
+                    )))
                 } else {
-                    return Err(CoreError::NotFound("Completion model is not enabled"));
+                    Err(CoreError::NotFound("Completion model is not enabled"))
                 }
             }
             ModelHealthBackend::Chat => {
                 if let Some(chat) = ctx.locator.chat() {
                     let request = CreateChatCompletionRequest::default();
                     match chat.chat(request).await {
-                        Ok(_) => return Ok(start.elapsed().as_millis() as i32),
-                        Err(e) => return Err(CoreError::Other(e.into())),
+                        Ok(_) => Ok(start.elapsed().as_millis() as i32),
+                        Err(e) => Err(CoreError::Other(e.into())),
                     }
                 } else {
-                    return Err(CoreError::NotFound("Chat model is not enabled"));
+                    Err(CoreError::NotFound("Chat model is not enabled"))
                 }
             }
             ModelHealthBackend::Embedding => {
                 let embedding = ctx.locator.embedding();
-                return match embedding.embed("hello Tabby".into()).await {
+                match embedding.embed("hello Tabby").await {
                     Ok(_) => Ok(start.elapsed().as_millis() as i32),
-                    Err(e) => Err(CoreError::Other(e.into())),
-                };
+                    Err(e) => Err(CoreError::Other(e)),
+                }
             }
         }
     }

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -46,7 +46,6 @@ use tabby_inference::{
     ChatCompletionStream, CompletionOptionsBuilder, CompletionStream, Embedding as EmbeddingService,
 };
 use thread::{CreateThreadAndRunInput, CreateThreadRunInput, ThreadRunStream, ThreadService};
-use tokio::sync::broadcast::error;
 use tracing::{error, warn};
 use user_group::{
     CreateUserGroupInput, UpsertUserGroupMembershipInput, UserGroup, UserGroupService,

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -167,7 +167,10 @@ pub enum TestModelConnectionError {
 
 impl<S: ScalarValue> IntoFieldError<S> for TestModelConnectionError {
     fn into_field_error(self) -> FieldError<S> {
-        self.into()
+        match self {
+            TestModelConnectionError::Other(err) => err.into_field_error(),
+            _ => self.into(),
+        }
     }
 }
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -689,6 +689,7 @@ impl Query {
                         return Ok(start.elapsed().as_millis() as i32);
                     }
 
+                    // ast-grep-ignore: use-schema-result
                     Err(CoreError::Other(anyhow::anyhow!(
                         "Failed to connect to the completion model"
                     )))

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -739,7 +739,7 @@ impl Query {
                     }
 
                     Err(TestModelConnectionError::FailedToConnect(
-                        "Failed to connect to the completion model".into()
+                        "Failed to connect to the completion model".into(),
                     ))
                 } else {
                     Err(TestModelConnectionError::NotEnabled)

--- a/ee/tabby-webserver/src/service/mod.rs
+++ b/ee/tabby-webserver/src/service/mod.rs
@@ -35,7 +35,7 @@ use tabby_common::{
     constants::USER_HEADER_FIELD_NAME,
 };
 use tabby_db::{DbConn, UserDAO, UserGroupDAO};
-use tabby_inference::{ChatCompletionStream, CodeGeneration, Embedding as EmbeddingService};
+use tabby_inference::{ChatCompletionStream, CompletionStream, Embedding as EmbeddingService};
 use tabby_schema::{
     access_policy::AccessPolicyService,
     analytic::AnalyticService,
@@ -66,7 +66,7 @@ struct ServerContext {
     mail: Arc<dyn EmailService>,
     embedding: Arc<dyn EmbeddingService>,
     chat: Option<Arc<dyn ChatCompletionStream>>,
-    completion: Option<Arc<CodeGeneration>>,
+    completion: Option<Arc<dyn CompletionStream>>,
     auth: Arc<dyn AuthenticationService>,
     license: Arc<dyn LicenseService>,
     repository: Arc<dyn RepositoryService>,
@@ -89,7 +89,7 @@ impl ServerContext {
     pub async fn new(
         logger: Arc<dyn EventLogger>,
         chat: Option<Arc<dyn ChatCompletionStream>>,
-        completion: Option<Arc<CodeGeneration>>,
+        completion: Option<Arc<dyn CompletionStream>>,
         code: Arc<dyn CodeSearch>,
         repository: Arc<dyn RepositoryService>,
         integration: Arc<dyn IntegrationService>,
@@ -274,7 +274,7 @@ impl ServiceLocator for ArcServerContext {
         self.0.code.clone()
     }
 
-    fn completion(&self) -> Option<Arc<CodeGeneration>> {
+    fn completion(&self) -> Option<Arc<dyn CompletionStream>> {
         self.0.completion.clone()
     }
 
@@ -342,7 +342,7 @@ impl ServiceLocator for ArcServerContext {
 pub async fn create_service_locator(
     logger: Arc<dyn EventLogger>,
     chat: Option<Arc<dyn ChatCompletionStream>>,
-    completion: Option<Arc<CodeGeneration>>,
+    completion: Option<Arc<dyn CompletionStream>>,
     code: Arc<dyn CodeSearch>,
     repository: Arc<dyn RepositoryService>,
     integration: Arc<dyn IntegrationService>,

--- a/ee/tabby-webserver/src/webserver.rs
+++ b/ee/tabby-webserver/src/webserver.rs
@@ -99,9 +99,9 @@ impl Webserver {
             ))
         });
 
-        let is_chat_enabled = chat.is_some();
         let ctx = create_service_locator(
             self.logger(),
+            chat.clone(),
             code.clone(),
             repository.clone(),
             integration.clone(),
@@ -111,7 +111,6 @@ impl Webserver {
             web_documents.clone(),
             self.db.clone(),
             self.embedding.clone(),
-            is_chat_enabled,
         )
         .await;
 

--- a/ee/tabby-webserver/src/webserver.rs
+++ b/ee/tabby-webserver/src/webserver.rs
@@ -10,7 +10,7 @@ use tabby_common::{
     config::Config,
 };
 use tabby_db::DbConn;
-use tabby_inference::{ChatCompletionStream, Embedding};
+use tabby_inference::{ChatCompletionStream, CodeGeneration, Embedding};
 use tabby_schema::job::JobService;
 use tracing::debug;
 
@@ -62,6 +62,7 @@ impl Webserver {
         ui: Router,
         code: Arc<dyn CodeSearch>,
         chat: Option<Arc<dyn ChatCompletionStream>>,
+        completion: Option<Arc<CodeGeneration>>,
         docsearch: Arc<dyn DocSearch>,
         serper_factory_fn: impl Fn(&str) -> Box<dyn DocSearch>,
     ) -> (Router, Router) {
@@ -102,6 +103,7 @@ impl Webserver {
         let ctx = create_service_locator(
             self.logger(),
             chat.clone(),
+            completion.clone(),
             code.clone(),
             repository.clone(),
             integration.clone(),

--- a/ee/tabby-webserver/src/webserver.rs
+++ b/ee/tabby-webserver/src/webserver.rs
@@ -10,7 +10,7 @@ use tabby_common::{
     config::Config,
 };
 use tabby_db::DbConn;
-use tabby_inference::{ChatCompletionStream, CodeGeneration, Embedding};
+use tabby_inference::{ChatCompletionStream, CompletionStream, Embedding};
 use tabby_schema::job::JobService;
 use tracing::debug;
 
@@ -62,7 +62,7 @@ impl Webserver {
         ui: Router,
         code: Arc<dyn CodeSearch>,
         chat: Option<Arc<dyn ChatCompletionStream>>,
-        completion: Option<Arc<CodeGeneration>>,
+        completion: Option<Arc<dyn CompletionStream>>,
         docsearch: Arc<dyn DocSearch>,
         serper_factory_fn: impl Fn(&str) -> Box<dyn DocSearch>,
     ) -> (Router, Router) {


### PR DESCRIPTION
- backend for https://github.com/TabbyML/tabby/issues/3239
- Both local model and HTTP model tested

![CleanShot 2024-10-28 at 15 40 22@2x](https://github.com/user-attachments/assets/d7140c2f-ac0a-48c7-bb59-b15b4960ae75)

![CleanShot 2024-10-28 at 15 41 18@2x](https://github.com/user-attachments/assets/7d46dc79-d7eb-4d2b-af4e-ff10db508940)

![CleanShot 2024-10-28 at 15 41 47@2x](https://github.com/user-attachments/assets/0868ba4d-527f-4b06-bfb4-fd392c8ac02c)


notes:
1. the `CompletionService` in tabby-inference is wrapped by `CodeGeneration`, and `CodeGeneration` is then wrapped by `CompletionService` struct in tabby service, we should use the CompltionService in tabby-inference, but it's a bit tricky according to the current implementation, so I returned the `CodeGeneration` from tabby-inference, and use it as the GraphQL context.
2. when failed to connect to the model, GraphQL request will fail, so I just return the latency as the success indication, it's `milliseconds` i32.
4. following the GraphQL convention, the enum is in SCREAMING_SNAKE_CASE by default