### PR TITLE
chore: reduce unnecessary GitHub pull backtrace log

### DIFF
--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/error.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/error.rs
@@ -6,6 +6,11 @@ pub fn octocrab_error_message(err: octocrab::Error) -> String {
             format!("GitHub error: {} {}", source.status_code, source.message)
         }
 
+        // no need to print the Json error backtrace
+        octocrab::Error::Json { source, .. } => {
+            format!("Json error: {}", source)
+        }
+
         // the other errors have impl Display or Debug
         _ => err.to_string(),
     }

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs
@@ -58,7 +58,7 @@ pub async fn list_github_pulls(
                             profile.email
                         }
                         Err(e) => {
-                            debug!("Failed to fetch user profile for {}: {}", author, e);
+                            debug!("Failed to fetch user profile for {}: {}", author, octocrab_error_message(e));
                             None
                         }
                     }


### PR DESCRIPTION
before:

```
2024-12-11T11:10:39.147465Z DEBUG tabby_webserver::service::background_job::third_party_integration::pulls: ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs:61: Failed to fetch user profile for 0jdxt: JSON Error in name: invalid type: null, expected a string at line 1 column 906
Found at    0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/backtrace.rs:331:13
   3: snafu::backtrace_impl::<impl snafu::GenerateImplicitData for std::backtrace::Backtrace>::generate
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/snafu-0.8.3/src/backtrace_impl_std.rs:5:9
   4: snafu::GenerateImplicitData::generate_with_source
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/snafu-0.8.3/src/lib.rs:1280:9
   5: <octocrab::error::JsonSnafu as snafu::IntoError<octocrab::error::Error>>::into_error
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/octocrab-0.38.0/src/error.rs:23:10
   6: <core::result::Result<T,E> as snafu::ResultExt<T,E>>::context
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/snafu-0.8.3/src/lib.rs:811:31
   7: <T as octocrab::from_response::FromResponse>::from_response::{{closure}}
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/octocrab-0.38.0/src/from_response.rs:23:16
   8: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/future/future.rs:123:9
   9: octocrab::Octocrab::get_with_headers::{{closure}}
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/octocrab-0.38.0/src/lib.rs:1280:68
  10: octocrab::Octocrab::get::{{closure}}
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/octocrab-0.38.0/src/lib.rs:1219:56
  11: octocrab::api::users::UserHandler::profile::{{closure}}
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/octocrab-0.38.0/src/api/users.rs:25:43
  12: tabby_webserver::service::background_job::third_party_integration::pulls::list_github_pulls::{{closure}}::{{closure}}
             at ./ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs:56:61
  13: <async_stream::async_stream::AsyncStream<T,U> as futures_core::stream::Stream>::poll_next
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-stream-0.3.5/src/async_stream.rs:56:13
  14: <core::pin::Pin<P> as futures_core::stream::Stream>::poll_next
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-core-0.3.30/src/stream.rs:120:9
  15: <futures_util::stream::stream::chain::Chain<St1,St2> as futures_core::stream::Stream>::poll_next
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-util-0.3.30/src/stream/stream/chain.rs:56:9
  16: <core::pin::Pin<P> as futures_core::stream::Stream>::poll_next
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-core-0.3.30/src/stream.rs:120:9
  17: <core::pin::Pin<P> as futures_core::stream::Stream>::poll_next
             at /Users/kweizh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/futures-core-0.3.30/src/stream.rs:120:9
  18: <&mut S as futures_core::stream::Stream>::poll_
```

after:

```
2024-12-11T11:15:40.021544Z DEBUG tabby_webserver::service::background_job::third_party_integration::pulls: ee/tabby-webserver/src/service/background_job/third_party_integration/pulls.rs:61: Failed to fetch user profile for 0jdxt: Json error: name: invalid type: null, expected a string at line 1 column 906
```