### PR TITLE
fix(answer): return error when request to llm failed

### DIFF
--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -172,14 +172,14 @@ impl AnswerService {
                 let chunk = match chunk {
                     Ok(chunk) => chunk,
                     Err(err) => {
-                        if let OpenAIError::StreamError(content) = err {
+                        if let OpenAIError::StreamError(content) = &err {
                             if content == "Stream ended" {
                                 break;
                             }
-                        } else {
-                            error!("Failed to get chat completion chunk: {:?}", err);
                         }
-                        break;
+                        error!("Failed to get chat completion chunk: {:?}", err);
+                        yield Err(anyhow!("Failed to get chat completion chunk: {:?}", err).into());
+                        return;
                     }
                 };
 


### PR DESCRIPTION
after:

![CleanShot 2024-11-12 at 00 50 03@2x](https://github.com/user-attachments/assets/ad01823b-ec29-4670-a715-ba2e70aacc2f)

may need your help @liangfung, looks like it's different error handling from the GraphQL API