### PR TITLE
ci(docker): update docker release runner to buildjet-2vcpu-ubuntu-2204

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   release-docker:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-2vcpu-ubuntu-2204
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
fix docker build: https://github.com/TabbyML/tabby/actions/runs/11695005630