### PR TITLE
feat(chat-panel): exchange methods during createServer and createClient by request built-in method in Thread

### DIFF
--- a/clients/tabby-chat-panel/package.json
+++ b/clients/tabby-chat-panel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabby-chat-panel",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "keywords": [],
   "sideEffects": false,
   "exports": {

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -362,8 +362,8 @@ export interface ClientApi extends ClientApiMethods {
   hasCapability: (method: keyof ClientApiMethods) => Promise<boolean>
 }
 
-export function createClient(target: HTMLIFrameElement, api: ClientApiMethods): ServerApi {
-  return createThreadFromIframe(target, {
+export async function createClient(target: HTMLIFrameElement, api: ClientApiMethods): Promise<ServerApi> {
+  const thread = createThreadFromIframe(target, {
     expose: {
       refresh: api.refresh,
       onApplyInEditor: api.onApplyInEditor,
@@ -382,10 +382,18 @@ export function createClient(target: HTMLIFrameElement, api: ClientApiMethods): 
       readFileContent: api.readFileContent,
     },
   })
+
+  const serverMethods = await thread._requestMethods() as (keyof ServerApi)[]
+  const serverApi = {} as ServerApi
+  for (const method of serverMethods) {
+    serverApi[method] = thread[method]
+  }
+
+  return serverApi
 }
 
-export function createServer(api: ServerApi): ClientApi {
-  return createThreadFromInsideIframe({
+export async function createServer(api: ServerApi): Promise<ClientApi> {
+  const thread = createThreadFromInsideIframe({
     expose: {
       init: api.init,
       executeCommand: api.executeCommand,
@@ -396,4 +404,11 @@ export function createServer(api: ServerApi): ClientApi {
       updateActiveSelection: api.updateActiveSelection,
     },
   })
+  const clientMethods = await thread._requestMethods() as (keyof ClientApi)[]
+  const clientApi = {} as ClientApi
+  for (const method of clientMethods) {
+    clientApi[method] = thread[method]
+  }
+
+  return clientApi
 }

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -409,6 +409,8 @@ export async function createServer(api: ServerApi): Promise<ClientApi> {
   for (const method of clientMethods) {
     clientApi[method] = thread[method]
   }
+  // hasCapability is not exposed from client
+  clientApi.hasCapability = thread.hasCapability
 
   return clientApi
 }

--- a/clients/tabby-chat-panel/src/react.ts
+++ b/clients/tabby-chat-panel/src/react.ts
@@ -11,7 +11,7 @@ function useClient(iframeRef: RefObject<HTMLIFrameElement>, api: ClientApiMethod
   useEffect(() => {
     if (iframeRef.current && !isCreated) {
       isCreated = true
-      setClient(createClient(iframeRef.current!, api))
+      createClient(iframeRef.current!, api).then(setClient)
     }
   }, [iframeRef.current])
 
@@ -26,7 +26,7 @@ function useServer(api: ServerApi) {
     const isInIframe = window.self !== window.top
     if (isInIframe && !isCreated) {
       isCreated = true
-      setServer(createServer(api))
+      createServer(api).then(setServer)
     }
   }, [])
 

--- a/clients/tabby-threads/source/types.ts
+++ b/clients/tabby-threads/source/types.ts
@@ -3,7 +3,7 @@ import type {
   RETAIN_METHOD,
   ENCODE_METHOD,
   RETAINED_BY,
-} from './constants.ts';
+} from "./constants.ts";
 
 /**
  * A thread represents a target JavaScript environment that exposes a set
@@ -18,6 +18,12 @@ export type Thread<Target> = {
       ? Target[K]
       : never
     : never;
+} & {
+  
+  /**
+   * A method that used to get all exposed methods of the opposite thread.
+   */
+  _requestMethods(): Promise<string[]>;
 };
 
 /**


### PR DESCRIPTION
The createServer and createClient of chatpanel will exchange methods between both parties at the beginning, so the methods that are not supported will return undefined