### PR TITLE
fix(models-http-api): use completion and embedding endpoint for llama.cpp

### DIFF
--- a/crates/http-api-bindings/src/completion/llama.rs
+++ b/crates/http-api-bindings/src/completion/llama.rs
@@ -19,7 +19,7 @@ impl LlamaCppEngine {
 
         Self {
             client,
-            api_endpoint: format!("{}/completions", api_endpoint),
+            api_endpoint: format!("{}/completion", api_endpoint),
             api_key,
         }
     }

--- a/crates/http-api-bindings/src/embedding/llama.rs
+++ b/crates/http-api-bindings/src/embedding/llama.rs
@@ -16,7 +16,7 @@ impl LlamaCppEngine {
 
         Self {
             client,
-            api_endpoint: format!("{}/embeddings", api_endpoint),
+            api_endpoint: format!("{}/embedding", api_endpoint),
             api_key,
         }
     }


### PR DESCRIPTION
Test Model Health pass:

![CleanShot 2024-11-12 at 18 22 53@2x](https://github.com/user-attachments/assets/63aa2886-1c77-4738-a582-5aa3f0bc46a1)

![CleanShot 2024-11-12 at 18 23 21@2x](https://github.com/user-attachments/assets/e18e6d3e-2194-420a-a1d5-3ae55afc1978)

VSCode extension completion works:

![CleanShot 2024-11-12 at 18 31 08@2x](https://github.com/user-attachments/assets/f2446cf7-0496-442f-a3c2-64b350fb0f67)
