### PR TITLE
chore(vscode): add useVSCodeProxy option to control whether to use Vscode Proxy

### DIFF
--- a/clients/tabby-agent/src/http/proxy.ts
+++ b/clients/tabby-agent/src/http/proxy.ts
@@ -26,6 +26,7 @@ export function createProxyForUrl(url: string, configs: ProxyConfig[]): Dispatch
       logger.info("Using proxy from environment variables.");
       return new EnvHttpProxyAgent();
     } else if ("url" in config && config["url"]) {
+      // "item1, item2  item3".split(/,|\s+/). Results in: ["item1", "item2", "item3"]
       const noProxyList = config["noProxy"]?.split(/,|\s+/).map((item) => item.trim());
       if (!noProxyList || !noProxyList.includes(host)) {
         logger.info(`Using proxy ${config["url"]}.`);

--- a/clients/tabby-agent/src/http/proxy.ts
+++ b/clients/tabby-agent/src/http/proxy.ts
@@ -26,7 +26,6 @@ export function createProxyForUrl(url: string, configs: ProxyConfig[]): Dispatch
       logger.info("Using proxy from environment variables.");
       return new EnvHttpProxyAgent();
     } else if ("url" in config && config["url"]) {
-      // "item1, item2  item3".split(/,|\s+/). Results in: ["item1", "item2", "item3"]
       const noProxyList = config["noProxy"]?.split(/,|\s+/).map((item) => item.trim());
       if (!noProxyList || !noProxyList.includes(host)) {
         logger.info(`Using proxy ${config["url"]}.`);

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -6,7 +6,7 @@ import { getLogger } from "./logger";
 interface AdvancedSettings {
   "inlineCompletion.triggerMode"?: "automatic" | "manual";
   "chatEdit.history"?: number;
-  "disableProxy"?: boolean;
+  disableProxy?: boolean;
 }
 
 export interface PastServerConfig {

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -17,7 +17,7 @@ export class Config extends EventEmitter {
   constructor(private readonly context: ExtensionContext) {
     super();
     context.subscriptions.push(
-      workspace.onDidChangeConfiguration(async (event) => {
+      workspace.onDidChangeConfiguration(async (event) => {        
         if (
           event.affectsConfiguration("tabby") ||
           event.affectsConfiguration("http.proxy") ||
@@ -168,6 +168,8 @@ export class Config extends EventEmitter {
     const https = workspace.getConfiguration("https");
     const httpsProxy = https.get("proxy", "");
     const httpProxy = this.httpConfig.get("proxy", "");
+    // noProxy bypass
+    if (this.noProxy.includes(httpsProxy) || this.noProxy.includes(httpProxy)) return "";
 
     return httpsProxy || httpProxy;
   }
@@ -181,6 +183,15 @@ export class Config extends EventEmitter {
         this.httpConfig.update("proxy", value);
       }
     }
+  }
+
+  // To fit createProxyForUrl function's signature in agent.
+  get noProxy() : string[] {
+    return this.httpConfig.get("noProxy", []);
+  }
+
+  set noProxy(value: string[]) {
+    this.httpConfig.update("noProxy", value);
   }
 
   buildClientProvidedConfig(): ClientProvidedConfig {

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -17,7 +17,7 @@ export class Config extends EventEmitter {
   constructor(private readonly context: ExtensionContext) {
     super();
     context.subscriptions.push(
-      workspace.onDidChangeConfiguration(async (event) => {        
+      workspace.onDidChangeConfiguration(async (event) => {
         if (
           event.affectsConfiguration("tabby") ||
           event.affectsConfiguration("http.proxy") ||

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -6,7 +6,7 @@ import { getLogger } from "./logger";
 interface AdvancedSettings {
   "inlineCompletion.triggerMode"?: "automatic" | "manual";
   "chatEdit.history"?: number;
-  "useVSCodeProxy"?: boolean;
+  useVSCodeProxy?: boolean;
 }
 
 export interface PastServerConfig {

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -76,7 +76,7 @@ export class Config extends EventEmitter {
 
   get useVSCodeProxy(): boolean {
     const advancedSettings = this.workspace.get("settings.advanced", {}) as AdvancedSettings;
-    return advancedSettings["useVSCodeProxy"] || true;
+    return advancedSettings["useVSCodeProxy"] ?? true;
   }
 
   get maxChatEditHistory(): number {

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -186,7 +186,7 @@ export class Config extends EventEmitter {
   }
 
   // To fit createProxyForUrl function's signature in agent.
-  get noProxy() : string[] {
+  get noProxy(): string[] {
     return this.httpConfig.get("noProxy", []);
   }
 

--- a/clients/vscode/src/Config.ts
+++ b/clients/vscode/src/Config.ts
@@ -6,7 +6,7 @@ import { getLogger } from "./logger";
 interface AdvancedSettings {
   "inlineCompletion.triggerMode"?: "automatic" | "manual";
   "chatEdit.history"?: number;
-  disableProxy?: boolean;
+  "useVSCodeProxy"?: boolean;
 }
 
 export interface PastServerConfig {
@@ -74,9 +74,9 @@ export class Config extends EventEmitter {
     }
   }
 
-  get disableProxy(): boolean {
+  get useVSCodeProxy(): boolean {
     const advancedSettings = this.workspace.get("settings.advanced", {}) as AdvancedSettings;
-    return advancedSettings["disableProxy"] || true;
+    return advancedSettings["useVSCodeProxy"] || true;
   }
 
   get maxChatEditHistory(): number {
@@ -190,8 +190,8 @@ export class Config extends EventEmitter {
   }
 
   buildClientProvidedConfig(): ClientProvidedConfig {
-    const url = this.disableProxy ? "" : this.url;
-    const authorization = this.disableProxy ? "" : this.authorization;
+    const url = this.useVSCodeProxy ? this.url : "";
+    const authorization = this.useVSCodeProxy ? this.authorization : "";
 
     return {
       // Note: current we only support http.proxy | http.authorization


### PR DESCRIPTION
# Test
- Setting 
```
    "tabby.settings.advanced": {
        "useVSCodeProxy": false
    },
```
, `proxy.url` will be ""(empty string).

- 
```
    "tabby.settings.advanced": {
        "useVSCodeProxy": true
    },
```
, `proxy.url` will be "http://localhost:9000".

close #3360 