### PR TITLE
feat: add support for the latest OpenAI chat models (e.g., o1, gpt-4o) for completions.

### DIFF
--- a/crates/http-api-bindings/src/completion/openai.rs
+++ b/crates/http-api-bindings/src/completion/openai.rs
@@ -4,6 +4,7 @@ use futures::{stream::BoxStream, StreamExt};
 use reqwest_eventsource::{Event, EventSource};
 use serde::{Deserialize, Serialize};
 use tabby_inference::{CompletionOptions, CompletionStream};
+use tracing::debug;
 use tracing::warn;
 
 use super::split_fim_prompt;
@@ -40,15 +41,29 @@ impl OpenAICompletionEngine {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Default, Serialize)]
 struct CompletionRequest {
     model: String,
-    prompt: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     suffix: Option<String>,
+
     max_tokens: i32,
     temperature: f32,
     stream: bool,
     presence_penalty: f32,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    messages: Vec<Message>,
+}
+
+#[derive(Serialize, Debug)]
+struct Message {
+    role: String,
+    content: String,
 }
 
 #[derive(Deserialize)]
@@ -56,31 +71,67 @@ struct CompletionResponseChunk {
     choices: Vec<CompletionResponseChoice>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 struct CompletionResponseChoice {
-    text: String,
+    text: Option<String>,
+    delta: Option<CompletionResponseDelta>,
     finish_reason: Option<String>,
+}
+
+#[derive(Clone, Deserialize, Default, Debug)]
+struct CompletionResponseDelta {
+    content: Option<String>,
 }
 
 #[async_trait]
 impl CompletionStream for OpenAICompletionEngine {
     async fn generate(&self, prompt: &str, options: CompletionOptions) -> BoxStream<String> {
-        let (prompt, suffix) = if self.support_fim {
-            split_fim_prompt(prompt)
-        } else {
-            (prompt, None)
-        };
+        const LEGACY_MODEL_NAME: &str = "gpt-3.5-turbo-instruct";
 
-        let request = CompletionRequest {
+        let mut request = CompletionRequest {
             model: self.model_name.clone(),
-            prompt: prompt.to_owned(),
-            suffix: suffix.map(|x| x.to_owned()),
             max_tokens: options.max_decoding_tokens,
-            temperature: options.sampling_temperature,
+            temperature: 1_f32,
             stream: true,
             presence_penalty: options.presence_penalty,
+            ..Default::default()
         };
 
+        if self.model_name == LEGACY_MODEL_NAME {
+            let (prompt, suffix) = if self.support_fim {
+                split_fim_prompt(prompt)
+            } else {
+                (prompt, None)
+            };
+            request.prompt = Some(prompt.into());
+            request.suffix = suffix.map(Into::into);
+        } else {
+            //FIXME: We may need to refine this prompt to achieve better completion results
+            const SYS_PMT: &str = r#"You are a code completion assistant that completes partial code snippets. Only provide the completion portion, not the full line.
+                            Examples:
+                            System.out.p ->rintln("Hello");
+                            Input: "String name = ->"John Doe";
+                            Input: "if(num > 0->) {
+                            Input: ArrayList<String> list = new -> ArrayList<>();"
+                            Rules:
+
+                            Return only the completion portion
+                            Include necessary closing syntax (parentheses, quotes, semicolons)
+                            Provide the most common completion for the context
+                            No explanations or alternatives
+
+                            Following is the code snippet you shouled work on:
+                            "#;
+
+            request.messages = vec![Message {
+                role: "user".to_string(),
+                content: format!("{SYS_PMT}\n{prompt}"),
+            }];
+
+            debug!("messages:{:?}", request.messages);
+        }
+
+        debug!("messages: {:?}", request.messages);
         let mut request = self.client.post(&self.api_endpoint).json(&request);
         if let Some(api_key) = &self.api_key {
             request = request.bearer_auth(api_key);
@@ -92,12 +143,22 @@ impl CompletionStream for OpenAICompletionEngine {
                 match event {
                     Ok(Event::Open) => {}
                     Ok(Event::Message(message)) => {
+
+                        //message.data example: {"id":"chatcmpl-AigtaSN","object":"chat.completion.chunk","created":1735214686,"model":"o1-mini-2024-09-12","system_fingerprint":"fp_e4","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}
                         let x: CompletionResponseChunk = serde_json::from_str(&message.data).expect("Failed to parse response");
                         if let Some(choice) = x.choices.first() {
-                            yield choice.text.clone();
-
                             if choice.finish_reason.is_some() {
                                 break;
+                            }
+
+                            if self.model_name ==  LEGACY_MODEL_NAME{
+                                if let Some(text) = choice.text.clone(){
+                                yield text;
+                                }
+                            }
+                            else if let Some(delta) =  choice.delta.clone(){
+                                debug!("delta:{:?}",delta.content);
+                                yield delta.content.unwrap_or_default();
                             }
                         }
                     }

--- a/crates/http-api-bindings/src/completion/openai.rs
+++ b/crates/http-api-bindings/src/completion/openai.rs
@@ -91,7 +91,7 @@ impl CompletionStream for OpenAICompletionEngine {
         let mut request = CompletionRequest {
             model: self.model_name.clone(),
             max_tokens: options.max_decoding_tokens,
-            temperature: 1_f32,
+            temperature: options.sampling_temperature,
             stream: true,
             presence_penalty: options.presence_penalty,
             ..Default::default()
@@ -127,11 +127,8 @@ impl CompletionStream for OpenAICompletionEngine {
                 role: "user".to_string(),
                 content: format!("{SYS_PMT}\n{prompt}"),
             }];
-
-            debug!("messages:{:?}", request.messages);
         }
 
-        debug!("messages: {:?}", request.messages);
         let mut request = self.client.post(&self.api_endpoint).json(&request);
         if let Some(api_key) = &self.api_key {
             request = request.bearer_auth(api_key);
@@ -153,7 +150,7 @@ impl CompletionStream for OpenAICompletionEngine {
 
                             if self.model_name ==  LEGACY_MODEL_NAME{
                                 if let Some(text) = choice.text.clone(){
-                                yield text;
+                                    yield text;
                                 }
                             }
                             else if let Some(delta) =  choice.delta.clone(){


### PR DESCRIPTION
# Add Support for Latest OpenAI Chat Models (e.g., o1, gpt-4o) for Completions

## Overview

The current implementation in `crates/http-api-bindings/src/completion/openai.rs` exclusively supports the legacy completion model `gpt-3.5-turbo-instruct`. This model has been marked as legacy in OpenAI's API documentation, as illustrated below:

![Legacy Model](https://github.com/user-attachments/assets/62337714-fe8d-49ee-92d8-21e7bfb1cb4e)

This pull request introduces support for the latest OpenAI chat models (e.g., `o1`, `gpt-4o`) for completions while retaining compatibility with the legacy `gpt-3.5-turbo-instruct` model.

## Changes

- **Updated Supported Models**: Added support for new OpenAI chat models such as `o1` and `gpt-4o`.
- **Backward Compatibility**: Maintained support for the legacy `gpt-3.5-turbo-instruct` completion model.
- **Configuration Enhancements**: Updated configuration examples to demonstrate usage with both new and legacy models.

## Configuration

Below is an example of the `config.toml` used during testing:

```toml
# Chat Model Configuration
[model.chat.http]
kind = "openai/chat"
model_name = "gpt-3.5-turbo"  # Ensure to use a chat model, such as gpt-4o
api_endpoint = "https://api.openai.com/v1"  # DO NOT append the `/chat/completions` suffix
api_key = "<your_api_key>"

# Completion Model Configuration
[model.completion.http]
kind = "openai/completion"
# Uncomment and configure the following lines to use a different completion model
# model_name = "gpt-4o-mini"  # Use a completion model, such as gpt-3.5-turbo-instruct
# api_endpoint = "https://api.openai.com/v1/chat"  # DO NOT append the `/completions` suffix

model_name = "gpt-3.5-turbo-instruct"  # Default to legacy completion model
api_endpoint = "https://api.openai.com/v1"  # DO NOT append the `/completions` suffix
api_key = "<your_api_key>"

# Embedding Model Configuration
[model.embedding.http]
kind = "openai/embedding"
model_name = "text-embedding-3-small"  # Use an embedding model, such as text-embedding-3-small
api_endpoint = "https://api.openai.com/v1"  # DO NOT append the `/embeddings` suffix
api_key = "<your_api_key>"