### PR TITLE
fix(webserver): forbid empty content message update

### DIFF
--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -1183,6 +1183,8 @@ impl Mutation {
         input: thread::UpdateMessageInput,
     ) -> Result<bool> {
         let user = check_user(ctx).await?;
+        input.validate()?;
+
         let svc = ctx.locator.thread();
         let Some(thread) = svc.get(&input.thread_id).await? else {
             return Err(CoreError::NotFound("Thread not found"));

--- a/ee/tabby-schema/src/schema/thread/types.rs
+++ b/ee/tabby-schema/src/schema/thread/types.rs
@@ -5,6 +5,7 @@ use tabby_common::api::{
     code::{CodeSearchDocument, CodeSearchHit, CodeSearchScores},
     doc::{DocSearchDocument, DocSearchHit},
 };
+use validator::Validate;
 
 use crate::{juniper::relay::NodeType, Context};
 
@@ -44,11 +45,12 @@ impl NodeType for Message {
     }
 }
 
-#[derive(GraphQLInputObject, Clone)]
+#[derive(GraphQLInputObject, Clone, Validate)]
 #[graphql(context = Context)]
 pub struct UpdateMessageInput {
     pub id: ID,
     pub thread_id: ID,
+    #[validate(length(min = 1, code = "content", message = "content can not be empty"))]
     pub content: String,
 }
 


### PR DESCRIPTION
after:
![CleanShot 2024-11-08 at 17 55 35@2x](https://github.com/user-attachments/assets/63d3a1af-a100-46ae-bae4-3b1fc281d2fc)

maybe we could also show the message to report the details? @liangfung 