### PR TITLE
feat(chat-panel): save chat state and reload state when webview reloading

### DIFF
--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -278,6 +278,20 @@ export interface ClientApiMethods {
    * @returns The active selection of active editor.
    */
   getActiveEditorSelection: () => Promise<EditorFileContext | null>
+
+  /**
+   * Fetch the saved persisted state from client.
+   * @param keys The keys to be fetched. Returns all keys if not provided.
+   * @return The saved persisted state.
+   */
+  fetchPersistedState?: (keys?: string[] | undefined) => Promise<Record<string, unknown> | null>
+
+  /**
+   * Save a persisted state of the chat panel.
+   * The saved state should be merged and updated by the record key.
+   * @param state The state to save.
+   */
+  storePersistedState?: (state: Record<string, unknown>) => Promise<void>
 }
 
 export interface ClientApi extends ClientApiMethods {
@@ -303,6 +317,8 @@ export function createClient(target: HTMLIFrameElement, api: ClientApiMethods): 
       openExternal: api.openExternal,
       readWorkspaceGitRepositories: api.readWorkspaceGitRepositories,
       getActiveEditorSelection: api.getActiveEditorSelection,
+      fetchPersistedState: api.fetchPersistedState,
+      storePersistedState: api.storePersistedState,
     },
   })
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -280,18 +280,20 @@ export interface ClientApiMethods {
   getActiveEditorSelection: () => Promise<EditorFileContext | null>
 
   /**
-   * Fetch the saved persisted state from client.
-   * @param keys The keys to be fetched. Returns all keys if not provided.
-   * @return The saved persisted state.
+   * Fetch the saved session state from the client.
+   * When initialized, the chat panel attempts to fetch the saved session state to restore the session.
+   * @param keys The keys to be fetched. If not provided, all keys will be returned.
+   * @return The saved persisted state, or null if no state is found.
    */
-  fetchPersistedState?: (keys?: string[] | undefined) => Promise<Record<string, unknown> | null>
+  fetchSessionState?: (keys?: string[] | undefined) => Promise<Record<string, unknown> | null>
 
   /**
-   * Save a persisted state of the chat panel.
+   * Save the session state of the chat panel.
+   * The client is responsible for maintaining the state in case of a webview reload.
    * The saved state should be merged and updated by the record key.
    * @param state The state to save.
    */
-  storePersistedState?: (state: Record<string, unknown>) => Promise<void>
+  storeSessionState?: (state: Record<string, unknown>) => Promise<void>
 }
 
 export interface ClientApi extends ClientApiMethods {
@@ -317,8 +319,8 @@ export function createClient(target: HTMLIFrameElement, api: ClientApiMethods): 
       openExternal: api.openExternal,
       readWorkspaceGitRepositories: api.readWorkspaceGitRepositories,
       getActiveEditorSelection: api.getActiveEditorSelection,
-      fetchPersistedState: api.fetchPersistedState,
-      storePersistedState: api.storePersistedState,
+      fetchSessionState: api.fetchSessionState,
+      storeSessionState: api.storeSessionState,
     },
   })
 }

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -304,6 +304,14 @@ export default function ChatPage() {
     return server?.getActiveEditorSelection() ?? null
   }
 
+  const fetchPersistedState = async () => {
+    return server?.fetchPersistedState?.() ?? null
+  }
+
+  const storePersistedState = async (state: Record<string, any>) => {
+    return server?.storePersistedState?.(state)
+  }
+
   const refresh = async () => {
     setIsRefreshLoading(true)
     await server?.refresh()
@@ -427,6 +435,8 @@ export default function ChatPage() {
             : undefined
         }
         getActiveEditorSelection={getActiveEditorSelection}
+        fetchPersistedState={fetchPersistedState}
+        storePersistedState={storePersistedState}
       />
     </ErrorBoundary>
   )

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -79,6 +79,10 @@ export default function ChatPage() {
     supportsReadWorkspaceGitRepoInfo,
     setSupportsReadWorkspaceGitRepoInfo
   ] = useState(false)
