### PR TITLE
fix(graphQL): fix wrong read status when list notifications

### DIFF
--- a/ee/tabby-db/src/notifications.rs
+++ b/ee/tabby-db/src/notifications.rs
@@ -109,10 +109,10 @@ SELECT
     notifications.id,
     notifications.created_at,
     notifications.updated_at,
-    recipient,
-    content,
+    notifications.recipient,
+    notifications.content,
     CASE
-        WHEN read_notifications.user_id IS NOT NULL THEN 1
+        WHEN read_notifications.user_id = '{user_id}' THEN 1
         ELSE 0
     END AS read
 FROM
@@ -121,6 +121,7 @@ LEFT JOIN
     read_notifications
 ON
     notifications.id = read_notifications.notification_id
+    AND read_notifications.user_id = '{user_id}'
 WHERE
     ({recipient_clause})
     AND notifications.created_at > '{date_7days_ago}'


### PR DESCRIPTION
1. admin list all
![CleanShot 2024-12-13 at 11 54 07@2x](https://github.com/user-attachments/assets/a90f0b99-0897-43e4-9013-3d1951b843e0)
2. user list users
![CleanShot 2024-12-13 at 11 54 53@2x](https://github.com/user-attachments/assets/87305f33-d212-4a14-9bbf-1019169ebd90)
3. admin mark all read
![CleanShot 2024-12-13 at 11 58 22@2x](https://github.com/user-attachments/assets/60c25a03-f67f-4194-82dc-c2295d88d1a5)
4. User notifications remain unread
![CleanShot 2024-12-13 at 11 59 13@2x](https://github.com/user-attachments/assets/6e253223-23d8-4193-8f13-e2009dd9ae21)
5. Users notifications read
![CleanShot 2024-12-13 at 12 00 59@2x](https://github.com/user-attachments/assets/f35ca9b9-d448-45c4-9704-34b34be60087)
