### PR TITLE
fix(vscode): do not set default context to null when active editor is…

### DIFF
--- a/clients/vscode/src/chat/webview.ts
+++ b/clients/vscode/src/chat/webview.ts
@@ -739,6 +739,11 @@ export class ChatWebview {
   }
 
   private async notifyActiveEditorSelectionChange(editor: TextEditor | undefined) {
+    if (editor && editor.document.uri.scheme === "output") {
+      // do not update when the active editor is an output channel
+      return;
+    }
+
     if (!editor || !isValidForSyncActiveEditorSelection(editor)) {
       await this.client?.updateActiveSelection(null);
       return;


### PR DESCRIPTION
… output panel.