### PR TITLE
fix(agent): normalize indentation in code completion postprocess

### DIFF
--- a/clients/tabby-agent/src/codeCompletion/postprocess/index.ts
+++ b/clients/tabby-agent/src/codeCompletion/postprocess/index.ts
@@ -13,6 +13,7 @@ import { trimMultiLineInSingleLineMode } from "./trimMultiLineInSingleLineMode";
 import { dropDuplicated } from "./dropDuplicated";
 import { dropMinimum } from "./dropMinimum";
 import { calculateReplaceRange } from "./calculateReplaceRange";
+import { normalizeIndentation } from "./normalizeIndentation";
 
 type ItemListFilter = (items: CompletionItem[]) => Promise<CompletionItem[]>;
 
@@ -51,6 +52,7 @@ export async function postCacheProcess(
     .then(applyFilter(limitScope))
     .then(applyFilter(removeDuplicatedBlockClosingLine))
     .then(applyFilter(formatIndentation))
+    .then(applyFilter(normalizeIndentation))
     .then(applyFilter(dropDuplicated))
     .then(applyFilter(trimSpace))
     .then(applyFilter(dropMinimum))

--- a/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.test.ts
+++ b/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.test.ts
@@ -1,0 +1,104 @@
+import { documentContext, inline, assertFilterResult } from "./testUtils";
+import { normalizeIndentation } from "./normalizeIndentation";
+
+describe("postprocess", () => {
+  describe("normalizeIndentation", () => {
+    const filter = normalizeIndentation();
+
+    it("should normalize indentation when cursor is on empty line", async () => {
+      const context = documentContext`
+        function test() {
+          ║
+        }
+      `;
+      const completion = inline`
+          ├console.log("test");┤
+      `;
+      const expected = inline`
+          ├console.log("test");┤
+      `;
+      await assertFilterResult(filter, context, completion, expected);
+    });
+
+    it("should not modify indentation when cursor line has content", async () => {
+      const context = documentContext`
+        let x = ║value
+      `;
+      const completion = inline`
+                ├42┤
+      `;
+      const expected = inline`
+                ├42┤
+      `;
+      await assertFilterResult(filter, context, completion, expected);
+    });
+
+    it("should handle empty lines in nested blocks", async () => {
+      const context = documentContext`
+        if (true) {
+          while (condition) {
+            ║
+          }
+        }
+      `;
+      context.language = "javascript";
+      const completion = inline`
+            ├doSomething();┤
+      `;
+      const expected = inline`
+            ├doSomething();┤
+      `;
+      await assertFilterResult(filter, context, completion, expected);
+    });
+
+    it("should handle deep nested block indentation", async () => {
+      const context = documentContext`
+        if let Some(code_query) = code_query {
+            let hits = self.collect_relevant_code(
+                &context_info_helper,
+                code_query,
+            ).await?;
+            ║
+        }
+      `;
+      context.language = "rust";
+      const completion = inline`
+            ├attachment.code_hits = Some(hits);┤
+      `;
+      const expected = inline`
+            ├attachment.code_hits = Some(hits);┤
+      `;
+      await assertFilterResult(filter, context, completion, expected);
+    });
+
+    it("should handle method arguments with object literals", async () => {
+      const context = documentContext`
+        await client.request(
+        ║
+        );
+      `;
+      context.language = "javascript";
+      const completion = inline`
+        ├{
+            method: 'POST',
+            url: '/api/data',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+          }┤
+      `;
+      const expected = inline`
+        ├{
+            method: 'POST',
+            url: '/api/data',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+          }┤
+      `;
+      await assertFilterResult(filter, context, completion, expected);
+    });
+  });
+});

--- a/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.test.ts
+++ b/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.test.ts
@@ -49,8 +49,8 @@ describe("postprocess", () => {
         }
       `;
       const completion = inline`
-           ├ doSomething();
-            doAnother();┤
+            ├ doSomething();
+             doAnother();┤
       `;
       const expected = inline`
            ├doSomething();
@@ -88,6 +88,50 @@ describe("postprocess", () => {
       `;
       const expected = inline`
         ├    bar();┤
+      `;
+      await assertFilterResult(filter, context, completion, expected);
+    });
+    it("should fix extra indent", async () => {
+      const context = documentContext`
+        {
+         ║
+        }
+      `;
+      const completion = inline`
+        ├"command": "tabby.inlineCompletion.trigger.automatic",
+         "title":  "Trigger Code Completion Automatically",
+         "category": "Tabby"┤
+      `;
+      const expected = inline`
+        ├"command": "tabby.inlineCompletion.trigger.automatic",
+        "title":  "Trigger Code Completion Automatically",
+        "category": "Tabby"┤
+      `;
+      await assertFilterResult(filter, context, completion, expected);
+    });
+
+    it("shouldn't change indent", async () => {
+      const context = documentContext`
+        {
+          "command": "tabby.toggleInlineCompletionTriggerMode",
+          "title": "Toggle Code Completion Trigger Mode (Automatic/Manual)",
+          "category": "Tabby"
+        },
+        ║
+      `;
+      const completion = inline`
+        ├{
+          "command": "tabby.inlineCompletion.trigger",
+          "title": "Trigger Code Completion Manually",
+          "category": "Tabby"
+        },┤
+      `;
+      const expected = inline`
+        ├{
+          "command": "tabby.inlineCompletion.trigger",
+          "title": "Trigger Code Completion Manually",
+          "category": "Tabby"
+        },┤
       `;
       await assertFilterResult(filter, context, completion, expected);
     });

--- a/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.ts
+++ b/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.ts
@@ -22,32 +22,24 @@ export function normalizeIndentation(): PostprocessFilter {
     }
 
     const normalizedLines = [...lines];
-
     const firstLine = normalizedLines[0];
+    const cursorLineSpaces = getLeadingSpaces(context.currentLinePrefix);
     if (firstLine) {
       const firstLineSpaces = getLeadingSpaces(firstLine);
-      const cursorLineSpaces = getLeadingSpaces(context.currentLinePrefix);
-      console.log("firstLineSpaces", firstLineSpaces);
-      console.log("curr prefix", context.currentLinePrefix);
-      console.log("cursorLineSpaces", cursorLineSpaces);
       // deal with current cursor odd indentation
       if ((firstLineSpaces + cursorLineSpaces) % 2 !== 0 && firstLineSpaces % 2 !== 0) {
         normalizedLines[0] = firstLine.substring(firstLineSpaces);
-        console.log("after normalize:", normalizedLines[0]);
       }
     }
 
     //deal with extra space in the line indent
-    let indents = -1; // use track previous line indentations
     for (let i = 0; i < normalizedLines.length; i++) {
       const line = normalizedLines[i];
       if (!line || !line.trim()) continue;
       const lineSpaces = getLeadingSpaces(line);
-      if (indents != -1 && lineSpaces % 2 !== 0) {
+      if (lineSpaces > 0 && lineSpaces % 2 !== 0) {
         // move current line to recently close indent
-        normalizedLines[i] = " ".repeat(indents) + line.trimStart();
-      } else {
-        indents = lineSpaces;
+        normalizedLines[i] = " ".repeat(lineSpaces - 1) + line.trimStart();
       }
     }
 

--- a/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.ts
+++ b/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.ts
@@ -22,38 +22,32 @@ export function normalizeIndentation(): PostprocessFilter {
     }
 
     const normalizedLines = [...lines];
+
     const firstLine = normalizedLines[0];
-
     if (firstLine) {
-      const cursorLineSpaces = getLeadingSpaces(context.currentLinePrefix);
       const firstLineSpaces = getLeadingSpaces(firstLine);
-
-      // check if any following line matches cursor indentation
-      let hasMatchingIndent = false;
-      for (let i = 1; i < lines.length; i++) {
-        const line = lines[i];
-        if (line && line.trim() && getLeadingSpaces(line) === cursorLineSpaces) {
-          hasMatchingIndent = true;
-          break;
-        }
+      const cursorLineSpaces = getLeadingSpaces(context.currentLinePrefix);
+      console.log("firstLineSpaces", firstLineSpaces);
+      console.log("curr prefix", context.currentLinePrefix);
+      console.log("cursorLineSpaces", cursorLineSpaces);
+      // deal with current cursor odd indentation
+      if ((firstLineSpaces + cursorLineSpaces) % 2 !== 0 && firstLineSpaces % 2 !== 0) {
+        normalizedLines[0] = firstLine.substring(firstLineSpaces);
+        console.log("after normalize:", normalizedLines[0]);
       }
+    }
 
-      // if cursor line has even spaces, process indentation
-      if (cursorLineSpaces % 2 === 0 && firstLineSpaces > 0) {
-        if (hasMatchingIndent) {
-          // if matching indent found, only process first line
-          const lineSpaces = getLeadingSpaces(firstLine);
-          const spacesToRemove = Math.min(lineSpaces, firstLineSpaces);
-          normalizedLines[0] = firstLine.substring(spacesToRemove);
-        } else {
-          // otherwise process all lines
-          normalizedLines.forEach((line, index) => {
-            if (!line || !line.trim()) return; // skip empty lines
-            const lineSpaces = getLeadingSpaces(line);
-            const spacesToRemove = Math.min(lineSpaces, firstLineSpaces);
-            normalizedLines[index] = line.substring(spacesToRemove);
-          });
-        }
+    //deal with extra space in the line indent
+    let indents = -1; // use track previous line indentations
+    for (let i = 0; i < normalizedLines.length; i++) {
+      const line = normalizedLines[i];
+      if (!line || !line.trim()) continue;
+      const lineSpaces = getLeadingSpaces(line);
+      if (indents != -1 && lineSpaces % 2 !== 0) {
+        // move current line to recently close indent
+        normalizedLines[i] = " ".repeat(indents) + line.trimStart();
+      } else {
+        indents = lineSpaces;
       }
     }
 

--- a/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.ts
+++ b/clients/tabby-agent/src/codeCompletion/postprocess/normalizeIndentation.ts
@@ -1,0 +1,62 @@
+import { PostprocessFilter } from "./base";
+import { CompletionItem } from "../solution";
+
+function isOnlySpaces(str: string | null | undefined): boolean {
+  if (!str) return true;
+  return /^\s*$/.test(str);
+}
+
+function getLeadingSpaces(str: string): number {
+  const match = str.match(/^(\s*)/);
+  return match ? match[0].length : 0;
+}
+
+export function normalizeIndentation(): PostprocessFilter {
+  return (item: CompletionItem): CompletionItem => {
+    const { context, lines } = item;
+    if (!Array.isArray(lines) || lines.length === 0) return item;
+
+    // skip if current line has content
+    if (!isOnlySpaces(context.currentLinePrefix)) {
+      return item;
+    }
+
+    const normalizedLines = [...lines];
+    const firstLine = normalizedLines[0];
+
+    if (firstLine) {
+      const cursorLineSpaces = getLeadingSpaces(context.currentLinePrefix);
+      const firstLineSpaces = getLeadingSpaces(firstLine);
+
+      // check if any following line matches cursor indentation
+      let hasMatchingIndent = false;
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (line && line.trim() && getLeadingSpaces(line) === cursorLineSpaces) {
+          hasMatchingIndent = true;
+          break;
+        }
+      }
+
+      // if cursor line has even spaces, process indentation
+      if (cursorLineSpaces % 2 === 0 && firstLineSpaces > 0) {
+        if (hasMatchingIndent) {
+          // if matching indent found, only process first line
+          const lineSpaces = getLeadingSpaces(firstLine);
+          const spacesToRemove = Math.min(lineSpaces, firstLineSpaces);
+          normalizedLines[0] = firstLine.substring(spacesToRemove);
+        } else {
+          // otherwise process all lines
+          normalizedLines.forEach((line, index) => {
+            if (!line || !line.trim()) return; // skip empty lines
+            const lineSpaces = getLeadingSpaces(line);
+            const spacesToRemove = Math.min(lineSpaces, firstLineSpaces);
+            normalizedLines[index] = line.substring(spacesToRemove);
+          });
+        }
+      }
+    }
+
+    return item.withText(normalizedLines.join(""));
+  };
+}


### PR DESCRIPTION
#3263

Fixing wrong indent in inline completion predict solution

#### Demo
https://github.com/user-attachments/assets/34580f0a-ab4b-4c08-8101-ba28f2687701



### Before
Only first line has extra spaces:
![image](https://github.com/user-attachments/assets/64c6de47-bd62-440b-ba72-a915281593f9)



exactly one extra space in the line indent
![image](https://github.com/user-attachments/assets/1e051aa4-fb1b-434f-bb72-b319af353132)


### After
![image](https://github.com/user-attachments/assets/6fefcdbc-24cc-4af0-9d67-6724ebb35f98)
exactly one extra space in the line indent
![image](https://github.com/user-attachments/assets/af238fd6-7fca-424f-977b-a72601144c1b)

### Implementation
Using whether the current indent is even as the judgment basis. If it's even, the prediction doesn't need any extra spaces and the prediction context will be processed accordingly.

### Potential risks:
Some users might use odd indent size
### Why
This approach is simple and doesn't require adding additional LSP or obtaining the best indent through client operations.


### Issue didn't fix
Due to some concern this post-processing not going to fix this situation

All lines in prediction have extra spaces:
![image](https://github.com/user-attachments/assets/470eac5e-a4ee-4bf3-a082-bc8714b4be79)

