### PR TITLE
feat(license): add license expiration check and daily cron job

### DIFF
--- a/ee/tabby-schema/src/schema/license.rs
+++ b/ee/tabby-schema/src/schema/license.rs
@@ -81,6 +81,14 @@ impl LicenseInfo {
 
         Ok(())
     }
+
+    pub fn expire_in_days(&self) -> Option<i64> {
+        self.expires_at.map(|expires_at| {
+            let now = Utc::now();
+            let duration = expires_at.signed_duration_since(now);
+            duration.num_days()
+        })
+    }
 }
 
 #[async_trait]

--- a/ee/tabby-webserver/src/service/background_job/license_check.rs
+++ b/ee/tabby-webserver/src/service/background_job/license_check.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tabby_db::DbConn;
+use tabby_schema::{
+    context::ContextService,
+    license::{LicenseService, LicenseType},
+    notification::{self, NotificationRecipient, NotificationService},
+};
+
+use super::helper::Job;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LicenseCheckJob;
+
+impl Job for LicenseCheckJob {
+    const NAME: &'static str = "license_check";
+}
+
+impl LicenseCheckJob {
+    pub async fn cron(
+        _now: DateTime<Utc>,
+        license_service: Arc<dyn LicenseService>,
+        notification_service: Arc<dyn NotificationService>,
+    ) -> tabby_schema::Result<()> {
+        let license = license_service.read().await?;
+        if license.r#type != LicenseType::Community {
+            return Ok(());
+        }
+        if let Some(expire_in_days) = license.expire_in_days() {
+            if expire_in_days < 7 && expire_in_days > 0 {
+                notification_service
+                    .create(
+                        NotificationRecipient::Admin,
+                        &make_expring_message(expire_in_days),
+                    )
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn make_expring_message(expire_in_days: i64) -> String {
+    format!(
+        r#"Your license will expire in {} days.
+
+To ensure uninterrupted access to Tabby and to continue enjoying all the premium features, please renew your license before it expires.
+
+If you have any questions or need assistance with the renewal process, please don't hesitate to contact our support team at support@tabbyml.com.
+"#,
+        expire_in_days
+    )
+}

--- a/ee/tabby-webserver/src/service/background_job/license_check.rs
+++ b/ee/tabby-webserver/src/service/background_job/license_check.rs
@@ -2,11 +2,10 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tabby_db::DbConn;
 use tabby_schema::{
     context::ContextService,
     license::{LicenseService, LicenseType},
-    notification::{self, NotificationRecipient, NotificationService},
+    notification::{NotificationRecipient, NotificationService},
 };
 
 use super::helper::Job;

--- a/ee/tabby-webserver/src/service/background_job/license_check.rs
+++ b/ee/tabby-webserver/src/service/background_job/license_check.rs
@@ -25,7 +25,7 @@ impl LicenseCheckJob {
         notification_service: Arc<dyn NotificationService>,
     ) -> tabby_schema::Result<()> {
         let license = license_service.read().await?;
-        if license.r#type != LicenseType::Community {
+        if license.r#type == LicenseType::Community {
             return Ok(());
         }
         if let Some(expire_in_days) = license.expire_in_days() {

--- a/ee/tabby-webserver/src/service/mod.rs
+++ b/ee/tabby-webserver/src/service/mod.rs
@@ -131,6 +131,8 @@ impl ServerContext {
             integration.clone(),
             repository.clone(),
             context.clone(),
+            license.clone(),
+            notification.clone(),
             embedding.clone(),
         )
         .await;


### PR DESCRIPTION
- Added `expire_in_days` method to `LicenseInfo` to calculate the number of days until license expiration.
- Introduced `LicenseCheckJob` module for handling license checks.
- Integrated `LicenseCheckJob` into the daily cron job schedule.