### PR TITLE
feat(graphQL): add is_sso_user and forbid update name, password for s…

### DIFF
--- a/ee/tabby-db/src/users.rs
+++ b/ee/tabby-db/src/users.rs
@@ -16,6 +16,9 @@ pub struct UserDAO {
     pub id: i64,
     pub email: String,
     pub name: Option<String>,
+
+    // when the user is created with password, this field is set and will never be changed to None
+    // when the user is created with SSO, this field is None and will never be set
     pub password_encrypted: Option<String>,
     pub is_admin: bool,
 

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -965,6 +965,7 @@ type UserSecured implements User {
   active: Boolean!
   authToken: String!
   isPasswordSet: Boolean!
+  isSsoUser: Boolean!
 }
 
 type WebContextSource implements ContextSourceId & ContextSource {

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -296,6 +296,7 @@ interface User {
   isAdmin: Boolean!
   isOwner: Boolean!
   active: Boolean!
+  isSsoUser: Boolean!
 }
 
 """

--- a/ee/tabby-schema/src/schema/auth.rs
+++ b/ee/tabby-schema/src/schema/auth.rs
@@ -198,6 +198,11 @@ pub struct UserSecured {
     pub auth_token: String,
     pub is_password_set: bool,
 
+    // is_sso_user is used to indicate if the user is created by SSO
+    // and should not be able to change Name and Password
+    // e.g. LDAP, OAuth users
+    pub is_sso_user: bool,
+
     #[graphql(skip)]
     pub policy: AccessPolicy,
 }

--- a/ee/tabby-schema/src/schema/interface.rs
+++ b/ee/tabby-schema/src/schema/interface.rs
@@ -14,6 +14,7 @@ pub struct User {
     pub is_admin: bool,
     pub is_owner: bool,
     pub active: bool,
+    pub is_sso_user: bool,
 }
 
 impl relay::NodeType for UserValue {

--- a/ee/tabby-webserver/src/service/auth.rs
+++ b/ee/tabby-webserver/src/service/auth.rs
@@ -161,6 +161,11 @@ impl AuthenticationService for AuthenticationServiceImpl {
     }
 
     async fn generate_reset_password_url(&self, id: &ID) -> Result<String> {
+        let user = self.get_user(id).await?;
+        if user.is_sso_user {
+            bail!("Cannot generate reset password url for SSO users");
+        }
+
         let external_url = self.setting.read_network_setting().await?.external_url;
         let id = id.as_rowid()?;
         let user = self.db.get_user(id).await?.context("User doesn't exits")?;
@@ -178,6 +183,10 @@ impl AuthenticationService for AuthenticationServiceImpl {
         let Some(user @ UserSecured { active: true, .. }) = user else {
             return Ok(None);
         };
+
+        if user.is_sso_user {
+            bail!("Cannot request password reset for SSO users");
+        }
 
         let id = user.id.as_rowid()?;
 
@@ -200,6 +209,11 @@ impl AuthenticationService for AuthenticationServiceImpl {
         let password_encrypted = password_hash(password).map_err(|_| anyhow!("Unknown error"))?;
 
         let user_id = self.db.verify_password_reset(code).await?;
+        let user = self.get_user(&user_id.as_id()).await?;
+        if user.is_sso_user {
+            bail!("Password cannot be reset for SSO users");
+        }
+
         let old_pass_encrypted = self
             .db
             .get_user(user_id)
@@ -225,6 +239,11 @@ impl AuthenticationService for AuthenticationServiceImpl {
     ) -> Result<()> {
         if is_demo_mode() {
             bail!("Changing passwords is disabled in demo mode");
+        }
+
+        let user = self.get_user(id).await?;
+        if user.is_sso_user {
+            bail!("Password cannot be changed for SSO users");
         }
 
         let user = self
@@ -280,6 +299,12 @@ impl AuthenticationService for AuthenticationServiceImpl {
         if is_demo_mode() {
             bail!("Changing profile data is disabled in demo mode");
         }
+
+        let user = self.get_user(id).await?;
+        if user.is_sso_user {
+            bail!("Name cannot be changed for SSO users");
+        }
+
         let id = id.as_rowid()?;
         self.db.update_user_name(id, name).await?;
         Ok(())

--- a/ee/tabby-webserver/src/service/mod.rs
+++ b/ee/tabby-webserver/src/service/mod.rs
@@ -463,6 +463,11 @@ impl UserSecuredExt for tabby_schema::auth::UserSecured {
             created_at: val.created_at,
             active: val.active,
             is_password_set: val.password_encrypted.is_some(),
+
+            // when a user created by registration, password_encrypted is set
+            // when a user created by SSO, password_encrypted is not set
+            // so, we can determine if a user is SSO user by checking if password_encrypted is set
+            is_sso_user: val.password_encrypted.is_none(),
         }
     }
 }


### PR DESCRIPTION
…so users

Tests:

- admin me
![CleanShot 2025-01-20 at 16 38 27@2x](https://github.com/user-attachments/assets/316e7744-b57e-4b46-a18b-fa0828c9f4f2)

- ldap me
![CleanShot 2025-01-20 at 16 38 52@2x](https://github.com/user-attachments/assets/b1dec757-a886-4daa-aca0-410531eb7758)

- ldap update name 
![CleanShot 2025-01-20 at 16 40 37@2x](https://github.com/user-attachments/assets/3ecf8957-dc6a-41d2-b24d-a536bab497bb)

- ldap update password
![CleanShot 2025-01-20 at 16 50 18@2x](https://github.com/user-attachments/assets/eef1297b-8cb4-4498-a828-5ff22cf3ad16)

- request password reset
![CleanShot 2025-01-20 at 16 50 34@2x](https://github.com/user-attachments/assets/fa029135-0e07-4ee8-b08d-aab9caabbcaa)

- admin generate password reset url
![CleanShot 2025-01-20 at 16 52 00@2x](https://github.com/user-attachments/assets/58306589-a3c3-41d9-bc90-19734d28537f)
