### PR TITLE
fix(ui): insert mention prefix with proper spacing in Answer Engine

### DIFF
--- a/ee/tabby-ui/components/textarea-search.tsx
+++ b/ee/tabby-ui/components/textarea-search.tsx
@@ -87,7 +87,23 @@ export default function TextAreaSearch({
     const editor = editorRef.current?.editor
     if (!editor) return
 
-    editor.chain().focus().insertContent(prefix).run()
+    editor
+      .chain()
+      .focus()
+      .command(({ tr, state }) => {
+        const { $from } = state.selection
+        const isAtLineStart = $from.parentOffset === 0
+        const isPrecededBySpace = $from.nodeBefore?.text?.endsWith(' ') ?? false
+
+        if (isAtLineStart || isPrecededBySpace) {
+          tr.insertText(prefix)
+        } else {
+          tr.insertText(' ' + prefix)
+        }
+
+        return true
+      })
+      .run()
   }
 
   const { hasCodebaseSource, hasDocumentSource } = useMemo(() => {


### PR DESCRIPTION
## Change
When clicking button to insert a mention's prefix, ensure a space precedes the prefix if the cursor is not at the line's start and no space exists beforehand

## Screen record
https://jam.dev/c/1366b9dd-39d9-46b5-ae81-908b363066ef