### PR TITLE
chore: log openai completion error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "tabby-common",
  "tabby-inference",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/http-api-bindings/Cargo.toml
+++ b/crates/http-api-bindings/Cargo.toml
@@ -20,6 +20,7 @@ ollama-api-bindings = { path = "../ollama-api-bindings" }
 async-openai.workspace = true
 ratelimit = "0.10"
 tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }


### PR DESCRIPTION
we can know what is the error when completion failed

```console
2024-11-26T17:46:53.617182Z  WARN http_api_bindings::completion::openai: crates/http-api-bindings/src/completion/openai.rs:107: Error in completion event source: 404 Not Found, {  "error": {    "message": "This is a chat model and not supported in the v1/completions endpoint. Did you mean to use v1/chat/completions?",    "type": "invalid_request_error",    "param": "model",    "code": null  }}
```