### PR TITLE
refactor(structured_doc): split pre-sync stage to optimize pull request indexing speed

### DIFF
--- a/.changes/unreleased/Fixed and Improvements-20241212-095738.yaml
+++ b/.changes/unreleased/Fixed and Improvements-20241212-095738.yaml
@@ -1,0 +1,3 @@
+kind: Fixed and Improvements
+body: Refactors the pull request indexing process to enhance the speed of incremental indexing for pull docs.
+time: 2024-12-12T09:57:38.860665+08:00

--- a/crates/tabby-index/src/indexer_tests.rs
+++ b/crates/tabby-index/src/indexer_tests.rs
@@ -72,7 +72,7 @@ mod structured_doc_tests {
         let updated_at = chrono::Utc::now();
         let res = tokio::runtime::Runtime::new().unwrap().block_on(async {
             let updated = indexer
-                .presync(StructuredDocState {
+                .presync(&StructuredDocState {
                     id: doc.id().to_string(),
                     updated_at,
                     deleted: false,
@@ -118,7 +118,7 @@ mod structured_doc_tests {
         let updated_at = chrono::Utc::now();
         let res = tokio::runtime::Runtime::new().unwrap().block_on(async {
             let updated = indexer
-                .presync(StructuredDocState {
+                .presync(&StructuredDocState {
                     id: doc.id().to_string(),
                     updated_at,
                     deleted: false,

--- a/crates/tabby-index/src/indexer_tests.rs
+++ b/crates/tabby-index/src/indexer_tests.rs
@@ -72,14 +72,13 @@ mod structured_doc_tests {
         let updated_at = chrono::Utc::now();
         let res = tokio::runtime::Runtime::new().unwrap().block_on(async {
             let updated = indexer
-                .sync(
-                    StructuredDocState {
-                        updated_at,
-                        deleted: false,
-                    },
-                    doc,
-                )
-                .await;
+                .presync(StructuredDocState {
+                    id: doc.id().to_string(),
+                    updated_at,
+                    deleted: false,
+                })
+                .await
+                && indexer.sync(doc).await;
             println!("{}", updated);
             updated
         });
@@ -119,14 +118,13 @@ mod structured_doc_tests {
         let updated_at = chrono::Utc::now();
         let res = tokio::runtime::Runtime::new().unwrap().block_on(async {
             let updated = indexer
-                .sync(
-                    StructuredDocState {
-                        updated_at,
-                        deleted: false,
-                    },
-                    doc,
-                )
-                .await;
+                .presync(StructuredDocState {
+                    id: doc.id().to_string(),
+                    updated_at,
+                    deleted: false,
+                })
+                .await
+                && indexer.sync(doc).await;
             println!("{}", updated);
             updated
         });
@@ -163,18 +161,9 @@ mod structured_doc_tests {
             }),
         };
 
-        let updated_at = chrono::Utc::now();
-        let res = tokio::runtime::Runtime::new().unwrap().block_on(async {
-            indexer
-                .sync(
-                    StructuredDocState {
-                        updated_at,
-                        deleted: false,
-                    },
-                    doc,
-                )
-                .await
-        });
+        let res = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { indexer.sync(doc).await });
         assert!(res);
         indexer.commit();
 

--- a/crates/tabby-index/src/structured_doc/public.rs
+++ b/crates/tabby-index/src/structured_doc/public.rs
@@ -30,6 +30,8 @@ pub struct StructuredDocState {
     // For instance, a closed pull request will be marked as deleted,
     // prompting the indexer to remove it from the index.
     pub deleted: bool,
+
+    pub raw: Option<serde_json::Value>,
 }
 
 pub struct StructuredDocIndexer {
@@ -46,7 +48,7 @@ impl StructuredDocIndexer {
 
     // Runs pre-sync checks to determine if the document needs to be updated.
     // Returns false if `sync` is not required to be called.
-    pub async fn presync(&self, state: StructuredDocState) -> bool {
+    pub async fn presync(&self, state: &StructuredDocState) -> bool {
         if state.deleted {
             self.indexer.delete(&state.id);
             return false;

--- a/crates/tabby-index/src/structured_doc/public.rs
+++ b/crates/tabby-index/src/structured_doc/public.rs
@@ -30,8 +30,6 @@ pub struct StructuredDocState {
     // For instance, a closed pull request will be marked as deleted,
     // prompting the indexer to remove it from the index.
     pub deleted: bool,
-
-    pub raw: Option<serde_json::Value>,
 }
 
 pub struct StructuredDocIndexer {

--- a/ee/tabby-schema/src/schema/integration.rs
+++ b/ee/tabby-schema/src/schema/integration.rs
@@ -124,5 +124,5 @@ pub trait IntegrationService: Send + Sync {
     ) -> Result<Vec<Integration>>;
 
     async fn get_integration(&self, id: ID) -> Result<Integration>;
-    async fn update_integration_sync_status(&self, id: ID, error: Option<String>) -> Result<()>;
+    async fn update_integration_sync_status(&self, id: &ID, error: Option<String>) -> Result<()>;
 }

--- a/ee/tabby-schema/src/schema/repository/third_party.rs
+++ b/ee/tabby-schema/src/schema/repository/third_party.rs
@@ -105,7 +105,7 @@ pub trait ThirdPartyRepositoryService: Send + Sync + RepositoryProvider {
         last: Option<usize>,
     ) -> Result<Vec<ProvidedRepository>>;
 
-    async fn get_provided_repository(&self, id: ID) -> Result<ProvidedRepository>;
+    async fn get_provided_repository(&self, id: &ID) -> Result<ProvidedRepository>;
 
     async fn update_repository_active(&self, id: ID, active: bool) -> Result<()>;
     async fn upsert_repository(

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
@@ -163,12 +163,18 @@ impl SchedulerGithubGitlabJob {
                 );
             }
 
-            if !index.presync(state).await {
+            if !index.presync(&state).await {
                 continue;
             }
+
+            if state.raw.as_ref().is_none() {
+                logkit::warn!("Pull {} has no raw data", id);
+                continue;
+            }
+
             let pull = get_github_pull_doc(
                 &repository.source_id(),
-                id,
+                state.raw.unwrap(),
                 integration.api_base(),
                 &repository.display_name,
                 &integration.access_token,
@@ -211,7 +217,7 @@ impl SchedulerGithubGitlabJob {
             let mut count = 0;
             let mut num_updated = 0;
             for await (state, doc) in issue_stream {
-                if index.presync(state).await && index.sync(doc).await {
+                if index.presync(&state).await && index.sync(doc).await {
                     num_updated += 1
                 }
                 count += 1;

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
@@ -138,7 +138,7 @@ impl SchedulerGithubGitlabJob {
         repository: &ProvidedRepository,
         embedding: Arc<dyn Embedding>,
     ) -> tabby_schema::Result<()> {
-        let mut pull_state_stream = match fetch_all_pull_states(&integration, &repository).await {
+        let mut pull_state_stream = match fetch_all_pull_states(integration, repository).await {
             Ok(s) => s,
             Err(e) => {
                 integration_service
@@ -195,7 +195,7 @@ impl SchedulerGithubGitlabJob {
         repository: &ProvidedRepository,
         embedding: Arc<dyn Embedding>,
     ) -> tabby_schema::Result<()> {
-        let issue_stream = match fetch_all_issues(&integration, &repository).await {
+        let issue_stream = match fetch_all_issues(integration, repository).await {
             Ok(s) => s,
             Err(e) => {
                 integration_service

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use issues::{list_github_issues, list_gitlab_issues};
 use juniper::ID;
-use pulls::list_github_pulls;
+use pulls::{get_github_pull_doc, list_github_pull_states};
 use serde::{Deserialize, Serialize};
 use tabby_common::config::CodeRepository;
 use tabby_index::public::{CodeIndexer, StructuredDoc, StructuredDocIndexer, StructuredDocState};
@@ -90,7 +90,7 @@ impl SchedulerGithubGitlabJob {
         integration_service: Arc<dyn IntegrationService>,
     ) -> tabby_schema::Result<()> {
         let repository = repository_service
-            .get_provided_repository(self.repository_id)
+            .get_provided_repository(&self.repository_id)
             .await?;
         let integration = integration_service
             .get_integration(repository.integration_id.clone())
@@ -116,50 +116,111 @@ impl SchedulerGithubGitlabJob {
             "Indexing documents for repository {}",
             repository.display_name
         );
+
+        self.sync_issues(
+            &integration,
+            integration_service.clone(),
+            &repository,
+            embedding.clone(),
+        )
+        .await?;
+
+        self.sync_pulls(&integration, integration_service, &repository, embedding)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn sync_pulls(
+        &self,
+        integration: &Integration,
+        integration_service: Arc<dyn IntegrationService>,
+        repository: &ProvidedRepository,
+        embedding: Arc<dyn Embedding>,
+    ) -> tabby_schema::Result<()> {
+        let mut pull_state_stream = match fetch_all_pull_states(&integration, &repository).await {
+            Ok(s) => s,
+            Err(e) => {
+                integration_service
+                    .update_integration_sync_status(&integration.id, Some(e.to_string()))
+                    .await?;
+                logkit::error!("Failed to fetch pulls: {}", e);
+                return Ok(());
+            }
+        };
+
+        let mut count = 0;
+        let mut num_updated = 0;
+
         let index = StructuredDocIndexer::new(embedding);
+        while let Some((id, state)) = pull_state_stream.next().await {
+            count += 1;
+            if count % 100 == 0 {
+                logkit::info!(
+                    "{} pull docs seen, {} pull docs updated",
+                    count,
+                    num_updated
+                );
+            }
+
+            if !index.presync(state).await {
+                continue;
+            }
+            let pull = get_github_pull_doc(
+                &repository.source_id(),
+                id,
+                integration.api_base(),
+                &repository.display_name,
+                &integration.access_token,
+            )
+            .await?;
+
+            index.sync(pull).await;
+            num_updated += 1;
+        }
+        logkit::info!(
+            "{} pull docs seen, {} pull docs updated",
+            count,
+            num_updated
+        );
+        index.commit();
+
+        Ok(())
+    }
+
+    async fn sync_issues(
+        &self,
+        integration: &Integration,
+        integration_service: Arc<dyn IntegrationService>,
+        repository: &ProvidedRepository,
+        embedding: Arc<dyn Embedding>,
+    ) -> tabby_schema::Result<()> {
         let issue_stream = match fetch_all_issues(&integration, &repository).await {
             Ok(s) => s,
             Err(e) => {
                 integration_service
-                    .update_integration_sync_status(integration.id, Some(e.to_string()))
+                    .update_integration_sync_status(&integration.id, Some(e.to_string()))
                     .await?;
                 logkit::error!("Failed to fetch issues: {}", e);
                 return Err(e);
             }
         };
 
-        let pull_stream = match fetch_all_pulls(&integration, &repository).await {
-            Ok(s) => Some(s),
-            Err(e) => {
-                integration_service
-                    .update_integration_sync_status(integration.id, Some(e.to_string()))
-                    .await?;
-                logkit::warn!("Failed to fetch pulls: {}", e);
-                None
-            }
-        };
-
+        let index = StructuredDocIndexer::new(embedding);
         stream! {
             let mut count = 0;
             let mut num_updated = 0;
-            let combined_stream = if let Some(pull_stream) = pull_stream {
-                issue_stream.chain(pull_stream).boxed()
-            } else {
-                issue_stream.boxed()
-            };
-
-            for await (state, doc) in combined_stream {
-            if index.sync(state, doc).await {
-                num_updated += 1
+            for await (state, doc) in issue_stream {
+                if index.presync(state).await && index.sync(doc).await {
+                    num_updated += 1
+                }
+                count += 1;
+                if count % 100 == 0 {
+                    logkit::info!("{} issue docs seen, {} issue docs updated", count, num_updated);
+                };
             }
 
-            count += 1;
-            if count % 100 == 0 {
-                logkit::info!("{} docs seen, {} docs updated", count, num_updated);
-            };
-            }
-
-            logkit::info!("{} docs seen, {} docs updated", count, num_updated);
+            logkit::info!("{} issue docs seen, {} issue docs updated", count, num_updated);
             index.commit();
         }
         .count()
@@ -212,13 +273,12 @@ async fn fetch_all_issues(
 
     Ok(s)
 }
-async fn fetch_all_pulls(
+async fn fetch_all_pull_states(
     integration: &Integration,
     repository: &ProvidedRepository,
-) -> tabby_schema::Result<BoxStream<'static, (StructuredDocState, StructuredDoc)>> {
+) -> tabby_schema::Result<BoxStream<'static, (u64, StructuredDocState)>> {
     match &integration.kind {
-        IntegrationKind::Github | IntegrationKind::GithubSelfHosted => Ok(list_github_pulls(
-            &repository.source_id(),
+        IntegrationKind::Github | IntegrationKind::GithubSelfHosted => Ok(list_github_pull_states(
             integration.api_base(),
             &repository.display_name,
             &integration.access_token,

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/issues.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/issues.rs
@@ -70,6 +70,7 @@ pub async fn list_github_issues(
                     id: doc.id().to_string(),
                     updated_at: issue.updated_at,
                     deleted: false,
+                    raw: None,
                 }, doc);
             }
 
@@ -137,6 +138,7 @@ pub async fn list_gitlab_issues(
                 id: doc.id().to_string(),
                 updated_at: issue.updated_at,
                 deleted: false,
+                raw: None,
             }, doc);
         }
     };

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/issues.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/issues.rs
@@ -67,6 +67,7 @@ pub async fn list_github_issues(
                     })
                 };
                 yield (StructuredDocState {
+                    id: doc.id().to_string(),
                     updated_at: issue.updated_at,
                     deleted: false,
                 }, doc);
@@ -133,6 +134,7 @@ pub async fn list_gitlab_issues(
                 closed: issue.state == "closed",
             })};
             yield (StructuredDocState {
+                id: doc.id().to_string(),
                 updated_at: issue.updated_at,
                 deleted: false,
             }, doc);

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/issues.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/issues.rs
@@ -70,7 +70,6 @@ pub async fn list_github_issues(
                     id: doc.id().to_string(),
                     updated_at: issue.updated_at,
                     deleted: false,
-                    raw: None,
                 }, doc);
             }
 
@@ -138,7 +137,6 @@ pub async fn list_gitlab_issues(
                 id: doc.id().to_string(),
                 updated_at: issue.updated_at,
                 deleted: false,
-                raw: None,
             }, doc);
         }
     };

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
@@ -61,7 +61,7 @@ pub async fn list_github_pull_states(
                 if let Some(state) = pull.state {
                     if state == IssueState::Closed && pull.merged_at.is_none() {
                         yield (pull.number, StructuredDocState{
-                            id: id,
+                            id,
                             updated_at: pull.updated_at.unwrap(),
                             deleted: true,
                         });
@@ -70,8 +70,8 @@ pub async fn list_github_pull_states(
                 }
 
                 yield (pull.number, StructuredDocState{
-                    id: id,
-                    updated_at: pull.updated_at.unwrap_or_else(|| chrono::Utc::now()),
+                    id,
+                    updated_at: pull.updated_at.unwrap_or_else(chrono::Utc::now),
                     deleted: false,
                 });
             }

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
@@ -9,12 +9,21 @@ use tracing::debug;
 
 use super::error::octocrab_error_message;
 
-pub async fn list_github_pulls(
-    source_id: &str,
+// FIXME(kweizh): we can only get StructuredDoc id after constructing the StructuredDoc
+// but we need to pass the id to the StructuredDocState
+// so we need to refactor the id() method in StructuredDoc
+fn pull_id(pull: &octocrab::models::pulls::PullRequest) -> String {
+    pull.html_url
+        .clone()
+        .map(|url| url.to_string())
+        .unwrap_or_else(|| pull.url.clone())
+}
+
+pub async fn list_github_pull_states(
     api_base: &str,
     full_name: &str,
     access_token: &str,
-) -> Result<impl Stream<Item = (StructuredDocState, StructuredDoc)>> {
+) -> Result<impl Stream<Item = (u64, StructuredDocState)>> {
     let octocrab = Octocrab::builder()
         .personal_token(access_token.to_string())
         .base_uri(api_base)?
@@ -26,7 +35,6 @@ pub async fn list_github_pulls(
 
     let owner = owner.to_owned();
     let repo = repo.to_owned();
-    let source_id = source_id.to_owned();
     let s = stream! {
         let mut page = 1u32;
         loop {
@@ -47,80 +55,25 @@ pub async fn list_github_pulls(
             let pages = response.number_of_pages().unwrap_or_default();
 
             for pull in response.items {
-                let url = pull.html_url.map(|url| url.to_string()).unwrap_or_else(|| pull.url);
-                let title = pull.title.clone().unwrap_or_default();
-                let body = pull.body.clone().unwrap_or_default();
-
-                let author = pull.user.as_ref().map(|user| user.login.clone());
-                let email = if let Some(author) = author {
-                    match octocrab.users(&author).profile().await {
-                        Ok(profile) => {
-                            profile.email
-                        }
-                        Err(e) => {
-                            debug!("Failed to fetch user profile for {}: {}", author, octocrab_error_message(e));
-                            None
-                        }
-                    }
-                } else {
-                    None
-                };
-
-                let doc = StructuredDoc {
-                    source_id: source_id.to_string(),
-                    fields: StructuredDocFields::Pull(StructuredDocPullDocumentFields {
-                        link: url.clone(),
-                        title,
-                        author_email: email.clone(),
-                        body,
-                        merged: pull.merged_at.is_some(),
-                        diff: String::new(),
-                    }),
-                };
+                let id = pull_id(&pull);
 
                 // skip closed but not merged pulls
                 if let Some(state) = pull.state {
                     if state == IssueState::Closed && pull.merged_at.is_none() {
-                        yield (StructuredDocState{
+                        yield (pull.number, StructuredDocState{
+                            id: id,
                             updated_at: pull.updated_at.unwrap(),
                             deleted: true,
-                        }, doc);
+                        });
                         continue;
                     }
                 }
 
-                // Fetch the diff only if the number of changed lines is fewer than 100,000,
-                // assuming 80 characters per line,
-                // and the size of the diff is less than 8MB.
-                let diff = if pull.additions.unwrap_or_default() + pull.deletions.unwrap_or_default()  < 100*1024 {
-                    match octocrab.pulls(&owner, &repo).get_diff(pull.number).await {
-                        Ok(x) => x,
-                        Err(e) => {
-                            logkit::error!("Failed to fetch pull request diff for {}: {}",
-                                url, octocrab_error_message(e));
-                            continue
-                        }
-                    }
-                } else {
-                    String::new()
-                };
-
-                let doc = StructuredDoc {
-                    source_id: source_id.to_string(),
-                    fields: StructuredDocFields::Pull(StructuredDocPullDocumentFields {
-                        link: url,
-                        title: pull.title.unwrap_or_default(),
-                        author_email: email,
-                        body: pull.body.unwrap_or_default(),
-                        diff,
-                        merged: pull.merged_at.is_some(),
-                })};
-
-
-                yield (StructuredDocState{
-                    updated_at: pull.updated_at.unwrap(),
+                yield (pull.number, StructuredDocState{
+                    id: id,
+                    updated_at: pull.updated_at.unwrap_or_else(|| chrono::Utc::now()),
                     deleted: false,
-                }, doc);
+                });
             }
 
             page += 1;
@@ -131,4 +84,83 @@ pub async fn list_github_pulls(
     };
 
     Ok(s)
+}
+
+pub async fn get_github_pull_doc(
+    source_id: &str,
+    id: u64,
+    api_base: &str,
+    full_name: &str,
+    access_token: &str,
+) -> Result<StructuredDoc> {
+    let octocrab = Octocrab::builder()
+        .personal_token(access_token.to_string())
+        .base_uri(api_base)?
+        .build()?;
+
+    let (owner, repo) = full_name
+        .split_once('/')
+        .ok_or_else(|| anyhow!("Invalid repository name"))?;
+
+    let owner = owner.to_owned();
+    let repo = repo.to_owned();
+    let source_id = source_id.to_owned();
+
+    let pull = octocrab.pulls(&owner, &repo).get(id).await.map_err(|e| {
+        anyhow!(
+            "Failed to fetch pull requests: {}",
+            octocrab_error_message(e)
+        )
+    })?;
+
+    let url = pull
+        .html_url
+        .map(|url| url.to_string())
+        .unwrap_or_else(|| pull.url);
+    let title = pull.title.clone().unwrap_or_default();
+    let body = pull.body.clone().unwrap_or_default();
+
+    let author = pull.user.as_ref().map(|user| user.login.clone());
+    let email = if let Some(author) = author {
+        match octocrab.users(&author).profile().await {
+            Ok(profile) => profile.email,
+            Err(e) => {
+                debug!("Failed to fetch user profile for {}: {}", author, e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // Fetch the diff only if the number of changed lines is fewer than 100,000,
+    // assuming 80 characters per line,
+    // and the size of the diff is less than 8MB.
+    let diff =
+        if pull.additions.unwrap_or_default() + pull.deletions.unwrap_or_default() < 100 * 1024 {
+            octocrab
+                .pulls(&owner, &repo)
+                .get_diff(pull.number)
+                .await
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to fetch pull request diff: {}",
+                        octocrab_error_message(e)
+                    )
+                })?
+        } else {
+            String::new()
+        };
+
+    Ok(StructuredDoc {
+        source_id: source_id.to_string(),
+        fields: StructuredDocFields::Pull(StructuredDocPullDocumentFields {
+            link: url.clone(),
+            title,
+            author_email: email.clone(),
+            body,
+            merged: pull.merged_at.is_some(),
+            diff,
+        }),
+    })
 }

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
@@ -1,8 +1,10 @@
 use anyhow::{anyhow, Result};
 use async_stream::stream;
 use futures::Stream;
-use octocrab::models::pulls::PullRequest;
-use octocrab::{models::IssueState, Octocrab};
+use octocrab::{
+    models::{pulls::PullRequest, IssueState},
+    Octocrab,
+};
 use tabby_index::public::{
     StructuredDoc, StructuredDocFields, StructuredDocPullDocumentFields, StructuredDocState,
 };

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
@@ -109,7 +109,11 @@ pub async fn get_github_pull_doc(
         match octocrab.users(&author).profile().await {
             Ok(profile) => profile.email,
             Err(e) => {
-                debug!("Failed to fetch user profile for {}: {}", author, e);
+                debug!(
+                    "Failed to fetch user profile for {}: {}",
+                    author,
+                    octocrab_error_message(e)
+                );
                 None
             }
         }

--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -54,15 +54,17 @@ impl WebCrawlerJob {
             };
 
             num_docs += 1;
-            indexer
-                .sync(
-                    StructuredDocState {
-                        updated_at: Utc::now(),
-                        deleted: false,
-                    },
-                    source_doc,
-                )
-                .await;
+
+            if indexer
+                .presync(StructuredDocState {
+                    id: source_doc.id().to_string(),
+                    updated_at: Utc::now(),
+                    deleted: false,
+                })
+                .await
+            {
+                indexer.sync(source_doc).await;
+            }
         }
         logkit::info!("Crawled {} documents from '{}'", num_docs, self.url);
         indexer.commit();

--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -60,7 +60,6 @@ impl WebCrawlerJob {
                     id: source_doc.id().to_string(),
                     updated_at: Utc::now(),
                     deleted: false,
-                    raw: None,
                 })
                 .await
             {

--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -56,10 +56,11 @@ impl WebCrawlerJob {
             num_docs += 1;
 
             if indexer
-                .presync(StructuredDocState {
+                .presync(&StructuredDocState {
                     id: source_doc.id().to_string(),
                     updated_at: Utc::now(),
                     deleted: false,
+                    raw: None,
                 })
                 .await
             {

--- a/ee/tabby-webserver/src/service/integration.rs
+++ b/ee/tabby-webserver/src/service/integration.rs
@@ -133,7 +133,7 @@ impl IntegrationService for IntegrationServiceImpl {
         Ok(self.db.get_integration(id.as_rowid()?).await?.try_into()?)
     }
 
-    async fn update_integration_sync_status(&self, id: ID, error: Option<String>) -> Result<()> {
+    async fn update_integration_sync_status(&self, id: &ID, error: Option<String>) -> Result<()> {
         self.db
             .update_integration_error(id.as_rowid()?, error)
             .await?;
@@ -191,7 +191,7 @@ mod tests {
         // Test updating error status for gitlab provider
         tokio::time::sleep(Duration::from_secs(1)).await;
         integration
-            .update_integration_sync_status(id.clone(), Some("error".into()))
+            .update_integration_sync_status(&id, Some("error".into()))
             .await
             .unwrap();
 
@@ -200,7 +200,7 @@ mod tests {
 
         // Test successful status (no error)
         integration
-            .update_integration_sync_status(id.clone(), None)
+            .update_integration_sync_status(&id, None)
             .await
             .unwrap();
 
@@ -246,7 +246,7 @@ mod tests {
 
         // Test integration status is failed after updating sync status with an error
         integration
-            .update_integration_sync_status(id.clone(), Some("error".into()))
+            .update_integration_sync_status(&id, Some("error".into()))
             .await
             .unwrap();
 
@@ -288,7 +288,7 @@ mod tests {
 
         // Test integration status is ready after a successful sync and an update which changes no fields
         integration
-            .update_integration_sync_status(id.clone(), None)
+            .update_integration_sync_status(&id, None)
             .await
             .unwrap();
         integration

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -114,7 +114,7 @@ impl RepositoryService for RepositoryServiceImpl {
             | RepositoryKind::GithubSelfHosted
             | RepositoryKind::GitlabSelfHosted => self
                 .third_party()
-                .get_provided_repository(id.clone())
+                .get_provided_repository(id)
                 .await
                 .map(|repo| to_repository(*kind, repo)),
         };


### PR DESCRIPTION
1. main branch introduces a feature to retrieve the pull request author's email from GitHub, which requires an additional profile API call. This results in an extra 4 minutes of processing time compared to r0.21.  
2. This pull request refactors the pull request synchronization process into pre-sync and sync stages. It skips unnecessary calls for author details or diffs when no updates are required, reducing subsequent indexing time by over 6 minutes.


---
## Test result

### Before(commit 975265635aae1077bacc58c23a3c9d5b865f25f0 (HEAD -> r0.21, tag: v0.21.2-rc.2)):

1. first indexing: 
![CleanShot 2024-12-11 at 16 16 21@2x](https://github.com/user-attachments/assets/57ab3519-4ad2-44e1-a6c6-d6cef941cc0e)

3. second indexing: 
![CleanShot 2024-12-11 at 17 46 06@2x](https://github.com/user-attachments/assets/833a8860-64da-49be-8b6f-99955627de34)

### Before(commit 675c654233a72b01407ede5eb322be3518fd4df8 (HEAD -> main, up/main)):
1. first indexing:
![CleanShot 2024-12-12 at 09 22 30@2x](https://github.com/user-attachments/assets/b2f3e6cb-d2b0-40ca-8044-3ed831971b84)

2. second indexing: 
![CleanShot 2024-12-12 at 09 31 32@2x](https://github.com/user-attachments/assets/71ee6240-8b31-4881-9919-5ab4e4b80d6e)


### After

1. first indexing:
![CleanShot 2024-12-12 at 02 10 53@2x](https://github.com/user-attachments/assets/3c5ee82b-cd3a-416f-a1a8-3167b0986546)

2. second indexing:
![CleanShot 2024-12-12 at 02 12 04@2x](https://github.com/user-attachments/assets/dc72cf92-ba78-4974-b469-a8376a8573d9)

