### PR TITLE
fix(ui): fix the style of inline code in Answer Engine

### DIFF
--- a/ee/tabby-ui/components/message-markdown/code.tsx
+++ b/ee/tabby-ui/components/message-markdown/code.tsx
@@ -83,7 +83,7 @@ export function CodeElement({
         {...props}
       >
         {isSymbolNavigable && (
-          <IconSquareChevronRight className="h-3.5 w-3.5 text-primary shrink-0" />
+          <IconSquareChevronRight className="h-3.5 w-3.5 shrink-0 text-primary" />
         )}
         <span
           className={cn('self-baseline', {

--- a/ee/tabby-ui/components/message-markdown/code.tsx
+++ b/ee/tabby-ui/components/message-markdown/code.tsx
@@ -73,20 +73,17 @@ export function CodeElement({
 
     return (
       <code
-        className={cn(
-          'group/symbol inline-flex flex-nowrap items-center',
-          className,
-          {
-            symbol: !!lookupSymbol,
-            'bg-muted leading-5': !!lookupSymbol && !isSymbolNavigable,
-            'cursor-pointer hover:bg-muted/50 border': isSymbolNavigable
-          }
-        )}
+        className={cn('group/symbol', className, {
+          symbol: !!lookupSymbol,
+          'bg-muted leading-5 py-0.5': !!lookupSymbol && !isSymbolNavigable,
+          'inline-flex items-center gap-1 cursor-pointer hover:bg-muted/50 border':
+            isSymbolNavigable
+        })}
         onClick={handleClick}
         {...props}
       >
         {isSymbolNavigable && (
-          <IconSquareChevronRight className="h-3.5 w-3.5 text-primary" />
+          <IconSquareChevronRight className="h-3.5 w-3.5 text-primary shrink-0" />
         )}
         <span
           className={cn('self-baseline', {

--- a/ee/tabby-ui/components/message-markdown/code.tsx
+++ b/ee/tabby-ui/components/message-markdown/code.tsx
@@ -74,11 +74,11 @@ export function CodeElement({
     return (
       <code
         className={cn(
-          'group/symbol inline-flex flex-nowrap items-center gap-1',
+          'group/symbol inline-flex flex-nowrap items-center',
           className,
           {
             symbol: !!lookupSymbol,
-            'bg-muted leading-5': !isSymbolNavigable,
+            'bg-muted leading-5': !!lookupSymbol && !isSymbolNavigable,
             'cursor-pointer hover:bg-muted/50 border': isSymbolNavigable
           }
         )}

--- a/ee/tabby-ui/components/message-markdown/style.css
+++ b/ee/tabby-ui/components/message-markdown/style.css
@@ -3,7 +3,7 @@
 }
 
 .message-markdown code.symbol {
-  @apply rounded-md font-normal mx-1 px-1 gap-1;
+  @apply rounded-md font-normal mx-1 px-1;
 }
 
 .message-markdown code.symbol::before,

--- a/ee/tabby-ui/components/message-markdown/style.css
+++ b/ee/tabby-ui/components/message-markdown/style.css
@@ -3,7 +3,7 @@
 }
 
 .message-markdown code.symbol {
-  @apply rounded-md font-normal mx-1 px-1;
+  @apply rounded-md font-normal mx-1 px-1 gap-1;
 }
 
 .message-markdown code.symbol::before,


### PR DESCRIPTION
### Before
<img width="934" alt="image" src="https://github.com/user-attachments/assets/1138d9bd-22f8-49fa-9c8b-9b1a12e56fcb">

### After
<img width="946" alt="image" src="https://github.com/user-attachments/assets/5baa92fc-1e78-4d07-8840-4d32fa6365a4">
