### PR TITLE
feat(ui): display alerts for invalid licenses

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/main-content.tsx
@@ -3,6 +3,7 @@
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
 import { Header } from '@/components/header'
+import { useShowLicenseBanner } from '@/components/license-banner'
 
 export default function MainContent({
   children
@@ -10,10 +11,16 @@ export default function MainContent({
   children: React.ReactNode
 }) {
   const [isShowDemoBanner] = useShowDemoBanner()
+  const [isShowLicenseBanner] = useShowLicenseBanner()
+  const style =
+    isShowDemoBanner || isShowLicenseBanner
+      ? {
+          height: `calc(100vh - ${
+            isShowDemoBanner ? BANNER_HEIGHT : '0rem'
+          } - ${isShowLicenseBanner ? BANNER_HEIGHT : '0rem'})`
+        }
+      : { height: '100vh' }
 
-  const style = isShowDemoBanner
-    ? { height: `calc(100vh - ${BANNER_HEIGHT})` }
-    : { height: '100vh' }
   return (
     <>
       {/* Wraps right hand side into ScrollArea, making scroll bar consistent across all browsers */}

--- a/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
+++ b/ee/tabby-ui/app/(dashboard)/components/sidebar.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/icons'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
+import { useShowLicenseBanner } from '@/components/license-banner'
 import LoadingWrapper from '@/components/loading-wrapper'
 
 export interface SidebarProps {
@@ -124,10 +125,16 @@ const menus: Menu[] = [
 
 export default function Sidebar({ children, className }: SidebarProps) {
   const [{ data, fetching: fetchingMe }] = useMe()
-  const [isShowDemoBanner] = useShowDemoBanner()
   const isAdmin = data?.me.isAdmin
-  const style = isShowDemoBanner
-    ? { height: `calc(100vh - ${BANNER_HEIGHT})` }
+  const [isShowDemoBanner] = useShowDemoBanner()
+  const [isShowLicenseBanner] = useShowLicenseBanner()
+  const showBanner = isShowDemoBanner || isShowLicenseBanner
+  const style = showBanner
+    ? {
+        height: `calc(100vh - ${isShowDemoBanner ? BANNER_HEIGHT : '0rem'} - ${
+          isShowLicenseBanner ? BANNER_HEIGHT : '0rem'
+        })`
+      }
     : { height: '100vh' }
 
   return (

--- a/ee/tabby-ui/app/(dashboard)/layout.tsx
+++ b/ee/tabby-ui/app/(dashboard)/layout.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next'
 
+import { LicenseBanner } from '@/components/license-banner'
+
 import MainContent from './components/main-content'
 import Sidebar from './components/sidebar'
 
@@ -16,9 +18,12 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <main className="flex flex-1">
-      <Sidebar />
-      <MainContent>{children}</MainContent>
-    </main>
+    <>
+      <LicenseBanner />
+      <main className="flex flex-1">
+        <Sidebar />
+        <MainContent>{children}</MainContent>
+      </main>
+    </>
   )
 }

--- a/ee/tabby-ui/app/(dashboard)/settings/(integrations)/providers/components/nav-bar.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/(integrations)/providers/components/nav-bar.tsx
@@ -7,7 +7,8 @@ import { cva } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
-import { BANNER_HEIGHT, useShowDemoBanner } from '@/components/demo-banner'
+import { useShowDemoBanner } from '@/components/demo-banner'
+import { useShowLicenseBanner } from '@/components/license-banner'
 
 import { PROVIDER_KIND_METAS } from '../constants'
 
@@ -33,9 +34,12 @@ interface SidebarButtonProps {
 
 export default function NavBar({ className }: { className?: string }) {
   const [isShowDemoBanner] = useShowDemoBanner()
-
-  const style = isShowDemoBanner
-    ? { height: `calc(100vh - ${BANNER_HEIGHT} - 4rem)` }
+  const [isShowLicenseBanner] = useShowLicenseBanner()
+  const showBanner = isShowDemoBanner || isShowLicenseBanner
+  const bannerHeight =
+    isShowDemoBanner && isShowLicenseBanner ? '7rem' : '3.5rem'
+  const style = showBanner
+    ? { height: `calc(100vh - ${bannerHeight} - 4rem)` }
     : { height: 'calc(100vh - 4rem)' }
 
   return (

--- a/ee/tabby-ui/app/(dashboard)/settings/subscription/components/subscription.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/subscription/components/subscription.tsx
@@ -80,7 +80,7 @@ function License({ license }: { license: LicenseInfo }) {
         <div className="mb-1 text-muted-foreground">Assigned / Total Seats</div>
         <div className="flex items-center gap-2 text-3xl">
           {seatsText}
-          {license.status === LicenseStatus.Expired && (
+          {license.status === LicenseStatus.SeatsExceeded && (
             <Badge variant="destructive" className="flex items-center gap-1">
               <IconAlertTriangle className="h-3 w-3" />
               Seats exceeded

--- a/ee/tabby-ui/app/(dashboard)/settings/subscription/components/subscription.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/subscription/components/subscription.tsx
@@ -66,7 +66,7 @@ function License({ license }: { license: LicenseInfo }) {
     <div className="grid font-bold lg:grid-cols-3">
       <div>
         <div className="mb-1 text-muted-foreground">Expires at</div>
-        <div className="text-3xl flex items-center gap-2">
+        <div className="flex items-center gap-2 text-3xl">
           {expiresAt}
           {license.status === LicenseStatus.Expired && (
             <Badge variant="destructive" className="flex items-center gap-1">
@@ -78,7 +78,7 @@ function License({ license }: { license: LicenseInfo }) {
       </div>
       <div>
         <div className="mb-1 text-muted-foreground">Assigned / Total Seats</div>
-        <div className="text-3xl flex items-center gap-2">
+        <div className="flex items-center gap-2 text-3xl">
           {seatsText}
           {license.status === LicenseStatus.Expired && (
             <Badge variant="destructive" className="flex items-center gap-1">

--- a/ee/tabby-ui/app/(dashboard)/settings/subscription/components/subscription.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/subscription/components/subscription.tsx
@@ -3,8 +3,14 @@
 import { capitalize } from 'lodash-es'
 import moment from 'moment'
 
-import { LicenseInfo, LicenseType } from '@/lib/gql/generates/graphql'
+import {
+  LicenseInfo,
+  LicenseStatus,
+  LicenseType
+} from '@/lib/gql/generates/graphql'
 import { useLicense } from '@/lib/hooks/use-license'
+import { Badge } from '@/components/ui/badge'
+import { IconAlertTriangle } from '@/components/ui/icons'
 import { Skeleton } from '@/components/ui/skeleton'
 import LoadingWrapper from '@/components/loading-wrapper'
 import { SubHeader } from '@/components/sub-header'
@@ -60,11 +66,27 @@ function License({ license }: { license: LicenseInfo }) {
     <div className="grid font-bold lg:grid-cols-3">
       <div>
         <div className="mb-1 text-muted-foreground">Expires at</div>
-        <div className="text-3xl">{expiresAt}</div>
+        <div className="text-3xl flex items-center gap-2">
+          {expiresAt}
+          {license.status === LicenseStatus.Expired && (
+            <Badge variant="destructive" className="flex items-center gap-1">
+              <IconAlertTriangle className="h-3 w-3" />
+              Expired
+            </Badge>
+          )}
+        </div>
       </div>
       <div>
         <div className="mb-1 text-muted-foreground">Assigned / Total Seats</div>
-        <div className="text-3xl">{seatsText}</div>
+        <div className="text-3xl flex items-center gap-2">
+          {seatsText}
+          {license.status === LicenseStatus.Expired && (
+            <Badge variant="destructive" className="flex items-center gap-1">
+              <IconAlertTriangle className="h-3 w-3" />
+              Seats exceeded
+            </Badge>
+          )}
+        </div>
       </div>
       <div>
         <div className="mb-1 text-muted-foreground">Current plan</div>

--- a/ee/tabby-ui/components/header.tsx
+++ b/ee/tabby-ui/components/header.tsx
@@ -3,11 +3,13 @@
 import * as React from 'react'
 import { compare } from 'compare-versions'
 
+import { LicenseStatus } from '@/lib/gql/generates/graphql'
 import { useHealth } from '@/lib/hooks/use-health'
 import { ReleaseInfo, useLatestRelease } from '@/lib/hooks/use-latest-release'
+import { useLicenseInfo } from '@/lib/hooks/use-license'
 import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
-import { IconNotice } from '@/components/ui/icons'
+import { IconInfoCircled, IconNotice } from '@/components/ui/icons'
 
 import { ClientOnly } from './client-only'
 import { ThemeToggle } from './theme-toggle'
@@ -22,7 +24,7 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-50 flex h-16 w-full shrink-0 items-center justify-between border-b px-4 backdrop-blur-xl lg:px-10">
-      <div className="flex items-center">
+      <div className="flex items-center gap-4">
         {newVersionAvailable && (
           <a
             target="_blank"
@@ -36,6 +38,7 @@ export function Header() {
             </span>
           </a>
         )}
+        <LicenseAlert />
       </div>
       <div className="flex items-center justify-center gap-6">
         <ClientOnly>
@@ -58,5 +61,29 @@ function isNewVersionAvailable(version?: string, latestRelease?: ReleaseInfo) {
 
     // Handle invalid semver
     return true
+  }
+}
+
+function LicenseAlert() {
+  const license = useLicenseInfo()
+
+  if (!license) return null
+
+  if (license.status === LicenseStatus.Expired) {
+    return (
+      <div className="flex items-center gap-1 text-destructive text-sm font-semibold">
+        <IconInfoCircled />
+        Your license has expired.
+      </div>
+    )
+  }
+
+  if (license.status === LicenseStatus.SeatsExceeded) {
+    return (
+      <div className="flex items-center gap-1 text-destructive text-sm font-semibold">
+        <IconInfoCircled />
+        Your seat count has exceeded the limit.
+      </div>
+    )
   }
 }

--- a/ee/tabby-ui/components/header.tsx
+++ b/ee/tabby-ui/components/header.tsx
@@ -3,13 +3,11 @@
 import * as React from 'react'
 import { compare } from 'compare-versions'
 
-import { LicenseStatus } from '@/lib/gql/generates/graphql'
 import { useHealth } from '@/lib/hooks/use-health'
 import { ReleaseInfo, useLatestRelease } from '@/lib/hooks/use-latest-release'
-import { useLicenseInfo } from '@/lib/hooks/use-license'
 import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
-import { IconInfoCircled, IconNotice } from '@/components/ui/icons'
+import { IconNotice } from '@/components/ui/icons'
 
 import { ClientOnly } from './client-only'
 import { ThemeToggle } from './theme-toggle'
@@ -38,7 +36,6 @@ export function Header() {
             </span>
           </a>
         )}
-        <LicenseAlert />
       </div>
       <div className="flex items-center justify-center gap-6">
         <ClientOnly>
@@ -61,29 +58,5 @@ function isNewVersionAvailable(version?: string, latestRelease?: ReleaseInfo) {
 
     // Handle invalid semver
     return true
-  }
-}
-
-function LicenseAlert() {
-  const license = useLicenseInfo()
-
-  if (!license) return null
-
-  if (license.status === LicenseStatus.Expired) {
-    return (
-      <div className="flex items-center gap-1 text-sm font-semibold text-destructive">
-        <IconInfoCircled />
-        Your license has expired.
-      </div>
-    )
-  }
-
-  if (license.status === LicenseStatus.SeatsExceeded) {
-    return (
-      <div className="flex items-center gap-1 text-sm font-semibold text-destructive">
-        <IconInfoCircled />
-        Your seat count has exceeded the limit.
-      </div>
-    )
   }
 }

--- a/ee/tabby-ui/components/header.tsx
+++ b/ee/tabby-ui/components/header.tsx
@@ -71,7 +71,7 @@ function LicenseAlert() {
 
   if (license.status === LicenseStatus.Expired) {
     return (
-      <div className="flex items-center gap-1 text-destructive text-sm font-semibold">
+      <div className="flex items-center gap-1 text-sm font-semibold text-destructive">
         <IconInfoCircled />
         Your license has expired.
       </div>
@@ -80,7 +80,7 @@ function LicenseAlert() {
 
   if (license.status === LicenseStatus.SeatsExceeded) {
     return (
-      <div className="flex items-center gap-1 text-destructive text-sm font-semibold">
+      <div className="flex items-center gap-1 text-sm font-semibold text-destructive">
         <IconInfoCircled />
         Your seat count has exceeded the limit.
       </div>

--- a/ee/tabby-ui/components/license-banner.tsx
+++ b/ee/tabby-ui/components/license-banner.tsx
@@ -82,7 +82,7 @@ export function LicenseBanner() {
   return (
     <div
       className={cn(
-        'flex items-center justify-between bg-secondary border-b px-4 text-secondary-foreground transition-all md:px-5',
+        'flex items-center justify-between border-b bg-secondary px-4 text-secondary-foreground transition-all md:px-5',
         {
           'opacity-100 pointer-events-auto': isShowLicenseBanner,
           'opacity-0 pointer-events-none': !isShowLicenseBanner
@@ -90,7 +90,7 @@ export function LicenseBanner() {
       )}
       style={style}
     >
-      <div className="text-destructive font-semibold flex items-center gap-1">
+      <div className="flex items-center gap-1 font-semibold text-destructive">
         <IconNotice />
         {tips}
       </div>

--- a/ee/tabby-ui/components/license-banner.tsx
+++ b/ee/tabby-ui/components/license-banner.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import { useLicenseValidity } from '@/lib/hooks/use-license'
+import { cn } from '@/lib/utils'
+import { IconClose, IconNotice } from '@/components/ui/icons'
+
+import { buttonVariants } from './ui/button'
+
+export const BANNER_HEIGHT = '3.5rem'
+
+interface ShowLicenseBannerContextValue {
+  isShowLicenseBanner: boolean
+  setIsShowLicenseBanner: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const ShowLicenseBannerContext =
+  React.createContext<ShowLicenseBannerContextValue>(
+    {} as ShowLicenseBannerContextValue
+  )
+
+export const ShowLicenseBannerProvider = ({
+  children
+}: {
+  children: React.ReactNode
+}) => {
+  const { isExpired, isSeatsExceeded, isLicenseOK } = useLicenseValidity()
+
+  const [isShowLicenseBanner, setIsShowLicenseBanner] = React.useState(false)
+
+  React.useEffect(() => {
+    const isInIframe = window.self !== window.top
+    if (isInIframe) return
+
+    if (isExpired || isSeatsExceeded) {
+      setIsShowLicenseBanner(true)
+    } else if (isLicenseOK) {
+      setIsShowLicenseBanner(false)
+    }
+  }, [isLicenseOK, isExpired, isSeatsExceeded])
+
+  return (
+    <ShowLicenseBannerContext.Provider
+      value={{ isShowLicenseBanner, setIsShowLicenseBanner }}
+    >
+      {children}
+    </ShowLicenseBannerContext.Provider>
+  )
+}
+
+export function useShowLicenseBanner(): [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>
+] {
+  const { isShowLicenseBanner, setIsShowLicenseBanner } = React.useContext(
+    ShowLicenseBannerContext
+  )
+  return [isShowLicenseBanner, setIsShowLicenseBanner]
+}
+
+export function LicenseBanner() {
+  const [isShowLicenseBanner, setIsShowLicenseBanner] = useShowLicenseBanner()
+  const { isExpired, isSeatsExceeded } = useLicenseValidity()
+  const pathname = usePathname()
+  const style = isShowLicenseBanner ? { height: BANNER_HEIGHT } : { height: 0 }
+
+  const tips = useMemo(() => {
+    if (isExpired) {
+      return 'Your license is expired.'
+    }
+
+    if (isSeatsExceeded) {
+      return 'You have more active users than seats included in your license.'
+    }
+
+    return 'No valid license configured'
+  }, [isExpired, isSeatsExceeded])
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between bg-secondary border-b px-4 text-secondary-foreground transition-all md:px-5',
+        {
+          'opacity-100 pointer-events-auto': isShowLicenseBanner,
+          'opacity-0 pointer-events-none': !isShowLicenseBanner
+        }
+      )}
+      style={style}
+    >
+      <div className="text-destructive font-semibold flex items-center gap-1">
+        <IconNotice />
+        {tips}
+      </div>
+
+      <div className="flex items-center gap-x-4 md:gap-x-8">
+        {pathname !== '/settings/subscription' && (
+          <Link
+            href="/settings/subscription"
+            className={cn(buttonVariants(), 'gap-1')}
+          >
+            See more
+          </Link>
+        )}
+
+        <IconClose
+          className="cursor-pointer transition-all hover:opacity-70"
+          onClick={() => setIsShowLicenseBanner(false)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/ee/tabby-ui/components/license-banner.tsx
+++ b/ee/tabby-ui/components/license-banner.tsx
@@ -69,11 +69,11 @@ export function LicenseBanner() {
 
   const tips = useMemo(() => {
     if (isExpired) {
-      return 'Your license is expired.'
+      return 'Your subscription is expired.'
     }
 
     if (isSeatsExceeded) {
-      return 'You have more active users than seats included in your license.'
+      return 'You have more active users than seats included in your subscription.'
     }
 
     return 'No valid license configured'

--- a/ee/tabby-ui/components/license-guard.tsx
+++ b/ee/tabby-ui/components/license-guard.tsx
@@ -91,7 +91,7 @@ function LicenseTips({
   const hasSufficientLicense = !!license && licenses.includes(license.type)
   const isLicenseExpired =
     hasSufficientLicense && license?.status === LicenseStatus.Expired
-  const isSearCountRelated =
+  const isSeatsExceeded =
     hasSufficientLicense && license?.status === LicenseStatus.SeatsExceeded
 
   const licenseString = capitalize(licenses[0])
@@ -102,7 +102,7 @@ function LicenseTips({
     )}`
   }
 
-  if (isSearCountRelated && isSeatCountRelated) {
+  if (isSeatsExceeded && isSeatCountRelated) {
     return (
       <>
         <div>

--- a/ee/tabby-ui/components/providers.tsx
+++ b/ee/tabby-ui/components/providers.tsx
@@ -12,6 +12,7 @@ import { client } from '@/lib/tabby/gql'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { ShowDemoBannerProvider } from '@/components/demo-banner'
 
+import { ShowLicenseBannerProvider } from './license-banner'
 import { TopbarProgressProvider } from './topbar-progress-indicator'
 
 const publicPaths = ['/chat']
@@ -35,10 +36,12 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
           <AuthProvider>
             <TopbarProgressProvider>
               <ShowDemoBannerProvider>
-                <PostHogProvider>
-                  {!isPublicPath && <EnsureSignin />}
-                  {children}
-                </PostHogProvider>
+                <ShowLicenseBannerProvider>
+                  <PostHogProvider>
+                    {!isPublicPath && <EnsureSignin />}
+                    {children}
+                  </PostHogProvider>
+                </ShowLicenseBannerProvider>
               </ShowDemoBannerProvider>
             </TopbarProgressProvider>
           </AuthProvider>

--- a/ee/tabby-ui/lib/hooks/use-license.ts
+++ b/ee/tabby-ui/lib/hooks/use-license.ts
@@ -67,8 +67,8 @@ export const useLicenseValidity = (options?: UseLicenseValidityOptions) => {
   const isSeatsExceeded = licenseInfo?.status === LicenseStatus?.SeatsExceeded
 
   // Testing parameters from searchParams
-  const isTestExpired = searchParams.get('licenseExpired') === '1'
-  const isTestSeatsExceeded = searchParams.get('seatsExceeded') === '1'
+  const isTestExpired = searchParams.get('licenseError') === 'expired'
+  const isTestSeatsExceeded = searchParams.get('licenseError') === 'seatsExceed'
 
   return {
     hasLicense,

--- a/ee/tabby-ui/lib/hooks/use-license.ts
+++ b/ee/tabby-ui/lib/hooks/use-license.ts
@@ -1,6 +1,8 @@
+import { useSearchParams } from 'next/navigation'
 import { useQuery } from 'urql'
 
 import { graphql } from '../gql/generates'
+import { LicenseStatus, LicenseType } from '../gql/generates/graphql'
 
 const getLicenseInfo = graphql(/* GraphQL */ `
   query GetLicenseInfo {
@@ -22,6 +24,60 @@ const useLicense = () => {
 const useLicenseInfo = () => {
   const [{ data }] = useLicense()
   return data?.license
+}
+
+type UseLicenseValidityOptions = {
+  /**
+   * requiredLicenses
+   */
+  licenses?: LicenseType[]
+  /**
+   * Indicates whether the operation permissions for the child component
+   * are related to the seat count.
+   *
+   * If `true`, the component will check if the seat count exceeds the limit
+   * before allowing the operation.
+   */
+  // isSeatCountRelated?: boolean
+}
+
+export type UseLicenseValidityResponse = ReturnType<typeof useLicenseValidity>
+
+/**
+ * check the validity of the current license
+ */
+export const useLicenseValidity = (options?: UseLicenseValidityOptions) => {
+  const [{ data }] = useLicense()
+  const licenseInfo = data?.license
+  const searchParams = useSearchParams()
+
+  const hasLicense = !!licenseInfo
+
+  // Determine if the current license has sufficient level
+  const hasSufficientLicense =
+    !!licenseInfo &&
+    (!options?.licenses?.length || options.licenses.includes(licenseInfo.type))
+
+  const isLicenseOK = licenseInfo?.status === LicenseStatus.Ok
+
+  // Determine if the current license is expired
+  const isExpired = licenseInfo?.status === LicenseStatus.Expired
+
+  // Determine if the seat count is exceeded
+  const isSeatsExceeded = licenseInfo?.status === LicenseStatus?.SeatsExceeded
+
+  // Testing parameters from searchParams
+  const isTestExpired = searchParams.get('licenseExpired') === '1'
+  const isTestSeatsExceeded = searchParams.get('seatsExceeded') === '1'
+
+  return {
+    hasLicense,
+    // FIXME introduced testing searchParams
+    isLicenseOK: isLicenseOK && !(isTestExpired || isTestSeatsExceeded),
+    isExpired: isExpired || isTestExpired,
+    isSeatsExceeded: isSeatsExceeded || isTestSeatsExceeded,
+    hasSufficientLicense
+  }
 }
 
 export { getLicenseInfo, useLicense, useLicenseInfo }


### PR DESCRIPTION
## Change

The following two scenarios will display an invalid license prompt, with the messages shown in order. If the first is matched, only that one will be displayed.
1. License insufficient
2. License expired
3. Seats exceeded

## Screenshots
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/9a733262-0012-4f2c-a2af-5b470b9905bc">

----

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/18bf4611-8897-4b42-a1fe-c8431bb2e4a9">

----

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/9eee3867-0100-4f67-893a-746b2f04e7c4">

----

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/1aec32c4-55d4-460c-bac0-bf23bf20277a">
