### PR TITLE
chore(download): use downloader to cache registry and check capability before download

### DIFF
--- a/crates/llama-cpp-server/src/lib.rs
+++ b/crates/llama-cpp-server/src/lib.rs
@@ -284,7 +284,7 @@ async fn resolve_model_path(model_id: &str) -> String {
             GGML_MODEL_PARTITIONED_PREFIX.to_owned()
         ))
     } else {
-        let (registry, name) = parse_model_id(model_id);
+        let (registry, name) = parse_model_id(model_id).unwrap();
         let registry = ModelRegistry::new(registry).await;
         registry
             .get_model_entry_path(name)
@@ -311,9 +311,9 @@ async fn resolve_prompt_info(model_id: &str) -> PromptInfo {
     if path.exists() {
         PromptInfo::read(path.join("tabby.json"))
     } else {
-        let (registry, name) = parse_model_id(model_id);
+        let (registry, name) = parse_model_id(model_id).unwrap();
         let registry = ModelRegistry::new(registry).await;
-        let model_info = registry.get_model_info(name);
+        let model_info = registry.get_model_info(name).unwrap();
         PromptInfo {
             prompt_template: model_info.prompt_template.to_owned(),
             chat_template: model_info.chat_template.to_owned(),

--- a/crates/tabby-download/src/lib.rs
+++ b/crates/tabby-download/src/lib.rs
@@ -3,7 +3,7 @@ use std::{fs, io};
 
 use aim_downloader::{bar::WrappedBar, error::DownloadError, hash::HashChecker, https};
 use anyhow::{anyhow, bail, Result};
-use tabby_common::registry::{parse_model_id, ModelInfo, ModelRegistry};
+use tabby_common::registry::{ModelInfo, ModelRegistry};
 use tokio_retry::{
     strategy::{jitter, ExponentialBackoff},
     Retry,
@@ -192,7 +192,7 @@ pub async fn download_model(
     model: &str,
     prefer_local_file: bool,
 ) -> Result<()> {
-    download_model_impl(&registry, model, prefer_local_file)
+    download_model_impl(registry, model, prefer_local_file)
         .await
         .map_err(|err| anyhow!("Failed to fetch model '{}' due to '{}'", model, err))
 }

--- a/crates/tabby/src/download.rs
+++ b/crates/tabby/src/download.rs
@@ -1,7 +1,7 @@
-use crate::services::model::Downloader;
-
 use clap::Args;
 use tracing::info;
+
+use crate::services::model::Downloader;
 
 #[derive(Args)]
 pub struct DownloadArgs {

--- a/crates/tabby/src/download.rs
+++ b/crates/tabby/src/download.rs
@@ -1,5 +1,6 @@
+use crate::services::model::Downloader;
+
 use clap::Args;
-use tabby_download::download_model;
 use tracing::info;
 
 #[derive(Args)]
@@ -14,6 +15,14 @@ pub struct DownloadArgs {
 }
 
 pub async fn main(args: &DownloadArgs) {
-    download_model(&args.model, args.prefer_local_file).await;
+    let mut downloader = Downloader::new();
+    let (registry, _) = downloader
+        .get_model_registry_and_info(&args.model)
+        .await
+        .unwrap();
+    downloader
+        .download_model(&registry, &args.model, args.prefer_local_file)
+        .await
+        .unwrap();
     info!("model '{}' is ready", args.model);
 }

--- a/crates/tabby/src/services/model/mod.rs
+++ b/crates/tabby/src/services/model/mod.rs
@@ -124,7 +124,7 @@ impl Downloader {
         download_model(&registry, model_name, prefer_local_file).await
     }
 
-    async fn download_model_with_validation(
+    async fn download_model_with_validation_if_needed(
         &mut self,
         model_id: &str,
         validation: fn(&ModelInfo) -> Result<()>,
@@ -141,7 +141,7 @@ impl Downloader {
     }
 
     pub async fn download_completion(&mut self, model_id: &str) -> Result<()> {
-        self.download_model_with_validation(model_id, |info| {
+        self.download_model_with_validation_if_needed(model_id, |info| {
             if info.prompt_template.is_none() {
                 bail!("Model doesn't support completion");
             }
@@ -151,7 +151,7 @@ impl Downloader {
     }
 
     pub async fn download_chat(&mut self, model_id: &str) -> Result<()> {
-        self.download_model_with_validation(model_id, |info| {
+        self.download_model_with_validation_if_needed(model_id, |info| {
             if info.chat_template.is_none() {
                 bail!("Model doesn't support chat");
             }
@@ -161,7 +161,7 @@ impl Downloader {
     }
 
     pub async fn download_embedding(&mut self, model_id: &str) -> Result<()> {
-        self.download_model_with_validation(model_id, |_| Ok(()))
+        self.download_model_with_validation_if_needed(model_id, |_| Ok(()))
             .await
     }
 }

--- a/crates/tabby/src/services/model/mod.rs
+++ b/crates/tabby/src/services/model/mod.rs
@@ -103,7 +103,7 @@ impl Downloader {
         let registry = if let Some(registry) = self.registries.get(registry_name) {
             registry.clone()
         } else {
-            let registry = ModelRegistry::new(&registry_name).await;
+            let registry = ModelRegistry::new(registry_name).await;
             self.registries
                 .insert(registry_name.to_owned(), registry.clone());
             registry
@@ -121,7 +121,7 @@ impl Downloader {
         prefer_local_file: bool,
     ) -> Result<()> {
         let (_, model_name) = parse_model_id(model_id)?;
-        download_model(&registry, model_name, prefer_local_file).await
+        download_model(registry, model_name, prefer_local_file).await
     }
 
     async fn download_model_with_validation_if_needed(


### PR DESCRIPTION
1. currently Tabby fetches remote registry for every model download, this PR caches the registry inside a hash_map within the Downloader and uses it directly if fetched.
2. Downloader will check the model capability before downloading it, e.g., prompt_template for completion, chat_template for chat.

## Tests

1. Downloading functionality
![CleanShot 2024-11-27 at 18 59 50@2x](https://github.com/user-attachments/assets/b3837117-14cf-49ad-9c00-e29740e45f09)
2. Local model support
![CleanShot 2024-11-27 at 18 54 53@2x](https://github.com/user-attachments/assets/862f74d7-1bf1-41fe-b708-7f8b7804e5c2)
2. `tabby download` command functionality
![CleanShot 2024-11-27 at 18 42 47@2x](https://github.com/user-attachments/assets/821ca5a5-3df3-4832-ac11-a18ffe9b3b6e)
2. Validate chat model capability before downloading
![CleanShot 2024-11-27 at 19 02 10@2x](https://github.com/user-attachments/assets/00ca342a-0e62-4db1-a00b-17e0281b4095)
4. Validate completion model capability before downloading
![CleanShot 2024-11-27 at 19 03 17@2x](https://github.com/user-attachments/assets/b4c6c0fc-b1a9-4cfa-8b78-a7a8b105e5f3)





