### PR TITLE
chore(clients): update tabby home link.

### DIFF
--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/actions/OpenOnlineDocumentation.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/actions/OpenOnlineDocumentation.kt
@@ -6,6 +6,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 
 class OpenOnlineDocumentation : AnAction() {
   override fun actionPerformed(e: AnActionEvent) {
-    BrowserUtil.browse("https://tabby.tabbyml.com/")
+    BrowserUtil.browse("https://tabby.tabbyml.com/docs")
   }
 }

--- a/clients/tabby-agent/README.md
+++ b/clients/tabby-agent/README.md
@@ -1,6 +1,6 @@
 # Tabby Agent
 
-The [tabby-agent](https://www.npmjs.com/package/tabby-agent) is an agent used for communication with the [Tabby](https://tabby.tabbyml.com) server. It is based on Node.js v18 and runs as a language server.
+The [tabby-agent](https://www.npmjs.com/package/tabby-agent) is an agent used for communication with the [Tabby](https://www.tabbyml.com) server. It is based on Node.js v18 and runs as a language server.
 
 **Breaking Changes**: The tabby-agent will only support running as a language server since version 1.7.0.
 

--- a/clients/tabby-agent/src/http/tabbyApiClient.ts
+++ b/clients/tabby-agent/src/http/tabbyApiClient.ts
@@ -526,7 +526,7 @@ export class TabbyApiClient extends EventEmitter {
       helpMessageForRunningLargeModelOnCPU +=
         `Your Tabby server is running model <i>${serverHealthState?.model}</i> on CPU. ` +
         "This model may be performing poorly due to its large parameter size, please consider trying smaller models or switch to GPU. " +
-        "You can find a list of recommend models in the <a href='https://tabby.tabbyml.com/'>online documentation</a>.<br/>";
+        "You can find a list of recommend models in the <a href='https://tabby.tabbyml.com/docs/'>online documentation</a>.<br/>";
     }
     let commonHelpMessage = "";
     if (helpMessageForRunningLargeModelOnCPU.length == 0) {
@@ -534,7 +534,7 @@ export class TabbyApiClient extends EventEmitter {
         serverHealthState?.model ?? ""
       }</i> may be performing poorly due to its large parameter size. `;
       commonHelpMessage +=
-        "Please consider trying smaller models. You can find a list of recommend models in the <a href='https://tabby.tabbyml.com/'>online documentation</a>.</li>";
+        "Please consider trying smaller models. You can find a list of recommend models in the <a href='https://tabby.tabbyml.com/docs/'>online documentation</a>.</li>";
     }
     const host = new URL(this.endpoint ?? "http://localhost:8080").host;
     if (!(host.startsWith("localhost") || host.startsWith("127.0.0.1") || host.startsWith("0.0.0.0"))) {

--- a/clients/vscode/README.md
+++ b/clients/vscode/README.md
@@ -6,7 +6,7 @@
 [![Open VSX](https://img.shields.io/open-vsx/dt/TabbyML/vscode-tabby?label=Open-VSX)](https://open-vsx.org/extension/TabbyML/vscode-tabby)
 [![Slack Community](https://shields.io/badge/Tabby-Join%20Slack-red?logo=slack)](https://links.tabbyml.com/join-slack)
 
-[Tabby](https://tabby.tabbyml.com/) is an open-source, self-hosted AI coding assistant designed to help you write code more efficiently.
+[Tabby](https://www.tabbyml.com/) is an open-source, self-hosted AI coding assistant designed to help you write code more efficiently.
 
 ## Installation
 
@@ -39,6 +39,6 @@ That's it! You can now start using Tabby in VSCode. Use the `Tabby: Quick Start`
 
 ## Additional Resources
 
-- [Online Documentation](https://tabby.tabbyml.com/)
+- [Online Documentation](https://tabby.tabbyml.com/docs/)
 - [GitHub Repository](https://github.com/TabbyML/tabby/): Feel free to [Report Issues](https://github.com/TabbyML/tabby/issues/new/choose) or [Contribute](https://github.com/TabbyML/tabby/blob/main/CONTRIBUTING.md)
 - [Slack Community](https://links.tabbyml.com/join-slack): Participate in discussions, seek assistance, and share your insights on Tabby.

--- a/clients/vscode/assets/walkthroughs/setupServer.md
+++ b/clients/vscode/assets/walkthroughs/setupServer.md
@@ -4,7 +4,7 @@ The Tabby VSCode extension requires a Tabby server to work, following the instru
 
 ## Install Tabby Server
 
-[Tabby](https://tabby.tabbyml.com/) is an open-source project that supports self-hosting.  
+[Tabby](https://www.tabbyml.com/) is an open-source project that supports self-hosting.  
 You can choose any of the following methods to install Tabby:
 
 - [Homebrew](https://tabby.tabbyml.com/docs/quick-start/installation/apple/) for macOS with Apple M-series chips.
@@ -23,5 +23,5 @@ Visit [http://localhost:8080/](http://localhost:8080/) (or your server address) 
 
 ## [Online Supports](command:tabby.openOnlineHelp)
 
-Please refer to our [online documentation](https://tabby.tabbyml.com/) and our [Github repository](https://github.com/tabbyml/tabby) for more information.
+Please refer to our [online documentation](https://tabby.tabbyml.com/docs/) and our [Github repository](https://github.com/tabbyml/tabby) for more information.
 If you encounter any problems during server setup, please join our [Slack community](https://links.tabbyml.com/join-slack-extensions) for support or [open an issue](https://github.com/TabbyML/tabby/issues/new/choose).

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -3,7 +3,7 @@
   "publisher": "TabbyML",
   "displayName": "Tabby",
   "description": "Tabby is a self-hosted AI coding assistant that can suggest multi-line code or full functions in real-time.",
-  "homepage": "https://tabby.tabbyml.com/",
+  "homepage": "https://www.tabbyml.com/",
   "repository": "https://github.com/TabbyML/tabby",
   "bugs": "https://github.com/TabbyML/tabby/issues",
   "license": "Apache-2.0",

--- a/clients/vscode/src/commands/index.ts
+++ b/clients/vscode/src/commands/index.ts
@@ -162,7 +162,7 @@ export class Commands {
           if (selection) {
             switch (selection.label) {
               case "Website":
-                env.openExternal(Uri.parse("https://tabby.tabbyml.com/"));
+                env.openExternal(Uri.parse("https://www.tabbyml.com/"));
                 break;
               case "Tabby Slack Community":
                 env.openExternal(Uri.parse("https://links.tabbyml.com/join-slack-extensions/"));


### PR DESCRIPTION
Updated links in tabby plugins:
- Tabby Homepage: from `https://tabby.tabbyml.com` to `https://www.tabbyml.com`
- Online Docs:  from `https://tabby.tabbyml.com` to `https://tabby.tabbyml.com/docs`