### PR TITLE
fix(vscode): update the default config for endpoint.

### DIFF
--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -298,7 +298,7 @@
         "properties": {
           "tabby.endpoint": {
             "type": "string",
-            "default": "",
+            "default": "http://localhost:8080",
             "pattern": "(^$)|(^https?:\\/\\/\\S+$)",
             "patternErrorMessage": "Please enter a valid HTTP or HTTPS URL.",
             "markdownDescription": "Please use the command [Connect to Server](command:tabby.connectToServer) to specify the endpoint of the Tabby server."


### PR DESCRIPTION
Update default configuration for endpoint:  
**From:** `""` (Empty string, which uses the configuration from the agent config file)  
**To:** `"http://localhost:8080"` (Endpoint and token will be saved in VSCode settings)

This change improves the user experience for users who start the Tabby server at `localhost:8080`, then launch VSCode and install the Tabby extension. The status bar will prompt the user to update the token.

**Before the change:**  `Update token` opens the agent config file.
**After the change:**   `Update token` shows an input prompt for the token, which is then saved in VSCode settings.
