### PR TITLE
docs(amazon-bedrock): add Amazon Bedrock documentation for HTTP API use case

### DIFF
--- a/website/docs/references/models-http-api/amazon-bedrock.md
+++ b/website/docs/references/models-http-api/amazon-bedrock.md
@@ -1,0 +1,25 @@
+# Amazon Bedrock
+
+Amazon Bedrock is a fully managed service on AWS that provides access to foundation models from various AI companies through a single API. With [Amazon Bedrock Access Gateway](https://github.com/aws-samples/bedrock-access-gateway), you can access Anthropic's Claude models through an OpenAI-compatible interface, enabling seamless integration with tools and applications designed for OpenAI's API structure.
+
+Follow the Amazon Bedrock Access Gateway setup guide to deploy your own OpenAI-compatible API endpoint for Claude models. The gateway transforms standard OpenAI API calls into Amazon Bedrock requests, enabling seamless integration with tools and applications designed for OpenAI's API structure.
+
+## Chat model
+
+Amazon Bedrock Access Gateway provides an OpenAI-compatible chat API interface for Claude models.
+
+```toml title="~/.tabby/config.toml"
+[model.chat.http]
+kind = "openai/chat"
+model_name = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+api_endpoint = "http://Bedrock-Proxy-xxxxx.{Region}.elb.amazonaws.com/api/v1"
+api_key = "your-api-key"
+```
+
+## Completion model
+
+Amazon Bedrock does not provide completion models.
+
+## Embeddings model
+
+While Amazon Bedrock supports embeddings models, Tabby does not currently support the embeddings API interface for Amazon models.

--- a/website/docs/references/models-http-api/amazon-bedrock.md
+++ b/website/docs/references/models-http-api/amazon-bedrock.md
@@ -2,6 +2,8 @@
 
 Amazon Bedrock is a fully managed service on AWS that provides access to foundation models from various AI companies through a single API. With [Amazon Bedrock Access Gateway](https://github.com/aws-samples/bedrock-access-gateway), you can access Anthropic's Claude models through an OpenAI-compatible interface, enabling seamless integration with tools and applications designed for OpenAI's API structure.
 
+Follow the Amazon Bedrock Access Gateway setup guide to deploy your own OpenAI-compatible API endpoint for Claude models.
+
 ## Chat model
 
 Amazon Bedrock Access Gateway provides an OpenAI-compatible chat API interface for Claude models. Here we use the `us.anthropic.claude-3-5-sonnet-20241022-v2:0` model as an example.

--- a/website/docs/references/models-http-api/amazon-bedrock.md
+++ b/website/docs/references/models-http-api/amazon-bedrock.md
@@ -2,11 +2,9 @@
 
 Amazon Bedrock is a fully managed service on AWS that provides access to foundation models from various AI companies through a single API. With [Amazon Bedrock Access Gateway](https://github.com/aws-samples/bedrock-access-gateway), you can access Anthropic's Claude models through an OpenAI-compatible interface, enabling seamless integration with tools and applications designed for OpenAI's API structure.
 
-Follow the Amazon Bedrock Access Gateway setup guide to deploy your own OpenAI-compatible API endpoint for Claude models. The gateway transforms standard OpenAI API calls into Amazon Bedrock requests, enabling seamless integration with tools and applications designed for OpenAI's API structure.
-
 ## Chat model
 
-Amazon Bedrock Access Gateway provides an OpenAI-compatible chat API interface for Claude models.
+Amazon Bedrock Access Gateway provides an OpenAI-compatible chat API interface for Claude models. Here we use the `us.anthropic.claude-3-5-sonnet-20241022-v2:0` model as an example.
 
 ```toml title="~/.tabby/config.toml"
 [model.chat.http]


### PR DESCRIPTION
<img width="912" alt="image" src="https://github.com/user-attachments/assets/1ebbca5c-67b3-4b73-bd54-9a708a30006a" />