### PR TITLE
fix(agent&vscode): use shared mutexAbortController for inlineEdit and smartApply

### DIFF
--- a/clients/tabby-agent/src/chat/global.ts
+++ b/clients/tabby-agent/src/chat/global.ts
@@ -1,0 +1,14 @@
+export let mutexAbortController: AbortController | undefined = undefined;
+
+// reset global mutexAbortController to undefined
+export const resetMutexAbortController = () => {
+  mutexAbortController = undefined;
+};
+
+// initialize global mutexAbortController
+export const initMutexAbortController = () => {
+  if (!mutexAbortController) {
+    mutexAbortController = new AbortController();
+  }
+  return mutexAbortController;
+};

--- a/clients/vscode/src/chat/WebviewHelper.ts
+++ b/clients/vscode/src/chat/WebviewHelper.ts
@@ -474,7 +474,7 @@ export class WebviewHelper {
           this.logger.info("Smart apply in editor started.");
           this.logger.trace("Smart apply in editor with content:", { content });
 
-          await window.withProgress(
+          window.withProgress(
             {
               location: ProgressLocation.Notification,
               title: "Smart Apply in Progress",


### PR DESCRIPTION
Fixing the issue where inline-editing cannot be cancelled when initiated with smart apply


https://github.com/user-attachments/assets/9aca4d85-19f5-41ce-9914-20d74d5df349

