### PR TITLE
feat(index): add commit to CodeSearchDocument

### DIFF
--- a/crates/tabby-common/src/api/code.rs
+++ b/crates/tabby-common/src/api/code.rs
@@ -30,6 +30,7 @@ pub struct CodeSearchDocument {
     pub body: String,
     pub filepath: String,
     pub git_url: String,
+    pub commit: String,
     pub language: String,
     pub start_line: usize,
 }

--- a/crates/tabby-common/src/api/code.rs
+++ b/crates/tabby-common/src/api/code.rs
@@ -30,7 +30,10 @@ pub struct CodeSearchDocument {
     pub body: String,
     pub filepath: String,
     pub git_url: String,
-    pub commit: String,
+
+    // FIXME(kweizh): This should be a required field after 0.25.0.
+    pub commit: Option<String>,
+
     pub language: String,
     pub start_line: usize,
 }

--- a/crates/tabby-common/src/api/code.rs
+++ b/crates/tabby-common/src/api/code.rs
@@ -32,6 +32,7 @@ pub struct CodeSearchDocument {
     pub git_url: String,
 
     // FIXME(kweizh): This should be a required field after 0.25.0.
+    // commit represents the specific revision at which the file was last edited.
     pub commit: Option<String>,
 
     pub language: String,

--- a/crates/tabby-common/src/index/code/mod.rs
+++ b/crates/tabby-common/src/index/code/mod.rs
@@ -11,6 +11,7 @@ use crate::api::code::CodeSearchQuery;
 
 pub mod fields {
     pub const CHUNK_GIT_URL: &str = "chunk_git_url";
+    pub const CHUNK_COMMIT: &str = "chunk_commit";
     pub const CHUNK_FILEPATH: &str = "chunk_filepath";
     pub const CHUNK_LANGUAGE: &str = "chunk_language";
     pub const CHUNK_BODY: &str = "chunk_body";

--- a/crates/tabby-common/src/index/code/mod.rs
+++ b/crates/tabby-common/src/index/code/mod.rs
@@ -10,8 +10,9 @@ use super::{corpus, IndexSchema};
 use crate::api::code::CodeSearchQuery;
 
 pub mod fields {
+    pub const ATTRIBUTE_COMMIT: &str = "commit";
+
     pub const CHUNK_GIT_URL: &str = "chunk_git_url";
-    pub const CHUNK_COMMIT: &str = "chunk_commit";
     pub const CHUNK_FILEPATH: &str = "chunk_filepath";
     pub const CHUNK_LANGUAGE: &str = "chunk_language";
     pub const CHUNK_BODY: &str = "chunk_body";

--- a/crates/tabby-index/src/code/index.rs
+++ b/crates/tabby-index/src/code/index.rs
@@ -154,7 +154,7 @@ fn require_updates(indexer: Arc<Indexer>, id: &str) -> bool {
 
 fn should_backfill(indexer: Arc<Indexer>, id: &str) -> bool {
     // v0.23.0 add the commit field to the code document.
-    !indexer.has_attribute_field(id, code::fields::CHUNK_COMMIT)
+    !indexer.has_attribute_field(id, code::fields::ATTRIBUTE_COMMIT)
 }
 
 fn is_valid_file(file: &SourceCode) -> bool {

--- a/crates/tabby-index/src/code/index.rs
+++ b/crates/tabby-index/src/code/index.rs
@@ -3,7 +3,7 @@ use std::{pin::pin, sync::Arc};
 use async_stream::stream;
 use futures::StreamExt;
 use ignore::{DirEntry, Walk};
-use tabby_common::index::corpus;
+use tabby_common::index::{code, corpus};
 use tabby_inference::Embedding;
 use tracing::warn;
 
@@ -21,7 +21,11 @@ static MIN_ALPHA_NUM_FRACTION: f32 = 0.25f32;
 static MAX_NUMBER_OF_LINES: usize = 100000;
 static MAX_NUMBER_FRACTION: f32 = 0.5f32;
 
-pub async fn index_repository(embedding: Arc<dyn Embedding>, repository: &CodeRepository) {
+pub async fn index_repository(
+    embedding: Arc<dyn Embedding>,
+    repository: &CodeRepository,
+    commit: &str,
+) {
     let total_files = Walk::new(repository.dir()).count();
     let file_stream = stream! {
         for file in Walk::new(repository.dir()) {
@@ -45,7 +49,7 @@ pub async fn index_repository(embedding: Arc<dyn Embedding>, repository: &CodeRe
     let mut count_chunks = 0;
     while let Some(files) = file_stream.next().await {
         count_files += files.len();
-        count_chunks += add_changed_documents(repository, embedding.clone(), files).await;
+        count_chunks += add_changed_documents(repository, commit, embedding.clone(), files).await;
         logkit::info!("Processed {count_files}/{total_files} files, updated {count_chunks} chunks",);
     }
 }
@@ -79,6 +83,7 @@ pub async fn garbage_collection() {
 
 async fn add_changed_documents(
     repository: &CodeRepository,
+    commit: &str,
     embedding: Arc<dyn Embedding>,
     files: Vec<DirEntry>,
 ) -> usize {
@@ -96,12 +101,11 @@ async fn add_changed_documents(
 
             let id = SourceCode::to_index_id(&repository.source_id, &key).id;
 
-            // Skip if already indexed and has no failed chunks
             if !require_updates(cloned_index.clone(), &id) {
                 continue;
             }
 
-            let Some(code) = CodeIntelligence::compute_source_file(repository, file.path()) else {
+            let Some(code) = CodeIntelligence::compute_source_file(repository, commit, file.path()) else {
                 continue;
             };
 
@@ -135,12 +139,22 @@ async fn add_changed_documents(
     count_docs
 }
 
+// 1. Backfill if the document is missing the commit field
+// 2. Skip if already indexed and has no failed chunks
 fn require_updates(indexer: Arc<Indexer>, id: &str) -> bool {
+    if should_backfill(indexer.clone(), id) {
+        return true;
+    }
     if indexer.is_indexed(id) && !indexer.has_failed_chunks(id) {
         return false;
     };
 
     true
+}
+
+fn should_backfill(indexer: Arc<Indexer>, id: &str) -> bool {
+    // v0.23.0 add the commit field to the code document.
+    !indexer.has_attribute_field(id, code::fields::CHUNK_COMMIT)
 }
 
 fn is_valid_file(file: &SourceCode) -> bool {

--- a/crates/tabby-index/src/code/intelligence.rs
+++ b/crates/tabby-index/src/code/intelligence.rs
@@ -265,12 +265,14 @@ mod tests {
     fn test_create_source_file() {
         set_tabby_root(get_tabby_root());
         let config = get_repository_config();
-        let source_file = CodeIntelligence::compute_source_file(&config, &get_rust_source_file())
-            .expect("Failed to create source file");
+        let source_file =
+            CodeIntelligence::compute_source_file(&config, "commit", &get_rust_source_file())
+                .expect("Failed to create source file");
 
         // check source_file properties
         assert_eq!(source_file.language, "rust");
         assert_eq!(source_file.tags.len(), 3);
         assert_eq!(source_file.filepath, "rust.rs");
+        assert_eq!(source_file.commit, "commit");
     }
 }

--- a/crates/tabby-index/src/code/intelligence.rs
+++ b/crates/tabby-index/src/code/intelligence.rs
@@ -73,7 +73,11 @@ impl CodeIntelligence {
         file_key.to_string() == item_key
     }
 
-    pub fn compute_source_file(config: &CodeRepository, path: &Path) -> Option<SourceCode> {
+    pub fn compute_source_file(
+        config: &CodeRepository,
+        commit: &str,
+        path: &Path,
+    ) -> Option<SourceCode> {
         let source_file_id = Self::compute_source_file_id(path)?;
 
         if path.is_dir() || !path.exists() {
@@ -114,6 +118,7 @@ impl CodeIntelligence {
             source_file_id,
             source_id: config.source_id.clone(),
             git_url: config.canonical_git_url(),
+            commit: commit.to_owned(),
             basedir: config.dir().display().to_string(),
             filepath: relative_path.display().to_string(),
             max_line_length,

--- a/crates/tabby-index/src/code/mod.rs
+++ b/crates/tabby-index/src/code/mod.rs
@@ -62,8 +62,10 @@ impl CodeBuilder {
 
 #[async_trait]
 impl IndexAttributeBuilder<SourceCode> for CodeBuilder {
-    async fn build_attributes(&self, _source_code: &SourceCode) -> serde_json::Value {
-        json!({})
+    async fn build_attributes(&self, source_code: &SourceCode) -> serde_json::Value {
+        json!({
+            code::fields::ATTRIBUTE_COMMIT: source_code.commit,
+        })
     }
 
     async fn build_chunk_attributes<'a>(
@@ -102,7 +104,6 @@ impl IndexAttributeBuilder<SourceCode> for CodeBuilder {
                 let attributes = json!({
                     code::fields::CHUNK_FILEPATH: source_code.filepath,
                     code::fields::CHUNK_GIT_URL: source_code.git_url,
-                    code::fields::CHUNK_COMMIT: source_code.commit,
                     code::fields::CHUNK_LANGUAGE: source_code.language,
                     code::fields::CHUNK_BODY: body,
                     code::fields::CHUNK_START_LINE: start_line,

--- a/crates/tabby-index/src/code/mod.rs
+++ b/crates/tabby-index/src/code/mod.rs
@@ -38,9 +38,9 @@ impl CodeIndexer {
             "Building source code index: {}",
             repository.canonical_git_url()
         );
-        repository::sync_repository(repository)?;
+        let commit = repository::sync_repository(repository)?;
 
-        index::index_repository(embedding, repository).await;
+        index::index_repository(embedding, repository, &commit).await;
         index::garbage_collection().await;
 
         Ok(())
@@ -102,6 +102,7 @@ impl IndexAttributeBuilder<SourceCode> for CodeBuilder {
                 let attributes = json!({
                     code::fields::CHUNK_FILEPATH: source_code.filepath,
                     code::fields::CHUNK_GIT_URL: source_code.git_url,
+                    code::fields::CHUNK_COMMIT: source_code.commit,
                     code::fields::CHUNK_LANGUAGE: source_code.language,
                     code::fields::CHUNK_BODY: body,
                     code::fields::CHUNK_START_LINE: start_line,

--- a/crates/tabby-index/src/code/repository.rs
+++ b/crates/tabby-index/src/code/repository.rs
@@ -49,7 +49,7 @@ impl RepositoryExt for CodeRepository {
             }
         }
 
-        get_commit_sha(&self)
+        get_commit_sha(self)
     }
 }
 

--- a/crates/tabby-index/src/code/repository.rs
+++ b/crates/tabby-index/src/code/repository.rs
@@ -12,11 +12,13 @@ use tracing::warn;
 use super::CodeRepository;
 
 trait RepositoryExt {
-    fn sync(&self) -> anyhow::Result<()>;
+    fn sync(&self) -> anyhow::Result<String>;
 }
 
 impl RepositoryExt for CodeRepository {
-    fn sync(&self) -> anyhow::Result<()> {
+    // sync clones the repository if it doesn't exist, otherwise it pulls the remote.
+    // and returns the git commit sha256.
+    fn sync(&self) -> anyhow::Result<String> {
         let dir = self.dir();
         let mut finished = false;
         if dir.exists() {
@@ -47,8 +49,15 @@ impl RepositoryExt for CodeRepository {
             }
         }
 
-        Ok(())
+        get_commit_sha(&self)
     }
+}
+
+fn get_commit_sha(repository: &CodeRepository) -> anyhow::Result<String> {
+    let repo = git2::Repository::open(repository.dir())?;
+    let head = repo.head()?;
+    let commit = head.peel_to_commit()?;
+    Ok(commit.id().to_string())
 }
 
 fn pull_remote(path: &Path) -> bool {
@@ -71,16 +80,15 @@ fn pull_remote(path: &Path) -> bool {
     true
 }
 
-pub fn sync_repository(repository: &CodeRepository) -> anyhow::Result<()> {
+pub fn sync_repository(repository: &CodeRepository) -> anyhow::Result<String> {
     if repository.is_local_dir() {
         if !repository.dir().exists() {
-            panic!("Directory {} does not exist", repository.dir().display());
+            bail!("Directory {} does not exist", repository.dir().display());
         }
+        get_commit_sha(repository)
     } else {
-        repository.sync()?;
+        repository.sync()
     }
-
-    Ok(())
 }
 
 pub fn garbage_collection(repositories: &[CodeRepository]) {

--- a/crates/tabby-index/src/code/types.rs
+++ b/crates/tabby-index/src/code/types.rs
@@ -12,6 +12,7 @@ pub struct SourceCode {
     pub source_file_id: String,
     pub source_id: String,
     pub git_url: String,
+    pub commit: String,
     pub basedir: String,
     pub filepath: String,
     pub language: String,

--- a/crates/tabby-index/src/indexer_tests.rs
+++ b/crates/tabby-index/src/indexer_tests.rs
@@ -206,7 +206,8 @@ mod builder_tests {
         let builder = Arc::new(create_code_builder(Some(Arc::new(embedding))));
 
         let repo = get_repository_config();
-        let code = CodeIntelligence::compute_source_file(&repo, &get_rust_source_file()).unwrap();
+        let code = CodeIntelligence::compute_source_file(&repo, "commit", &get_rust_source_file())
+            .unwrap();
         let index_id = code.to_index_id();
 
         let (id, s) = tokio::runtime::Runtime::new()

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -185,6 +185,14 @@ fn create_hit(scores: CodeSearchScores, doc: TantivyDocument) -> CodeSearchHit {
             code::fields::CHUNK_GIT_URL,
         )
         .to_owned(),
+        // commit is introduced in v0.23, but it is also a required field
+        // so we need to handle the case where it's not present
+        commit: get_json_text_field_or_default(
+            &doc,
+            schema.field_chunk_attributes,
+            code::fields::CHUNK_COMMIT,
+        )
+        .to_owned(),
         language: get_json_text_field(
             &doc,
             schema.field_chunk_attributes,
@@ -226,6 +234,18 @@ fn get_json_text_field<'a>(doc: &'a TantivyDocument, field: schema::Field, name:
         .1
         .as_str()
         .unwrap()
+}
+
+fn get_json_text_field_or_default<'a>(
+    doc: &'a TantivyDocument,
+    field: schema::Field,
+    name: &str,
+) -> &'a str {
+    doc.get_first(field)
+        .and_then(|value| value.as_object())
+        .and_then(|mut obj| obj.find(|(k, _)| *k == name))
+        .and_then(|(_, v)| v.as_str())
+        .unwrap_or("")
 }
 
 struct CodeSearchService {

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -298,6 +298,7 @@ mod tests {
                 body: body.to_string(),
                 filepath: "".to_owned(),
                 git_url: "".to_owned(),
+                commit: "".to_owned(),
                 language: "".to_owned(),
                 start_line: 0,
             },

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -187,12 +187,12 @@ fn create_hit(scores: CodeSearchScores, doc: TantivyDocument) -> CodeSearchHit {
         .to_owned(),
         // commit is introduced in v0.23, but it is also a required field
         // so we need to handle the case where it's not present
-        commit: get_json_text_field_or_default(
+        commit: get_json_text_field_optional(
             &doc,
             schema.field_chunk_attributes,
             code::fields::CHUNK_COMMIT,
         )
-        .to_owned(),
+        .map(|s| s.to_owned()),
         language: get_json_text_field(
             &doc,
             schema.field_chunk_attributes,
@@ -236,16 +236,15 @@ fn get_json_text_field<'a>(doc: &'a TantivyDocument, field: schema::Field, name:
         .unwrap()
 }
 
-fn get_json_text_field_or_default<'a>(
+fn get_json_text_field_optional<'a>(
     doc: &'a TantivyDocument,
     field: schema::Field,
     name: &str,
-) -> &'a str {
+) -> Option<&'a str> {
     doc.get_first(field)
         .and_then(|value| value.as_object())
         .and_then(|mut obj| obj.find(|(k, _)| *k == name))
         .and_then(|(_, v)| v.as_str())
-        .unwrap_or("")
 }
 
 struct CodeSearchService {
@@ -298,7 +297,7 @@ mod tests {
                 body: body.to_string(),
                 filepath: "".to_owned(),
                 git_url: "".to_owned(),
-                commit: "".to_owned(),
+                commit: Some("".to_owned()),
                 language: "".to_owned(),
                 start_line: 0,
             },

--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -94,7 +94,7 @@ async fn add_doc_attribute(reader: &IndexReader, searched_code: &mut CodeSearchR
             .searcher()
             .search(&query, &TopDocs::with_limit(1))
             .unwrap();
-        if doc.len() == 0 {
+        if doc.is_empty() {
             continue;
         }
         let doc = reader.searcher().doc(doc[0].1).unwrap();

--- a/ee/tabby-db/src/threads.rs
+++ b/ee/tabby-db/src/threads.rs
@@ -77,6 +77,7 @@ pub struct ThreadMessageAttachmentAuthor {
 #[derive(Serialize, Deserialize)]
 pub struct ThreadMessageAttachmentCode {
     pub git_url: String,
+    pub commit: Option<String>,
     pub language: String,
     pub filepath: String,
     pub content: String,

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -497,7 +497,7 @@ type MessageAttachmentClientCode {
 
 type MessageAttachmentCode {
   gitUrl: String!
-  commit: String!
+  commit: String
   filepath: String!
   language: String!
   content: String!

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -497,6 +497,7 @@ type MessageAttachmentClientCode {
 
 type MessageAttachmentCode {
   gitUrl: String!
+  commit: String!
   filepath: String!
   language: String!
   content: String!

--- a/ee/tabby-schema/src/dao.rs
+++ b/ee/tabby-schema/src/dao.rs
@@ -202,7 +202,7 @@ impl From<ThreadMessageAttachmentCode> for thread::MessageAttachmentCode {
     fn from(value: ThreadMessageAttachmentCode) -> Self {
         Self {
             git_url: value.git_url,
-            commit: value.commit.unwrap_or_default(),
+            commit: value.commit,
             filepath: value.filepath,
             language: value.language,
             content: value.content,
@@ -215,7 +215,7 @@ impl From<&thread::MessageAttachmentCode> for ThreadMessageAttachmentCode {
     fn from(val: &thread::MessageAttachmentCode) -> Self {
         ThreadMessageAttachmentCode {
             git_url: val.git_url.clone(),
-            commit: Some(val.commit.clone()),
+            commit: val.commit.clone(),
             filepath: val.filepath.clone(),
             language: val.language.clone(),
             content: val.content.clone(),

--- a/ee/tabby-schema/src/dao.rs
+++ b/ee/tabby-schema/src/dao.rs
@@ -202,6 +202,7 @@ impl From<ThreadMessageAttachmentCode> for thread::MessageAttachmentCode {
     fn from(value: ThreadMessageAttachmentCode) -> Self {
         Self {
             git_url: value.git_url,
+            commit: value.commit.unwrap_or_default(),
             filepath: value.filepath,
             language: value.language,
             content: value.content,
@@ -214,6 +215,7 @@ impl From<&thread::MessageAttachmentCode> for ThreadMessageAttachmentCode {
     fn from(val: &thread::MessageAttachmentCode) -> Self {
         ThreadMessageAttachmentCode {
             git_url: val.git_url.clone(),
+            commit: Some(val.commit.clone()),
             filepath: val.filepath.clone(),
             language: val.language.clone(),
             content: val.content.clone(),

--- a/ee/tabby-schema/src/schema/thread/types.rs
+++ b/ee/tabby-schema/src/schema/thread/types.rs
@@ -72,7 +72,7 @@ pub struct MessageAttachmentClientCode {
 #[derive(GraphQLObject, Clone)]
 pub struct MessageAttachmentCode {
     pub git_url: String,
-    pub commit: String,
+    pub commit: Option<String>,
     pub filepath: String,
     pub language: String,
     pub content: String,

--- a/ee/tabby-schema/src/schema/thread/types.rs
+++ b/ee/tabby-schema/src/schema/thread/types.rs
@@ -72,6 +72,7 @@ pub struct MessageAttachmentClientCode {
 #[derive(GraphQLObject, Clone)]
 pub struct MessageAttachmentCode {
     pub git_url: String,
+    pub commit: String,
     pub filepath: String,
     pub language: String,
     pub content: String,
@@ -82,6 +83,7 @@ impl From<CodeSearchDocument> for MessageAttachmentCode {
     fn from(doc: CodeSearchDocument) -> Self {
         Self {
             git_url: doc.git_url,
+            commit: doc.commit,
             filepath: doc.filepath,
             language: doc.language,
             content: doc.body,

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -767,6 +767,7 @@ mod tests {
             })],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com/".to_owned(),
+                commit: "commit".to_owned(),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "from flask import Flask\n\napp = Flask(__name__)\n\n@app.route('/')\ndef hello():\n    return 'Hello, World!'".to_owned(),
@@ -800,6 +801,7 @@ mod tests {
             )],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com".to_owned(),
+                commit: "commit".to_owned(),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "print('Hello, server!')".to_owned(),
@@ -976,6 +978,7 @@ mod tests {
             )],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com".to_owned(),
+                commit: "commit".to_owned(),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "print('Hello, server!')".to_owned(),
@@ -1037,6 +1040,7 @@ mod tests {
             )],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com".to_owned(),
+                commit: "commit".to_owned(),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "print('Hello, server!')".to_owned(),
@@ -1334,6 +1338,7 @@ mod tests {
                     body: "fn test1() {}\nfn test2() {}".to_string(),
                     filepath: "test.rs".to_string(),
                     git_url: "https://github.com/test/repo.git".to_string(),
+                    commit: "commit".to_string(),
                     language: "rust".to_string(),
                     start_line: 1,
                 },
@@ -1350,6 +1355,7 @@ mod tests {
                     body: "fn test3() {}\nfn test4() {}".to_string(),
                     filepath: "test.rs".to_string(),
                     git_url: "https://github.com/test/repo.git".to_string(),
+                    commit: "commit".to_string(),
                     language: "rust".to_string(),
                     start_line: 3,
                 },

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -767,7 +767,7 @@ mod tests {
             })],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com/".to_owned(),
-                commit: "commit".to_owned(),
+                commit: Some("commit".to_owned()),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "from flask import Flask\n\napp = Flask(__name__)\n\n@app.route('/')\ndef hello():\n    return 'Hello, World!'".to_owned(),
@@ -801,7 +801,7 @@ mod tests {
             )],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com".to_owned(),
-                commit: "commit".to_owned(),
+                commit: Some("commit".to_owned()),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "print('Hello, server!')".to_owned(),
@@ -978,7 +978,7 @@ mod tests {
             )],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com".to_owned(),
-                commit: "commit".to_owned(),
+                commit: Some("commit".to_owned()),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "print('Hello, server!')".to_owned(),
@@ -1040,7 +1040,7 @@ mod tests {
             )],
             code: vec![tabby_schema::thread::MessageAttachmentCode {
                 git_url: "https://github.com".to_owned(),
-                commit: "commit".to_owned(),
+                commit: Some("commit".to_owned()),
                 filepath: "server.py".to_owned(),
                 language: "python".to_owned(),
                 content: "print('Hello, server!')".to_owned(),
@@ -1338,7 +1338,7 @@ mod tests {
                     body: "fn test1() {}\nfn test2() {}".to_string(),
                     filepath: "test.rs".to_string(),
                     git_url: "https://github.com/test/repo.git".to_string(),
-                    commit: "commit".to_string(),
+                    commit: Some("commit".to_string()),
                     language: "rust".to_string(),
                     start_line: 1,
                 },
@@ -1355,7 +1355,7 @@ mod tests {
                     body: "fn test3() {}\nfn test4() {}".to_string(),
                     filepath: "test.rs".to_string(),
                     git_url: "https://github.com/test/repo.git".to_string(),
-                    commit: "commit".to_string(),
+                    commit: Some("commit".to_string()),
                     language: "rust".to_string(),
                     start_line: 3,
                 },
@@ -1370,5 +1370,7 @@ mod tests {
         let result = merge_code_snippets(&repo.unwrap(), hits).await;
 
         assert_eq!(result.len(), 2);
+        assert_eq!(result[0].doc.commit, Some("commit".to_string()));
+        assert_eq!(result[1].doc.commit, Some("commit".to_string()));
     }
 }

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -577,7 +577,7 @@ pub async fn merge_code_snippets(
 
             if let Some(file_content) = file_content {
                 debug!(
-                    "file {} less than 200, it will be included whole file content",
+                    "file {} less than 300, it will be included whole file content",
                     file_hits[0].doc.filepath
                 );
                 let mut insert_hit = file_hits[0].clone();

--- a/ee/tabby-webserver/src/service/answer/testutils/mod.rs
+++ b/ee/tabby-webserver/src/service/answer/testutils/mod.rs
@@ -148,6 +148,7 @@ impl CodeSearch for FakeCodeSearch {
                         file_id: "1".to_string(),
                         chunk_id: "chunk1".to_string(),
                         git_url: "https://github.com/test/repo".to_string(),
+                        commit: Some("commit".to_string()),
                     },
                     scores: CodeSearchScores {
                         bm25: 0.8,
@@ -164,6 +165,7 @@ impl CodeSearch for FakeCodeSearch {
                         file_id: "2".to_string(),
                         chunk_id: "chunk2".to_string(),
                         git_url: "https://github.com/test/repo".to_string(),
+                        commit: Some("commit".to_string()),
                     },
                     scores: CodeSearchScores {
                         bm25: 0.7,


### PR DESCRIPTION
this PR does:

1. check code indexes, and reindex if no commit field
2. index code with commit as a field
3. return commit in codeAttachment

commit in response:
![CleanShot 2024-12-17 at 19 59 08@2x](https://github.com/user-attachments/assets/222d9ab7-16f6-433e-96b4-ff6f796bf44c)
