### PR TITLE
docs(models): emphasize the deprecation of OpenAI completion API

### DIFF
--- a/website/docs/references/models-http-api/openai.md
+++ b/website/docs/references/models-http-api/openai.md
@@ -6,26 +6,38 @@ Tabby supports OpenAI's API specifications for chat, completion, and embedding t
 The OpenAI API is widely used and is also provided by other vendors,
 such as vLLM, Nvidia NIM, and LocalAI.
 
-OpenAI has designated its `/v1/completions` API for code completion as legacy,
-and **OpenAI itself no longer supports it**.
-
 Tabby continues to support the OpenAI Completion API specifications due to its widespread usage.
+
+## Chat model
 
 ```toml title="~/.tabby/config.toml"
 # Chat model
 [model.chat.http]
 kind = "openai/chat"
-model_name = "gpt-3.5-turbo"  # Please make sure to use a chat model, such as gpt-4o
+model_name = "gpt-4o"  # Please make sure to use a chat model, such as gpt-4o
 api_endpoint = "https://api.openai.com/v1"   # DO NOT append the `/chat/completions` suffix
 api_key = "secret-api-key"
+```
 
+## Completion model
+
+OpenAI has designated its `/v1/completions` API for code completion as legacy,
+and **OpenAI itself no longer supports it**. If you use it with OpenAI, you may encounter unpredictable problems.
+
+For other vendors that have implemented an OpenAI-compatible server, you could use the `openai/completion` kind.
+
+```toml title="~/.tabby/config.toml"
 # Completion model
 [model.completion.http]
 kind = "openai/completion"
 model_name = "gpt-3.5-turbo-instruct"   # Please make sure to use a completion model, such as gpt-3.5-turbo-instruct
 api_endpoint = "https://api.openai.com/v1"   # DO NOT append the `/completions` suffix
 api_key = "secret-api-key"
+```
 
+## Embeddings model
+
+```toml title="~/.tabby/config.toml"
 # Embedding model
 [model.embedding.http]
 kind = "openai/embedding"

--- a/website/docs/references/models-http-api/openai.md
+++ b/website/docs/references/models-http-api/openai.md
@@ -22,18 +22,7 @@ api_key = "secret-api-key"
 ## Completion model
 
 OpenAI has designated its `/v1/completions` API for code completion as legacy,
-and **OpenAI itself no longer supports it**. If you use it with OpenAI, you may encounter unpredictable problems.
-
-For other vendors that have implemented an OpenAI-compatible server, you could use the `openai/completion` kind.
-
-```toml title="~/.tabby/config.toml"
-# Completion model
-[model.completion.http]
-kind = "openai/completion"
-model_name = "gpt-3.5-turbo-instruct"   # Please make sure to use a completion model, such as gpt-3.5-turbo-instruct
-api_endpoint = "https://api.openai.com/v1"   # DO NOT append the `/completions` suffix
-api_key = "secret-api-key"
-```
+and using OpenAI models for completion is no longer supported.
 
 ## Embeddings model
 


### PR DESCRIPTION
![CleanShot 2025-01-16 at 00 03 26@2x](https://github.com/user-attachments/assets/72587f7f-c660-4aa3-9d04-5995a2e0bf1a)