+  const [
+    supportsStoreAndFetchSessionState,
+    setSupportsStoreAndFetchSessionState
+  ] = useState(false)
 
   const executeCommand = (command: ChatCommand) => {
     if (chatRef.current) {
@@ -244,6 +248,10 @@ export default function ChatPage() {
         server
           ?.hasCapability('readWorkspaceGitRepositories')
           .then(setSupportsReadWorkspaceGitRepoInfo)
+        Promise.all([server?.hasCapability('fetchSessionState'), server?.hasCapability('storeSessionState')])
+          .then(results => {
+            setSupportsStoreAndFetchSessionState(results.every(result => !!result))
+          })
       }
 
       checkCapabilities().then(() => {
@@ -435,8 +443,8 @@ export default function ChatPage() {
             : undefined
         }
         getActiveEditorSelection={getActiveEditorSelection}
-        fetchSessionState={fetchSessionState}
-        storeSessionState={storeSessionState}
+        fetchSessionState={supportsStoreAndFetchSessionState ? fetchSessionState : undefined}
+        storeSessionState={supportsStoreAndFetchSessionState ? storeSessionState : undefined}
       />
     </ErrorBoundary>
   )

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -304,12 +304,12 @@ export default function ChatPage() {
     return server?.getActiveEditorSelection() ?? null
   }
 
-  const fetchPersistedState = async () => {
-    return server?.fetchPersistedState?.() ?? null
+  const fetchSessionState = async () => {
+    return server?.fetchSessionState?.() ?? null
   }
 
-  const storePersistedState = async (state: Record<string, any>) => {
-    return server?.storePersistedState?.(state)
+  const storeSessionState = async (state: Record<string, any>) => {
+    return server?.storeSessionState?.(state)
   }
 
   const refresh = async () => {
@@ -435,8 +435,8 @@ export default function ChatPage() {
             : undefined
         }
         getActiveEditorSelection={getActiveEditorSelection}
-        fetchPersistedState={fetchPersistedState}
-        storePersistedState={storePersistedState}
+        fetchSessionState={fetchSessionState}
+        storeSessionState={storeSessionState}
       />
     </ErrorBoundary>
   )

--- a/ee/tabby-ui/app/chat/page.tsx
+++ b/ee/tabby-ui/app/chat/page.tsx
@@ -248,10 +248,14 @@ export default function ChatPage() {
         server
           ?.hasCapability('readWorkspaceGitRepositories')
           .then(setSupportsReadWorkspaceGitRepoInfo)
-        Promise.all([server?.hasCapability('fetchSessionState'), server?.hasCapability('storeSessionState')])
-          .then(results => {
-            setSupportsStoreAndFetchSessionState(results.every(result => !!result))
-          })
+        Promise.all([
+          server?.hasCapability('fetchSessionState'),
+          server?.hasCapability('storeSessionState')
+        ]).then(results => {
+          setSupportsStoreAndFetchSessionState(
+            results.every(result => !!result)
+          )
+        })
       }
 
       checkCapabilities().then(() => {
@@ -443,8 +447,12 @@ export default function ChatPage() {
             : undefined
         }
         getActiveEditorSelection={getActiveEditorSelection}
-        fetchSessionState={supportsStoreAndFetchSessionState ? fetchSessionState : undefined}
-        storeSessionState={supportsStoreAndFetchSessionState ? storeSessionState : undefined}
+        fetchSessionState={
+          supportsStoreAndFetchSessionState ? fetchSessionState : undefined
+        }
+        storeSessionState={
+          supportsStoreAndFetchSessionState ? storeSessionState : undefined
+        }
       />
     </ErrorBoundary>
   )

--- a/ee/tabby-ui/components/chat/chat.tsx
+++ b/ee/tabby-ui/components/chat/chat.tsx
@@ -389,19 +389,22 @@ function ChatRenderer(
     }
   }, [answer, isLoading])
 
-  const scrollToBottom = useDebounceCallback((behavior: ScrollBehavior = 'smooth') => {
-    if (container) {
-      container.scrollTo({
-        top: container.scrollHeight,
-        behavior
-      })
-    } else {
-      window.scrollTo({
-        top: document.body.offsetHeight,
-        behavior
-      })
-    }
-  }, 100)
+  const scrollToBottom = useDebounceCallback(
+    (behavior: ScrollBehavior = 'smooth') => {
+      if (container) {
+        container.scrollTo({
+          top: container.scrollHeight,
+          behavior
+        })
+      } else {
+        window.scrollTo({
+          top: document.body.offsetHeight,
+          behavior
+        })
+      }
+    },
+    100
+  )
 
   React.useLayoutEffect(() => {
     // scroll to bottom when a request is sent


### PR DESCRIPTION
In VSCode, when a user drags the chat panel to another location, the webview is reloaded. To restore the chat state, this PR adds the `fetchSessionState` and `storeSessionState` interfaces. These interfaces store the chat state and reload it when the webview is reloaded.
