### PR TITLE
chore(ui): optimize display where the question length is excessive

### DIFF
--- a/ee/tabby-ui/app/search/components/user-message-section.tsx
+++ b/ee/tabby-ui/app/search/components/user-message-section.tsx
@@ -19,7 +19,8 @@ export function UserMessageSection({
   const { contextInfo, fetchingContextInfo } = useContext(SearchContext)
   const { supportsOnApplyInEditorV2 } = useContext(ChatContext)
   const contentLen = message.content?.length
-  const fontSizeClassname = contentLen > 400 ? 'text-base' : contentLen > 200 ? 'text-lg' : 'text-xl'
+  const fontSizeClassname =
+    contentLen > 400 ? 'text-base' : contentLen > 200 ? 'text-lg' : 'text-xl'
 
   return (
     <div className={cn('font-semibold', className)} {...props}>

--- a/ee/tabby-ui/app/search/components/user-message-section.tsx
+++ b/ee/tabby-ui/app/search/components/user-message-section.tsx
@@ -18,6 +18,9 @@ export function UserMessageSection({
 }: QuestionBlockProps) {
   const { contextInfo, fetchingContextInfo } = useContext(SearchContext)
   const { supportsOnApplyInEditorV2 } = useContext(ChatContext)
+  const contentLen = message.content?.length
+  const fontSizeClassname = contentLen > 400 ? 'text-base' : contentLen > 200 ? 'text-lg' : 'text-xl'
+
   return (
     <div className={cn('font-semibold', className)} {...props}>
       <MessageMarkdown
@@ -25,7 +28,7 @@ export function UserMessageSection({
         contextInfo={contextInfo}
         supportsOnApplyInEditorV2={supportsOnApplyInEditorV2}
         fetchingContextInfo={fetchingContextInfo}
-        className="text-xl prose-p:mb-2 prose-p:mt-0"
+        className={cn('prose-p:mb-2 prose-p:mt-0', fontSizeClassname)}
         headline
         canWrapLongLines
       />


### PR DESCRIPTION
## Preview
### string length exceeds 400
#### Before
<img width="961" alt="image" src="https://github.com/user-attachments/assets/0c462c83-5182-4ae0-bed2-a07625a5b284" />

#### After
<img width="974" alt="image" src="https://github.com/user-attachments/assets/ac395ce9-c7a9-41c1-9de7-2d27f7b1d477" />

### string length exceeds 200
### Before
<img width="945" alt="image" src="https://github.com/user-attachments/assets/16b45a7f-c708-4550-a4c1-fc300dfbcb92" />

### After
<img width="936" alt="image" src="https://github.com/user-attachments/assets/07f33750-c439-4443-9254-99b0a67a4147" />

