### PR TITLE
feat(notification): send notification to admin when job failed

### DIFF
--- a/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-detail.tsx
+++ b/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-detail.tsx
@@ -36,6 +36,14 @@ export default function JobRunDetail() {
   const isPending =
     (stateLabel === 'Pending' || stateLabel === 'Running') &&
     !currentNode?.stdout
+  
+  const handleBackNavigation = () => {
+    if (typeof window !== 'undefined' && window.history.length <= 1) {
+      router.push('/jobs')
+    } else {
+      router.back()
+    }
+  }
 
   React.useEffect(() => {
     let timer: number
@@ -61,7 +69,7 @@ export default function JobRunDetail() {
           {currentNode && (
             <>
               <div
-                onClick={() => router.back()}
+                onClick={handleBackNavigation}
                 className="-ml-1 flex cursor-pointer items-center transition-opacity hover:opacity-60"
               >
                 <IconChevronLeft className="mr-1 h-6 w-6" />

--- a/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-detail.tsx
+++ b/ee/tabby-ui/app/(dashboard)/(logs)/jobs/components/job-detail.tsx
@@ -36,7 +36,7 @@ export default function JobRunDetail() {
   const isPending =
     (stateLabel === 'Pending' || stateLabel === 'Running') &&
     !currentNode?.stdout
-  
+
   const handleBackNavigation = () => {
     if (typeof window !== 'undefined' && window.history.length <= 1) {
       router.push('/jobs')

--- a/ee/tabby-ui/app/globals.css
+++ b/ee/tabby-ui/app/globals.css
@@ -103,3 +103,7 @@
 .dialog-without-close-btn > button {
   display: none;
 }
+
+.unread-notification::before {
+  @apply content-[''] float-left w-2 h-2 mr-1.5 mt-2 rounded-full bg-red-400;
+}

--- a/ee/tabby-ui/components/notification-box.tsx
+++ b/ee/tabby-ui/components/notification-box.tsx
@@ -12,18 +12,18 @@ import { useMutation } from '@/lib/tabby/gql'
 import { notificationsQuery } from '@/lib/tabby/query'
 import { ArrayElementType } from '@/lib/types'
 import { cn } from '@/lib/utils'
-
-import LoadingWrapper from './loading-wrapper'
-import { ListSkeleton } from './skeleton'
-import { Button } from './ui/button'
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger
-} from './ui/dropdown-menu'
-import { IconBell, IconCheck } from './ui/icons'
-import { Separator } from './ui/separator'
-import { Tabs, TabsList, TabsTrigger } from './ui/tabs'
+} from '@/components/ui/dropdown-menu'
+import { IconBell, IconCheck } from '@/components/ui/icons'
+import { Separator } from '@/components/ui/separator'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import LoadingWrapper from '@/components/loading-wrapper'
+import { MemoizedReactMarkdown } from '@/components/markdown'
+import { ListSkeleton } from '@/components/skeleton'
 
 interface Props extends HTMLAttributes<HTMLDivElement> {}
 
@@ -89,7 +89,7 @@ export function NotificationBox({ className, ...rest }: Props) {
           </div>
           <Separator />
           <Tabs
-            className="relative my-2 flex-1 overflow-y-auto px-4"
+            className="relative my-2 flex-1 overflow-y-auto px-5"
             defaultValue="unread"
           >
             <TabsList className="sticky top-0 z-10 grid w-full grid-cols-2">
@@ -156,8 +156,6 @@ interface NotificationItemProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 function NotificationItem({ data }: NotificationItemProps) {
-  const { title, content } = resolveNotification(data.content)
-
   const markNotificationsRead = useMutation(markNotificationsReadMutation)
 
   const onClickMarkRead = () => {
@@ -168,17 +166,14 @@ function NotificationItem({ data }: NotificationItemProps) {
 
   return (
     <div className="space-y-1.5">
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-1.5 overflow-hidden text-sm font-medium">
-          {!data.read && (
-            <span className="h-2 w-2 shrink-0 rounded-full bg-red-400"></span>
-          )}
-          <span className="flex-1 truncate">{title}</span>
-        </div>
-        <div className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
-          {content}
-        </div>
-      </div>
+      <MemoizedReactMarkdown
+        className={cn(
+          'prose max-w-none break-words dark:prose-invert prose-p:leading-relaxed text-sm',
+          { 'unread-notification': !data.read }
+        )}
+      >
+        {data.content}
+      </MemoizedReactMarkdown>
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span className="text-muted-foreground">
           {formatNotificationTime(data.createdAt)}

--- a/ee/tabby-ui/components/notification-box.tsx
+++ b/ee/tabby-ui/components/notification-box.tsx
@@ -168,7 +168,7 @@ function NotificationItem({ data }: NotificationItemProps) {
     <div className="space-y-1.5">
       <MemoizedReactMarkdown
         className={cn(
-          'prose max-w-none break-words dark:prose-invert prose-p:leading-relaxed prose-p:my-1 text-sm',
+          'prose max-w-none break-words text-sm dark:prose-invert prose-p:my-1 prose-p:leading-relaxed',
           { 'unread-notification': !data.read }
         )}
       >

--- a/ee/tabby-ui/components/notification-box.tsx
+++ b/ee/tabby-ui/components/notification-box.tsx
@@ -168,7 +168,7 @@ function NotificationItem({ data }: NotificationItemProps) {
     <div className="space-y-1.5">
       <MemoizedReactMarkdown
         className={cn(
-          'prose max-w-none break-words dark:prose-invert prose-p:leading-relaxed text-sm',
+          'prose max-w-none break-words dark:prose-invert prose-p:leading-relaxed prose-p:my-1 text-sm',
           { 'unread-notification': !data.read }
         )}
       >

--- a/ee/tabby-webserver/src/service/background_job/db.rs
+++ b/ee/tabby-webserver/src/service/background_job/db.rs
@@ -3,11 +3,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tabby_db::DbConn;
-use tabby_schema::{
-    context::ContextService,
-    notification::NotificationService,
-    CoreError,
-};
+use tabby_schema::{context::ContextService, notification::NotificationService, CoreError};
 
 use super::helper::Job;
 

--- a/ee/tabby-webserver/src/service/background_job/db.rs
+++ b/ee/tabby-webserver/src/service/background_job/db.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tabby_db::DbConn;
 use tabby_schema::{
     context::ContextService,
-    notification::{NotificationRecipient, NotificationService},
+    notification::NotificationService,
     CoreError,
 };
 

--- a/ee/tabby-webserver/src/service/background_job/db.rs
+++ b/ee/tabby-webserver/src/service/background_job/db.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tabby_db::DbConn;
-use tabby_schema::{context::ContextService, CoreError};
+use tabby_schema::{
+    context::ContextService,
+    notification::{NotificationRecipient, NotificationService},
+    CoreError,
+};
 
 use super::helper::Job;
 
@@ -19,6 +23,7 @@ impl DbMaintainanceJob {
         now: DateTime<Utc>,
         context: Arc<dyn ContextService>,
         db: DbConn,
+        notification_service: Arc<dyn NotificationService>,
     ) -> tabby_schema::Result<()> {
         let mut errors = vec![];
 

--- a/ee/tabby-webserver/src/service/background_job/db.rs
+++ b/ee/tabby-webserver/src/service/background_job/db.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tabby_db::DbConn;
 use tabby_schema::{context::ContextService, CoreError};
 
-use super::helper::{Job, JobLogger};
+use super::helper::Job;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DbMaintainanceJob;
@@ -19,9 +19,7 @@ impl DbMaintainanceJob {
         now: DateTime<Utc>,
         context: Arc<dyn ContextService>,
         db: DbConn,
-        job_id: i64,
     ) -> tabby_schema::Result<()> {
-        let logger = JobLogger::new(db.clone(), job_id);
         let mut exit_code = 0;
 
         if let Err(e) = db.delete_expired_token().await {
@@ -64,7 +62,6 @@ impl DbMaintainanceJob {
             logkit::warn!(exit_code = exit_code; "Failed to run data retention job: {}", e);
         }
 
-        logger.finalize().await;
         if exit_code == 0 {
             Ok(())
         } else {

--- a/ee/tabby-webserver/src/service/background_job/git.rs
+++ b/ee/tabby-webserver/src/service/background_job/git.rs
@@ -45,7 +45,7 @@ impl SchedulerGitJob {
         let repositories = match git_repository.repository_list().await {
             Ok(repos) => repos,
             Err(err) => {
-                logkit::warn!(exit_code = -1; "Failed to list repositories: {}", err);
+                logkit::warn!("Failed to list repositories: {}", err);
                 return Err(err);
             }
         };

--- a/ee/tabby-webserver/src/service/background_job/git.rs
+++ b/ee/tabby-webserver/src/service/background_job/git.rs
@@ -8,7 +8,7 @@ use tabby_index::public::CodeIndexer;
 use tabby_inference::Embedding;
 use tabby_schema::{job::JobService, repository::GitRepositoryService};
 
-use super::{helper::Job, BackgroundJobEvent, JobLogger};
+use super::{helper::Job, BackgroundJobEvent};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SchedulerGitJob {
@@ -41,15 +41,11 @@ impl SchedulerGitJob {
         _now: DateTime<Utc>,
         git_repository: Arc<dyn GitRepositoryService>,
         job: Arc<dyn JobService>,
-        db: tabby_db::DbConn,
-        job_id: i64,
     ) -> tabby_schema::Result<()> {
-        let logger = JobLogger::new(db.clone(), job_id);
         let repositories = match git_repository.repository_list().await {
             Ok(repos) => repos,
             Err(err) => {
                 logkit::warn!(exit_code = -1; "Failed to list repositories: {}", err);
-                logger.finalize().await;
                 return Err(err);
             }
         };
@@ -65,7 +61,6 @@ impl SchedulerGitJob {
                 .await;
         }
 
-        logger.finalize().await;
         Ok(())
     }
 }

--- a/ee/tabby-webserver/src/service/background_job/helper/mod.rs
+++ b/ee/tabby-webserver/src/service/background_job/helper/mod.rs
@@ -4,6 +4,13 @@ mod logger;
 pub use cron::CronStream;
 pub use logger::JobLogger;
 
-pub trait Job {
+pub trait Job: serde::Serialize {
     const NAME: &'static str;
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+    fn to_command(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
 }

--- a/ee/tabby-webserver/src/service/background_job/index_garbage_collection.rs
+++ b/ee/tabby-webserver/src/service/background_job/index_garbage_collection.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
+use serde::Serialize;
 use tabby_index::public::{run_index_garbage_collection, CodeIndexer};
 use tabby_schema::{context::ContextService, repository::RepositoryService};
 
-use super::helper::Job;
+use super::helper::{Job, JobLogger};
 
+#[derive(Serialize)]
 pub struct IndexGarbageCollection;
 
 impl Job for IndexGarbageCollection {
@@ -16,22 +18,45 @@ impl IndexGarbageCollection {
         self,
         repository: Arc<dyn RepositoryService>,
         context: Arc<dyn ContextService>,
+        db: tabby_db::DbConn,
+        job_id: i64,
     ) -> tabby_schema::Result<()> {
+        let logger = JobLogger::new(db.clone(), job_id);
+
         // Run garbage collection on the index
-        let sources = context
-            .read(None)
-            .await?
+        let sources = match context.read(None).await {
+            Ok(sources) => sources,
+            Err(err) => {
+                logkit::warn!(exit_code = -1; "Failed to list sources: {}", err);
+                logger.finalize().await;
+                return Err(err);
+            }
+        };
+        let sources = sources
             .sources
             .into_iter()
             .map(|x| x.source_id())
             .collect::<Vec<_>>();
-        run_index_garbage_collection(sources)?;
+
+        if let Err(e) = run_index_garbage_collection(sources) {
+            logkit::warn!(exit_code = -1; "Failed to run index garbage collection: {}", e);
+            logger.finalize().await;
+            return Err(e.into());
+        }
 
         // Run garbage collection on the code repositories (cloned directories)
-        let repositories = repository.list_all_code_repository().await?;
+        let repositories = match repository.list_all_code_repository().await {
+            Ok(repos) => repos,
+            Err(err) => {
+                logkit::warn!(exit_code = -1; "Failed to list repositories: {}", err);
+                logger.finalize().await;
+                return Err(err);
+            }
+        };
         let mut code = CodeIndexer::default();
         code.garbage_collection(&repositories).await;
 
+        logger.finalize().await;
         Ok(())
     }
 }

--- a/ee/tabby-webserver/src/service/background_job/index_garbage_collection.rs
+++ b/ee/tabby-webserver/src/service/background_job/index_garbage_collection.rs
@@ -23,7 +23,7 @@ impl IndexGarbageCollection {
         let sources = match context.read(None).await {
             Ok(sources) => sources,
             Err(err) => {
-                logkit::warn!(exit_code = -1; "Failed to list sources: {}", err);
+                logkit::warn!("Failed to list sources: {}", err);
                 return Err(err);
             }
         };
@@ -34,7 +34,7 @@ impl IndexGarbageCollection {
             .collect::<Vec<_>>();
 
         if let Err(e) = run_index_garbage_collection(sources) {
-            logkit::warn!(exit_code = -1; "Failed to run index garbage collection: {}", e);
+            logkit::warn!("Failed to run index garbage collection: {}", e);
             return Err(e.into());
         }
 
@@ -42,7 +42,7 @@ impl IndexGarbageCollection {
         let repositories = match repository.list_all_code_repository().await {
             Ok(repos) => repos,
             Err(err) => {
-                logkit::warn!(exit_code = -1; "Failed to list repositories: {}", err);
+                logkit::warn!("Failed to list repositories: {}", err);
                 return Err(err);
             }
         };

--- a/ee/tabby-webserver/src/service/background_job/license_check.rs
+++ b/ee/tabby-webserver/src/service/background_job/license_check.rs
@@ -25,7 +25,7 @@ impl LicenseCheckJob {
         let license = match license_service.read().await {
             Ok(license) => license,
             Err(err) => {
-                logkit::warn!(exit_code = -1; "Failed to read license: {}", err);
+                logkit::warn!("Failed to read license: {}", err);
                 return Err(err);
             }
         };
@@ -41,7 +41,7 @@ impl LicenseCheckJob {
                     )
                     .await
                 {
-                    logkit::warn!(exit_code = -1; "Failed to create notification: {}", e);
+                    logkit::warn!("Failed to create notification: {}", e);
                     return Err(e);
                 }
             }

--- a/ee/tabby-webserver/src/service/background_job/mod.rs
+++ b/ee/tabby-webserver/src/service/background_job/mod.rs
@@ -172,7 +172,7 @@ pub async fn start(
 
                     match &result {
                         Err(err) => {
-                            logkit::info!(exit_code = 1; "Job failed {}", err);
+                            logkit::warn!(exit_code = 1; "Job failed {}", err);
                             logger.finalize().await;
                             notify_job_error!(notification_service, err, job_name, job_id);
                         },
@@ -235,7 +235,7 @@ pub async fn start(
                 }
                 else => {
                     warn!("Background job channel closed");
-                    return;
+                    break;
                 }
             };
         }

--- a/ee/tabby-webserver/src/service/background_job/mod.rs
+++ b/ee/tabby-webserver/src/service/background_job/mod.rs
@@ -265,7 +265,10 @@ async fn run_job<F, Fut>(
 
     let logger = JobLogger::new(db.clone(), job_id);
     if let Err(err) = job_fn().await {
+        logkit::warn!(exit_code = 1; "Job failed {}", err);
         notify_job_error!(notification_service, err, job_name, job_id);
+    } else {
+        logkit::info!(exit_code = 0; "Job completed successfully");
     }
     logger.finalize().await;
 }

--- a/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
+++ b/ee/tabby-webserver/src/service/background_job/third_party_integration.rs
@@ -61,7 +61,7 @@ impl SyncIntegrationJob {
         {
             Ok(integrations) => integrations,
             Err(err) => {
-                logkit::warn!(exit_code = -1; "Failed to list integrations: {}", err);
+                logkit::warn!("Failed to list integrations: {}", err);
                 return Err(err);
             }
         };
@@ -243,7 +243,7 @@ impl SchedulerGithubGitlabJob {
         {
             Ok(repos) => repos,
             Err(err) => {
-                logkit::warn!(exit_code = -1; "Failed to list repositories: {}", err);
+                logkit::warn!("Failed to list repositories: {}", err);
                 return Err(err);
             }
         };

--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -34,6 +34,10 @@ impl WebCrawlerJob {
         }
     }
 
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
     pub async fn run_impl(self, embedding: Arc<dyn Embedding>) -> tabby_schema::Result<()> {
         logkit::info!("Starting doc index pipeline for {}", self.url);
         let embedding = embedding.clone();


### PR DESCRIPTION
This PR:
1. create a job_run in db before running a background job
2. save background error logs using `logkit::warn`
3. send a notification if the job failed and users could redirect to the job detail page

db failed:
![CleanShot 2025-01-13 at 15 23 03@2x](https://github.com/user-attachments/assets/2a39dfa9-dde3-4800-a920-4dab707a80a2)

click on return will go back to job list:
![CleanShot 2025-01-13 at 15 42 45@2x](https://github.com/user-attachments/assets/52068806-afbf-4ad7-98c1-87a7abf0226d)

![CleanShot 2025-01-13 at 21 03 01@2x](https://github.com/user-attachments/assets/edca71be-6785-483f-a7d4-2641936340f1)


when click on return:
https://jam.dev/c/dd698d82-0b48-4bbd-b056-9f8d23f218d3
