### PR TITLE
fix(chat-panel): update typedef of filepath.

### DIFF
--- a/clients/tabby-chat-panel/package.json
+++ b/clients/tabby-chat-panel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabby-chat-panel",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "keywords": [],
   "sideEffects": false,
   "exports": {

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -107,7 +107,7 @@ export interface ErrorMessage {
 /**
  * Represents a filepath to identify a file.
  */
-export type Filepath = FilepathInGitRepository | FilepathUri
+export type Filepath = FilepathInGitRepository | FilepathUri | FilepathAbsoluteUri
 
 /**
  * This is used for files in a Git repository, and should be used in priority.
@@ -135,10 +135,29 @@ export interface FilepathInGitRepository {
 }
 
 /**
- * This is used for files not in a Git repository.
+ * This is used for files in the workspace, but not in a Git repository.
  */
 export interface FilepathUri {
   kind: 'uri'
+
+  /**
+   * A string that can be parsed as a URI, used to identify the directory in the client.
+   * The scheme of the URI could be 'file' or some other protocol to access the directory.
+   */
+  baseDir: string
+
+  /**
+   * A string that is a relative path to `baseDir`.
+   */
+  filepath: string
+}
+
+/**
+ * This is used for files not in a Git repository and not in the workspace.
+ * Also used for untitled files not saved.
+ */
+export interface FilepathAbsoluteUri {
+  kind: 'absolute-uri'
 
   /**
    * A string that can be parsed as a URI, used to identify the file in the client.

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -9,7 +9,7 @@ import {
   MessageAttachmentClientCode
 } from '@/lib/gql/generates/graphql'
 import { AttachmentCodeItem, AttachmentDocItem, FileContext } from '@/lib/types'
-import { cn } from '@/lib/utils'
+import { cn, getFilepathFromContext } from '@/lib/utils'
 import {
   HoverCard,
   HoverCardContent,
@@ -21,7 +21,6 @@ import './style.css'
 
 import {
   FileLocation,
-  Filepath,
   LookupSymbolHint,
   SymbolInfo
 } from 'tabby-chat-panel/index'
@@ -175,26 +174,8 @@ export function MessageMarkdown({
     setSymbolLocationMap(map => new Map(map.set(keyword, undefined)))
     const hints: LookupSymbolHint[] = []
     if (activeSelection && activeSelection?.range) {
-      // FIXME(@icycodes): this is intended to convert the filepath to Filepath type
-      // We should remove this after FileContext.filepath use type Filepath instead of string
-      let filepath: Filepath
-      if (
-        activeSelection.git_url.length > 1 &&
-        !activeSelection.filepath.includes(':')
-      ) {
-        filepath = {
-          kind: 'git',
-          filepath: activeSelection.filepath,
-          gitUrl: activeSelection.git_url
-        }
-      } else {
-        filepath = {
-          kind: 'uri',
-          uri: activeSelection.filepath
-        }
-      }
       hints.push({
-        filepath,
+        filepath: getFilepathFromContext(activeSelection),
         location: {
           start: activeSelection.range.start,
           end: activeSelection.range.end

--- a/ee/tabby-ui/lib/utils/index.ts
+++ b/ee/tabby-ui/lib/utils/index.ts
@@ -195,28 +195,6 @@ export function getPromptForChatCommand(command: ChatCommand) {
   }
 }
 
-// FIXME: improve this conversion
-export function fromChatPanelFilepath(filepath: Filepath) {
-  if (filepath.kind === 'absolute-uri') {
-    return {
-      filepath: filepath.uri,
-      git_url: ''
-    }
-  }
-
-  if (filepath.kind === 'uri') {
-    return {
-      filepath: filepath.filepath,
-      git_url: ''
-    }
-  }
-
-  return {
-    filepath: filepath.filepath,
-    git_url: filepath.gitUrl
-  }
-}
-
 export function convertEditorContext(
   editorContext: EditorContext
 ): FileContext {
@@ -237,11 +215,33 @@ export function convertEditorContext(
     }
   }
 
+  // FIXME: improve this conversion
+  const convertFilepath = (filepath: Filepath) => {
+    if (filepath.kind === 'absolute-uri') {
+      return {
+        filepath: filepath.uri,
+        git_url: ''
+      }
+    }
+
+    if (filepath.kind === 'uri') {
+      return {
+        filepath: filepath.filepath,
+        git_url: ''
+      }
+    }
+
+    return {
+      filepath: filepath.filepath,
+      git_url: filepath.gitUrl
+    }
+  }
+
   return {
     kind: 'file',
     content: editorContext.content,
     range: convertRange(editorContext.range),
-    ...fromChatPanelFilepath(editorContext.filepath)
+    ...convertFilepath(editorContext.filepath)
   }
 }
 

--- a/ee/tabby-ui/lib/utils/index.ts
+++ b/ee/tabby-ui/lib/utils/index.ts
@@ -195,6 +195,28 @@ export function getPromptForChatCommand(command: ChatCommand) {
   }
 }
 
+// FIXME: improve this conversion
+export function fromChatPanelFilepath(filepath: Filepath) {
+  if (filepath.kind === 'absolute-uri') {
+    return {
+      filepath: filepath.uri,
+      git_url: ''
+    }
+  }
+
+  if (filepath.kind === 'uri') {
+    return {
+      filepath: filepath.filepath,
+      git_url: ''
+    }
+  }
+
+  return {
+    filepath: filepath.filepath,
+    git_url: filepath.gitUrl
+  }
+}
+
 export function convertEditorContext(
   editorContext: EditorContext
 ): FileContext {
@@ -215,28 +237,15 @@ export function convertEditorContext(
     }
   }
 
-  const convertFilepath = (filepath: Filepath) => {
-    if (filepath.kind === 'uri') {
-      return {
-        filepath: filepath.uri,
-        git_url: ''
-      }
-    }
-
-    return {
-      filepath: filepath.filepath,
-      git_url: filepath.gitUrl
-    }
-  }
-
   return {
     kind: 'file',
     content: editorContext.content,
     range: convertRange(editorContext.range),
-    ...convertFilepath(editorContext.filepath)
+    ...fromChatPanelFilepath(editorContext.filepath)
   }
 }
 
+// FIXME: improve this conversion
 export function getFilepathFromContext(context: FileContext): Filepath {
   if (context.git_url.length > 1 && !context.filepath.includes(':')) {
     return {
@@ -246,7 +255,7 @@ export function getFilepathFromContext(context: FileContext): Filepath {
     }
   } else {
     return {
-      kind: 'uri',
+      kind: 'absolute-uri',
       uri: context.filepath
     }
   }


### PR DESCRIPTION
This PR helps to resolve the issue of when the workspace is not a git repository, the file path is displayed as an absolute uri. It would be better to show a relative path to the workspace instead.

![Screenshot from 2025-01-20 10-13-01](https://github.com/user-attachments/assets/bf7bf9b0-4a27-4e57-b02d-deb7d3e57ee8)
