### PR TITLE
docs(windows): update quickstart section

### DIFF
--- a/website/docs/quick-start/installation/windows/index.mdx
+++ b/website/docs/quick-start/installation/windows/index.mdx
@@ -34,7 +34,7 @@ nvcc --version
 * In this directory, you'll find an executable file named `tabby.exe`.
 
 ## Running Tabby
-Open a command prompt or PowerShell window in the directory where the `tabby.exe` is located (from the previous step).
+Open a command prompt or PowerShell window, as administrator, in the directory where the `tabby.exe` is located (from the previous step).
 
 Run the following command:
 ```


### PR DESCRIPTION
Command must run as Administrator, or it fails:

```powershell
C:\tabby_x86_64-windows-msvc-cuda122>.\tabby.exe serve --model Qwen2.5-Coder-1.5B --chat-model Qwen2-1.5B-Instruct --device cuda
⠹     0.162 s   Starting...←[2m2024-12-14T02:45:52.034764Z←[0m ←[33m WARN←[0m ←[2mllama_cpp_server::supervisor←[0m←[2m:←[0m ←[2mcrates\llama-cpp-server\src\supervisor.rs←[0m←[2m:←[0m←[2m98:←[0m llama-server <embedding> exited with status code -1073741515, args: `Command { std: "C:\\tabby_x86_64-windows-msvc-cuda122\\llama-server.exe" "-m" "C:\\Users\\user1\\.tabby\\models\\TabbyML\\Nomic-Embed-Text\\ggml\\model-00001-of-00001.gguf" "--cont-batching" "--port" "30888" "-np" "1" "--log-disable" "--ctx-size" "4096" "-ngl" "9999" "--embedding" "--ubatch-size" "4096", kill_on_drop: true }`
⠴     1.211 s   Starting...←[2m2024-12-14T02:45:53.044967Z←[0m ←[33m WARN←[0m ←[2mllama_cpp_server::supervisor←[0m←[2m:←[0m ←[2mcrates\llama-cpp-server\src\supervisor.rs←[0m←[2m:←[0m←[2m98:←[0m llama-server <embedding> exited with status code -1073741515, args: `Command { std: "C:\\tabby_x86_64-windows-msvc-cuda122\\llama-server.exe" "-m" "C:\\Users\\user1\\.tabby\\models\\TabbyML\\Nomic-Embed-Text\\ggml\\model-00001-of-00001.gguf" "--cont-batching" "--port" "30888" "-np" "1" "--log-disable" "--ctx-size" "4096" "-ngl" "9999" "--embedding" "--ubatch-size" "4096", kill_on_drop: true }`
⠧     2.178 s   Starting...←[2m2024-12-14T02:45:54.061157Z←[0m ←[33m WARN←[0m ←[2mllama_cpp_server::supervisor←[0m←[2m:←[0m ←[2mcrates\llama-cpp-server\src\supervisor.rs←[0m←[2m:←[0m←[2m98:←[0m llama-server <embedding> exited with status code -1073741515, args: `Command { std: "C:\\tabby_x86_64-windows-msvc-cuda122\\llama-server.exe" "-m" "C:\\Users\\user1\\.tabby\\models\\TabbyML\\Nomic-Embed-Text\\ggml\\model-00001-of-00001.gguf" "--cont-batching" "--port" "30888" "-np" "1" "--log-disable" "--ctx-size" "4096" "-ngl" "9999" "--embedding" "--ubatch-size" "4096", kill_on_drop: true }`
...
```