### PR TITLE
docs(models-http-api): add jan.ai chat example

### DIFF
--- a/website/docs/references/models-http-api/jan.ai.md
+++ b/website/docs/references/models-http-api/jan.ai.md
@@ -1,0 +1,20 @@
+# Jan AI
+
+[Jan](https://jan.ai/) is an open-source alternative to ChatGPT that runs entirely offline on your computer.
+
+Jan can run a server that provides an OpenAI-equivalent chat API at https://localhost:1337,
+allowing us to use the OpenAI kinds for chat.
+To use the Jan Server, you need to enable it in the Jan App's `Local API Server` UI.
+
+However, Jan does not yet provide API support for completion and embeddings.
+
+Below is an example for chat:
+
+```toml title="~/.tabby/config.toml"
+# Chat model
+[model.chat.http]
+kind = "openai/chat"
+model_name = "your_model"
+api_endpoint = "http://localhost:1337/v1"
+api_key = ""
+```


### PR DESCRIPTION
janAI [completion](https://cortex.so/docs/capabilities/text-generation) and [embedding](https://cortex.so/docs/capabilities/embeddings) APIs are both under construction, and not yet supported by Jan now