### PR TITLE
refactor: remove deprecated code

### DIFF
--- a/crates/tabby-common/src/index/mod.rs
+++ b/crates/tabby-common/src/index/mod.rs
@@ -82,12 +82,6 @@ pub const FIELD_ATTRIBUTES: &str = "attributes";
 pub mod corpus {
     pub const CODE: &str = "code";
     pub const STRUCTURED_DOC: &str = "structured_doc";
-
-    #[deprecated(
-        since = "0.20.0",
-        note = "The web corpus is deprecated and will be removed during the version upgrade."
-    )]
-    pub const WEB: &str = "web";
 }
 
 impl IndexSchema {

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -103,11 +103,6 @@ pub struct ServeArgs {
 
     #[cfg(feature = "ee")]
     #[clap(hide = true, long, default_value_t = false)]
-    #[deprecated(since = "0.11.0", note = "webserver is enabled by default")]
-    webserver: bool,
-
-    #[cfg(feature = "ee")]
-    #[clap(hide = true, long, default_value_t = false)]
     no_webserver: bool,
 }
 
@@ -117,12 +112,6 @@ pub async fn main(config: &Config, args: &ServeArgs) {
     load_model(&config).await;
 
     let tx = try_run_spinner();
-
-    #[cfg(feature = "ee")]
-    #[allow(deprecated)]
-    if args.webserver {
-        warn!("'--webserver' is enabled by default since 0.11, and will be removed in the next major release. Please remove this flag from your command.");
-    }
 
     #[allow(unused_assignments)]
     let mut webserver = None;


### PR DESCRIPTION
- Removed deprecated `webserver` flag and related warning in `serve.rs`.
- Removed deprecated `WEB` corpus constant in `index/mod.rs`.