### PR TITLE
fix(webserver):  validate ThreadRunOptionsInput and return error message

### DIFF
--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -1318,19 +1318,10 @@ fn from_validation_errors<S: ScalarValue>(error: ValidationErrors) -> FieldError
 
     error.errors().iter().for_each(|(field, kind)| match kind {
         validator::ValidationErrorsKind::Struct(e) => {
-            for (_, error) in e.0.iter() {
-                if let validator::ValidationErrorsKind::Field(field_errors) = error {
-                    for error in field_errors {
-                        let mut obj = Object::with_capacity(2);
-                        obj.add_field("path", Value::scalar(field.to_string()));
-                        obj.add_field(
-                            "message",
-                            Value::scalar(error.message.clone().unwrap_or_default().to_string()),
-                        );
-                        errors.push(obj.into());
-                    }
-                }
-            }
+            let mut obj = Object::with_capacity(2);
+            obj.add_field("path", field.to_string().into());
+            obj.add_field("message", Value::scalar(e.to_string()));
+            errors.push(obj.into());
         }
         validator::ValidationErrorsKind::List(_) => {
             warn!("List errors are not handled");

--- a/ee/tabby-schema/src/schema/thread/inputs.rs
+++ b/ee/tabby-schema/src/schema/thread/inputs.rs
@@ -25,6 +25,7 @@ pub struct CreateThreadAndRunInput {
     #[validate(nested)]
     pub thread: CreateThreadInput,
 
+    #[validate(nested)]
     #[graphql(default)]
     pub options: ThreadRunOptionsInput,
 }


### PR DESCRIPTION
there are two changes in this PR:

1. add `validate(nested)` to enable validation on ThreadRunOptionsInput
2. show a detailed error message when ValidationError is a struct

for `2.`, the validationError had impl Display, so we could use it directly,
for the original code, it can only show error message when the error is a `Field` inside `Struct`:

before:
![CleanShot 2024-12-06 at 01 08 46@2x](https://github.com/user-attachments/assets/45b2b411-6002-43a5-85c8-4945e7c5dd52)


after:
![CleanShot X 2024-12-06 00 55 50](https://github.com/user-attachments/assets/051aa06f-ff17-443f-a62e-a33d93934661)
