### PR TITLE
ci(release): release filename without version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,8 @@ jobs:
             fi
           }
 
-          mkdir -p dist
+          dist_dir=$(pwd)/dist
+          mkdir -p $dist_dir
 
           for llama_server in llama-server_*/llama-server_*; do
             for tabby in tabby_*/tabby_*; do
@@ -320,22 +321,29 @@ jobs:
 
               if [[ $llamav == *"$tabbyv"* ]]; then
                 echo "Creating bundle for $llamav"
-                release_dir=tabby_${llamav}
+
+                # the downloaded files may have the same folder name with release_dir
+                # put the release files in a new folder
+                build_dir=build
+                release_name=tabby_${llamav}
+                release_dir=$build_dir/$release_name
                 mkdir -p $release_dir
                 cp $llama_server $release_dir/llama-server${extname}
                 cp $tabby $release_dir/tabby${extname}
 
+                pushd $build_dir
                 # Release zip for Windows, tar.gz for macOS and Linux
                 # use `extname` to determine the platform
                 if [[ "$extname" == ".exe" ]]; then
-                  zip -r $release_dir.zip $release_dir
-                  mv $release_dir.zip dist/
+                  zip -r $release_name.zip $release_name
+                  mv $release_name.zip $dist_dir/
                 else
-                  chmod +x $release_dir/llama-server${extname} $release_dir/tabby${extname}
-                  tar zcvf $release_dir.tar.gz $release_dir
-                  mv $release_dir.tar.gz dist/
+                  chmod +x $release_name/llama-server${extname} $release_name/tabby${extname}
+                  tar zcvf $release_name.tar.gz $release_name
+                  mv $release_name.tar.gz $dist_dir/
                 fi
-                rm -rf "$release_dir"
+                rm -rf "$release_name"
+                popd
               fi
             done
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,7 +293,7 @@ jobs:
         run: ls -R
 
       - name: Creating distribution bundles
-        run: >
+        run: |
           get_file_extension() {
             local filename="$1"
             # Check if the file has an extension
@@ -306,6 +306,7 @@ jobs:
 
           dist_dir=$(pwd)/dist
           mkdir -p $dist_dir
+
           for llama_server in llama-server_*/llama-server_*; do
             for tabby in tabby_*/tabby_*; do
               llamab=$(basename $llama_server)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,17 +266,11 @@ jobs:
 
       - name: Package CUDA 11.7
         run: >
-          # Get the current release version, prefer the tag name, fallback to commit sha
-          version="${{ github.ref_name }}"
-          [ -z "$version" ] && version="${GITHUB_SHA::8}"
-          LLAMA_CPP_PLATFORM=cuda-cu11.7.1-x64 OUTPUT_NAME=tabby_${version}_x86_64-windows-msvc-cuda117 ./ci/package-win.sh
+          LLAMA_CPP_PLATFORM=cuda-cu11.7.1-x64 OUTPUT_NAME=tabby_x86_64-windows-msvc-cuda117 ./ci/package-win.sh
 
       - name: Package CUDA 12.2
         run: >
-          # Get the current release version, prefer the tag name, fallback to commit sha
-          version="${{ github.ref_name }}"
-          [ -z "$version" ] && version="${GITHUB_SHA::8}"
-          LLAMA_CPP_PLATFORM=cuda-cu12.2.0-x64 OUTPUT_NAME=tabby_${version}_x86_64-windows-msvc-cuda122 ./ci/package-win.sh
+          LLAMA_CPP_PLATFORM=cuda-cu12.2.0-x64 OUTPUT_NAME=tabby_x86_64-windows-msvc-cuda122 ./ci/package-win.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -324,13 +318,9 @@ jobs:
               llamav=${llaman#llama-server_}
               tabbyv=${tabbyn#tabby_}
 
-              # Get the current release version, prefer the tag name, fallback to commit sha
-              version="${{ github.ref_name }}"
-              [ -z "$version" ] && version="${GITHUB_SHA::8}"
-
               if [[ $llamav == *"$tabbyv"* ]]; then
                 echo "Creating bundle for $llamav"
-                release_dir=tabby_${version}_${llamav}
+                release_dir=tabby_${llamav}
                 mkdir -p $release_dir
                 cp $llama_server $release_dir/llama-server${extname}
                 cp $tabby $release_dir/tabby${extname}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,6 @@ jobs:
 
           dist_dir=$(pwd)/dist
           mkdir -p $dist_dir
-
           for llama_server in llama-server_*/llama-server_*; do
             for tabby in tabby_*/tabby_*; do
               llamab=$(basename $llama_server)

--- a/ci/package-win.sh
+++ b/ci/package-win.sh
@@ -4,7 +4,7 @@
 TABBY_VERSION=${TABBY_VERSION:-dev}
 LLAMA_CPP_VERSION=${LLAMA_CPP_VERSION:-b3571}
 LLAMA_CPP_PLATFORM=${LLAMA_CPP_PLATFORM:-cuda-cu11.7.1-x64}
-OUTPUT_NAME=${OUTPUT_NAME:-tabby_${TABBY_VERSION}_x86_64-windows-msvc-cuda117}
+OUTPUT_NAME=${OUTPUT_NAME:-tabby_x86_64-windows-msvc-cuda117}
 
 NAME=llama-${LLAMA_CPP_VERSION}-bin-win-${LLAMA_CPP_PLATFORM}
 ZIP_FILE=${NAME}.zip
@@ -18,7 +18,7 @@ cp ../tabby_x86_64-windows-msvc.exe/tabby_x86_64-windows-msvc.exe tabby.exe
 popd
 
 zip -r ${OUTPUT_NAME}.zip ${OUTPUT_NAME}
-rm -rf ${OUTPUT_NAME}
+rm -rf "${OUTPUT_NAME}"
 
 mkdir -p dist
 mv ${OUTPUT_NAME}.zip dist/


### PR DESCRIPTION
Tested on: https://github.com/zwpaper/tabby/releases/tag/v0.78.0

![CleanShot 2024-11-21 at 00 14 34@2x](https://github.com/user-attachments/assets/1159e682-4331-4f3c-95c0-0ec38640480a)
