### PR TITLE
fix(code): correct condition for setting CHUNK_START_LINE attribute

### DIFF
--- a/crates/tabby-index/src/code/mod.rs
+++ b/crates/tabby-index/src/code/mod.rs
@@ -108,7 +108,9 @@ impl IndexAttributeBuilder<SourceCode> for CodeBuilder {
                     code::fields::CHUNK_BODY: body,
                 });
 
-                if text.len() == body.len() {
+                // When text length is not equal to body length, it means this chunk is not the entire
+                // content of the file, thus we need to record the start line.
+                if text.len() != body.len() {
                     attributes[code::fields::CHUNK_START_LINE] = start_line.into();
                 }
                 let embedding = embedding.clone();


### PR DESCRIPTION
The condition for setting the `CHUNK_START_LINE` attribute was incorrect. It now checks if the text length is not equal to the body length, ensuring the attribute is set only when necessary.