### PR TITLE
fix(tabby-agent): correctly handle auto widget completion Item

### DIFF
--- a/clients/tabby-agent/src/codeCompletion/contexts.ts
+++ b/clients/tabby-agent/src/codeCompletion/contexts.ts
@@ -174,14 +174,13 @@ export class CompletionContext {
    */
   private handleAutoComplete(request: CompletionRequest): void {
     if (!request.autoComplete?.completionItem) return;
+    // check if the completion item is the same as the curr segment
+    if (!request.autoComplete.currSeg || !request.autoComplete.completionItem.startsWith(request.autoComplete.currSeg))
+      return;
+
     this.completionItem = request.autoComplete.completionItem;
     this.currSeg = request.autoComplete.currSeg ?? "";
     this.insertSeg = request.autoComplete.insertSeg ?? "";
-
-    // check if the completion item is the same as the insert segment
-    if (!this.completionItem.startsWith(this.insertSeg)) {
-      return;
-    }
 
     const prefixText = request.text.slice(0, request.position);
     const lastIndex = prefixText.lastIndexOf(this.currSeg);


### PR DESCRIPTION
refer to comment in `clients/tabby-agent/src/codeCompletion/contexts.ts`

cons| -> console  
completionItem: console  
insertPosition: 4  
insertSeg: ole  
currSeg: cons

We should not continue processing the autocomplete item if the `completionItem` is "console" but the user typed "cnt" as `currSeg`. Make sure that the characters typed by the user that trigger the completionItem match the completionItem’s prefix.