### PR TITLE
feat(backend): adding Azure AI Foundry OpenAPI support

### DIFF
--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -18,12 +18,7 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
             let config = async_openai_alt::config::AzureConfig::new()
                 .with_api_base(api_endpoint)
                 .with_api_key(model.api_key.clone().unwrap_or_default())
-                .with_api_version(
-                    model
-                        .api_version
-                        .clone()
-                        .unwrap_or("2024-05-01-preview".to_string()),
-                )
+                .with_api_version("2024-08-01-preview")
                 .with_deployment_id(model.model_name.as_deref().expect("Model name is required"));
             Box::new(
                 async_openai_alt::Client::with_config(config)

--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -12,31 +12,48 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
         .api_endpoint
         .as_deref()
         .expect("api_endpoint is required");
-    let config = OpenAIConfig::default()
-        .with_api_base(api_endpoint)
-        .with_api_key(model.api_key.clone().unwrap_or_default());
 
-    let mut builder = ExtendedOpenAIConfig::builder();
+    let engine: Box<dyn ChatCompletionStream> = match model.kind.as_str() {
+        "azure/chat" => {
+            let config = async_openai_alt::config::AzureConfig::new()
+                .with_api_base(api_endpoint)
+                .with_api_key(model.api_key.clone().unwrap_or_default())
+                .with_api_version(
+                    model
+                        .api_version
+                        .clone()
+                        .unwrap_or("2024-05-01-preview".to_string()),
+                )
+                .with_deployment_id(model.model_name.as_deref().expect("Model name is required"));
+            Box::new(
+                async_openai_alt::Client::with_config(config)
+                    .with_http_client(create_reqwest_client(api_endpoint)),
+            )
+        }
+        "openai/chat" | "mistral/chat" => {
+            let config = OpenAIConfig::default()
+                .with_api_base(api_endpoint)
+                .with_api_key(model.api_key.clone().unwrap_or_default());
 
-    builder
-        .base(config)
-        .supported_models(model.supported_models.clone())
-        .model_name(model.model_name.as_deref().expect("Model name is required"));
+            let mut builder = ExtendedOpenAIConfig::builder();
+            builder
+                .base(config)
+                .supported_models(model.supported_models.clone())
+                .model_name(model.model_name.as_deref().expect("Model name is required"));
 
-    if model.kind == "openai/chat" {
-        // Do nothing
-    } else if model.kind == "mistral/chat" {
-        builder.fields_to_remove(ExtendedOpenAIConfig::mistral_fields_to_remove());
-    } else {
-        panic!("Unsupported model kind: {}", model.kind);
-    }
+            if model.kind == "mistral/chat" {
+                builder.fields_to_remove(ExtendedOpenAIConfig::mistral_fields_to_remove());
+            }
 
-    let config = builder.build().expect("Failed to build config");
-
-    let engine = Box::new(
-        async_openai_alt::Client::with_config(config)
-            .with_http_client(create_reqwest_client(api_endpoint)),
-    );
+            Box::new(
+                async_openai_alt::Client::with_config(
+                    builder.build().expect("Failed to build config"),
+                )
+                .with_http_client(create_reqwest_client(api_endpoint)),
+            )
+        }
+        _ => panic!("Unsupported model kind: {}", model.kind),
+    };
 
     Arc::new(rate_limit::new_chat(
         engine,

--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -5,7 +5,7 @@ use tabby_common::config::HttpModelConfig;
 use tabby_inference::{ChatCompletionStream, ExtendedOpenAIConfig};
 
 use super::rate_limit;
-use crate::create_reqwest_client;
+use crate::{create_reqwest_client, AZURE_API_VERSION};
 
 pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
     let api_endpoint = model
@@ -18,7 +18,7 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
             let config = async_openai_alt::config::AzureConfig::new()
                 .with_api_base(api_endpoint)
                 .with_api_key(model.api_key.clone().unwrap_or_default())
-                .with_api_version("2024-08-01-preview")
+                .with_api_version(AZURE_API_VERSION.to_string())
                 .with_deployment_id(model.model_name.as_deref().expect("Model name is required"));
             Box::new(
                 async_openai_alt::Client::with_config(config)

--- a/crates/http-api-bindings/src/embedding/azure.rs
+++ b/crates/http-api-bindings/src/embedding/azure.rs
@@ -47,7 +47,7 @@ impl AzureEmbeddingEngine {
             client: Arc::new(client),
             api_endpoint: azure_endpoint,
             api_key: api_key.unwrap_or_default().to_owned(),
-            api_version: api_version.unwrap_or("2024-02-15-preview").to_owned(),
+            api_version: api_version.unwrap_or("2023-05-15").to_owned(),
         })
     }
 }

--- a/crates/http-api-bindings/src/embedding/azure.rs
+++ b/crates/http-api-bindings/src/embedding/azure.rs
@@ -1,8 +1,9 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use tabby_inference::Embedding;
 
 #[derive(Clone)]

--- a/crates/http-api-bindings/src/embedding/azure.rs
+++ b/crates/http-api-bindings/src/embedding/azure.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tabby_inference::Embedding;
+
+#[derive(Clone)]
+pub struct AzureEmbeddingEngine {
+    client: Arc<Client>,
+    api_endpoint: String,
+    api_key: String,
+    api_version: String,
+}
+
+#[derive(Debug, Serialize)]
+struct EmbeddingRequest {
+    input: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<Data>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Data {
+    embedding: Vec<f32>,
+}
+
+impl AzureEmbeddingEngine {
+    pub fn create(
+        api_endpoint: &str,
+        model_name: &str,
+        api_key: Option<&str>,
+        api_version: Option<&str>,
+    ) -> Box<dyn Embedding> {
+        let client = Client::new();
+        let deployment_id = model_name;
+        let azure_endpoint = format!(
+            "{}/openai/deployments/{}/embeddings",
+            api_endpoint.trim_end_matches('/'),
+            deployment_id
+        );
+
+        Box::new(Self {
+            client: Arc::new(client),
+            api_endpoint: azure_endpoint,
+            api_key: api_key.unwrap_or_default().to_owned(),
+            api_version: api_version.unwrap_or("2024-02-15-preview").to_owned(),
+        })
+    }
+}
+
+#[async_trait]
+impl Embedding for AzureEmbeddingEngine {
+    async fn embed(&self, prompt: &str) -> Result<Vec<f32>> {
+        let client = self.client.clone();
+        let api_endpoint = self.api_endpoint.clone();
+        let api_key = self.api_key.clone();
+        let api_version = self.api_version.clone();
+        let request = EmbeddingRequest {
+            input: prompt.to_owned(),
+        };
+
+        let response = client
+            .post(&api_endpoint)
+            .query(&[("api-version", &api_version)])
+            .header("api-key", &api_key)
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            anyhow::bail!("Azure API error: {}", error_text);
+        }
+
+        let embedding_response: EmbeddingResponse = response.json().await?;
+        embedding_response
+            .data
+            .first()
+            .map(|data| data.embedding.clone())
+            .ok_or_else(|| anyhow::anyhow!("No embedding data received"))
+    }
+}

--- a/crates/http-api-bindings/src/embedding/mod.rs
+++ b/crates/http-api-bindings/src/embedding/mod.rs
@@ -1,9 +1,11 @@
+mod azure;
 mod llama;
 mod openai;
 
 use core::panic;
 use std::sync::Arc;
 
+use azure::AzureEmbeddingEngine;
 use llama::LlamaCppEngine;
 use openai::OpenAIEmbeddingEngine;
 use tabby_common::config::HttpModelConfig;
@@ -39,6 +41,15 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
                 .as_deref()
                 .expect("model_name must be set for voyage/embedding"),
             config.api_key.as_deref(),
+        ),
+        "azure/embedding" => AzureEmbeddingEngine::create(
+            config
+                .api_endpoint
+                .as_deref()
+                .expect("api_endpoint is required for azure/embedding"),
+            config.model_name.as_deref().unwrap_or_default(), // Provide a default if model_name is optional
+            config.api_key.as_deref(),                        // Pass the API key if available
+            config.api_version.as_deref(),                    // Pass the API version if available
         ),
         unsupported_kind => panic!(
             "Unsupported kind for http embedding model: {}",

--- a/crates/http-api-bindings/src/embedding/mod.rs
+++ b/crates/http-api-bindings/src/embedding/mod.rs
@@ -49,7 +49,6 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
                 .expect("api_endpoint is required for azure/embedding"),
             config.model_name.as_deref().unwrap_or_default(), // Provide a default if model_name is optional
             config.api_key.as_deref(),
-            Some("2023-05-15"),
         ),
         unsupported_kind => panic!(
             "Unsupported kind for http embedding model: {}",

--- a/crates/http-api-bindings/src/embedding/mod.rs
+++ b/crates/http-api-bindings/src/embedding/mod.rs
@@ -48,8 +48,8 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
                 .as_deref()
                 .expect("api_endpoint is required for azure/embedding"),
             config.model_name.as_deref().unwrap_or_default(), // Provide a default if model_name is optional
-            config.api_key.as_deref(),                        // Pass the API key if available
-            config.api_version.as_deref(),                    // Pass the API version if available
+            config.api_key.as_deref(),
+            Some("2023-05-15"),
         ),
         unsupported_kind => panic!(
             "Unsupported kind for http embedding model: {}",

--- a/crates/http-api-bindings/src/lib.rs
+++ b/crates/http-api-bindings/src/lib.rs
@@ -20,3 +20,5 @@ fn create_reqwest_client(api_endpoint: &str) -> reqwest::Client {
 
     builder.build().unwrap()
 }
+
+static AZURE_API_VERSION: &str = "2024-02-01";

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -310,6 +310,11 @@ pub struct HttpModelConfig {
 
     #[builder(default)]
     pub additional_stop_words: Option<Vec<String>>,
+
+    /// Used For Azure API to specify the api version
+    #[builder(default)]
+    #[serde(default)]
+    pub api_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -310,11 +310,6 @@ pub struct HttpModelConfig {
 
     #[builder(default)]
     pub additional_stop_words: Option<Vec<String>>,
-
-    /// Used For Azure API to specify the api version
-    #[builder(default)]
-    #[serde(default)]
-    pub api_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/tabby-inference/src/chat.rs
+++ b/crates/tabby-inference/src/chat.rs
@@ -125,3 +125,20 @@ impl ChatCompletionStream for async_openai_alt::Client<ExtendedOpenAIConfig> {
         self.chat().create_stream(request).await
     }
 }
+
+#[async_trait]
+impl ChatCompletionStream for async_openai_alt::Client<async_openai_alt::config::AzureConfig> {
+    async fn chat(
+        &self,
+        request: CreateChatCompletionRequest,
+    ) -> Result<CreateChatCompletionResponse, OpenAIError> {
+        self.chat().create(request).await
+    }
+
+    async fn chat_stream(
+        &self,
+        request: CreateChatCompletionRequest,
+    ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        self.chat().create_stream(request).await
+    }
+}


### PR DESCRIPTION
# Azure OpenAI HTTP API Support

Added HTTP API support for Azure OpenAI Service, enabling seamless integration with all OpenAI API models available through Azure AI Service, including:

- GPT series chat models
- Embedding models 


add the following configuration to your `~/.tabby/config.toml` to get started:

```toml
# Configure chat model
[model.chat.http]
kind = "azure/chat"
model_name = "gpt-4o-mini"
api_endpoint = "https://xxx.openai.azure.com"  
api_key = "your-api-key"

# Configure embedding model
[model.embedding.http]
kind = "azure/embedding"
model_name = "text-embedding-3-small"
api_endpoint = "https://xxx.openai.azure.com"  
api_key = "your-api-key"
```

### Relate Issues
- #3668 