### PR TITLE
chore(webserver): Print the count of repositories imported from third-party integrations instead of listing each one individually

### DIFF
--- a/ee/tabby-webserver/src/service/repository/third_party.rs
+++ b/ee/tabby-webserver/src/service/repository/third_party.rs
@@ -260,9 +260,8 @@ async fn refresh_repositories_for_provider(
 ) -> Result<()> {
     let start = Utc::now();
 
+    debug!("importing {} repositories", repos.len());
     for repo in repos {
-        debug!("importing: {}", repo.name);
-
         let id = repo.vendor_id;
 
         repository


### PR DESCRIPTION
this log would print hundreds of lines when I enable all repos with my GitHub token.

if no one needs this info, printing the number should be enough for us