### PR TITLE
feat(tabby-webserver): add readRepositoryRelatedQuestions query and related functionality

### DIFF
--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -798,7 +798,7 @@ type Query {
   userGroups: [UserGroup!]!
   sourceIdAccessPolicies(sourceId: String!): SourceIdAccessPolicy!
   testModelConnection(backend: ModelHealthBackend!): ModelBackendHealthInfo!
-  generateRepoRelateQuestion(sourceId: String!): [String!]!
+  readRepositoryRelatedQuestions(sourceId: String!): [String!]!
 }
 
 type RefreshTokenResponse {

--- a/ee/tabby-schema/graphql/schema.graphql
+++ b/ee/tabby-schema/graphql/schema.graphql
@@ -798,6 +798,7 @@ type Query {
   userGroups: [UserGroup!]!
   sourceIdAccessPolicies(sourceId: String!): SourceIdAccessPolicy!
   testModelConnection(backend: ModelHealthBackend!): ModelBackendHealthInfo!
+  generateRepoRelateQuestion(sourceId: String!): [String!]!
 }
 
 type RefreshTokenResponse {

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -852,7 +852,7 @@ impl Query {
                 source_id,
             )
             .await
-            .map_err(|e| CoreError::NotFound(&format!("Not found this repository: {:?}", e)))
+            .map_err(|e| CoreError::NotFound("Repository not found"))
     }
 }
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -852,7 +852,7 @@ impl Query {
                 source_id,
             )
             .await
-            .map_err(|e| CoreError::NotFound("Repository not found"))
+            .map_err(|e| e.into())
     }
 }
 

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -837,7 +837,7 @@ impl Query {
         }
     }
 
-    async fn generate_repo_relate_question(
+    async fn read_repository_related_questions(
         ctx: &Context,
         source_id: String,
     ) -> Result<Vec<String>, CoreError> {

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -844,7 +844,7 @@ impl Query {
         let user = check_user(ctx).await?;
         ctx.locator
             .repository()
-            .generate_repo_questions(
+            .read_repository_related_questions(
                 ctx.locator
                     .chat()
                     .ok_or(CoreError::NotFound("The Chat didn't initialize yet"))?,

--- a/ee/tabby-schema/src/schema/mod.rs
+++ b/ee/tabby-schema/src/schema/mod.rs
@@ -836,6 +836,24 @@ impl Query {
             }
         }
     }
+
+    async fn generate_repo_relate_question(
+        ctx: &Context,
+        source_id: String,
+    ) -> Result<Vec<String>, CoreError> {
+        let user = check_user(ctx).await?;
+        ctx.locator
+            .repository()
+            .generate_repo_questions(
+                ctx.locator
+                    .chat()
+                    .ok_or(CoreError::NotFound("The Chat didn't initialize yet"))?,
+                &user.policy,
+                source_id,
+            )
+            .await
+            .map_err(|e| CoreError::NotFound(&format!("Not found this repository: {:?}", e)))
+    }
 }
 
 #[derive(GraphQLObject)]

--- a/ee/tabby-schema/src/schema/repository/mod.rs
+++ b/ee/tabby-schema/src/schema/repository/mod.rs
@@ -299,5 +299,5 @@ pub trait RepositoryService: Send + Sync {
         chat: Arc<dyn ChatCompletionStream>,
         policy: &AccessPolicy,
         source_id: String,
-    ) -> Result<Vec<String>, anyhow::Error>;
+    ) -> Result<Vec<String>>;
 }

--- a/ee/tabby-schema/src/schema/repository/mod.rs
+++ b/ee/tabby-schema/src/schema/repository/mod.rs
@@ -294,7 +294,7 @@ pub trait RepositoryService: Send + Sync {
     fn third_party(&self) -> Arc<dyn ThirdPartyRepositoryService>;
 
     async fn list_all_code_repository(&self) -> Result<Vec<CodeRepository>>;
-    async fn generate_repo_questions(
+    async fn read_repository_related_questions(
         &self,
         chat: Arc<dyn ChatCompletionStream>,
         policy: &AccessPolicy,

--- a/ee/tabby-schema/src/schema/repository/mod.rs
+++ b/ee/tabby-schema/src/schema/repository/mod.rs
@@ -1,6 +1,7 @@
 mod types;
 use std::{path::PathBuf, sync::Arc};
 
+use tabby_inference::ChatCompletionStream;
 pub use types::*;
 
 mod git;
@@ -293,4 +294,10 @@ pub trait RepositoryService: Send + Sync {
     fn third_party(&self) -> Arc<dyn ThirdPartyRepositoryService>;
 
     async fn list_all_code_repository(&self) -> Result<Vec<CodeRepository>>;
+    async fn generate_repo_questions(
+        &self,
+        chat: Arc<dyn ChatCompletionStream>,
+        policy: &AccessPolicy,
+        source_id: String,
+    ) -> Result<Vec<String>, anyhow::Error>;
 }

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -1,4 +1,4 @@
-mod prompt_tools;
+pub mod prompt_tools;
 
 use std::{
     collections::HashMap,
@@ -36,7 +36,7 @@ use tabby_schema::{
     auth::AuthenticationService,
     context::{ContextInfoHelper, ContextService},
     policy::AccessPolicy,
-    repository::{Repository, RepositoryService},
+    repository::{Repository, RepositoryKind, RepositoryService},
     thread::{
         self, CodeQueryInput, CodeSearchParamsOverrideInput, DocQueryInput, MessageAttachment,
         MessageAttachmentCodeInput, MessageAttachmentDoc, MessageAttachmentInput,

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -1,4 +1,4 @@
-pub mod prompt_tools;
+mod prompt_tools;
 
 use std::{
     collections::HashMap,

--- a/ee/tabby-webserver/src/service/answer/prompt_tools.rs
+++ b/ee/tabby-webserver/src/service/answer/prompt_tools.rs
@@ -5,7 +5,7 @@ use tabby_inference::ChatCompletionStream;
 use tabby_schema::thread::ThreadAssistantMessageReadingCode;
 use tracing::debug;
 
-use crate::service::common_prompt_tools::{detect_content, request_llm, transform_line_items};
+use crate::service::utils::prompt::{detect_content, request_llm, transform_line_items};
 
 /// Given context and a question, generate related questions.
 pub async fn pipeline_related_questions(

--- a/ee/tabby-webserver/src/service/answer/prompt_tools.rs
+++ b/ee/tabby-webserver/src/service/answer/prompt_tools.rs
@@ -6,10 +6,10 @@ use async_openai_alt::types::{
     CreateChatCompletionRequestArgs,
 };
 use tabby_inference::ChatCompletionStream;
-use tabby_schema::thread::ThreadAssistantMessageReadingCode;
+use tabby_schema::{repository::FileEntrySearchResult, thread::ThreadAssistantMessageReadingCode};
 use tracing::debug;
 
-async fn request_llm(chat: Arc<dyn ChatCompletionStream>, prompt: &str) -> Result<String> {
+pub async fn request_llm(chat: Arc<dyn ChatCompletionStream>, prompt: &str) -> Result<String> {
     let request = CreateChatCompletionRequestArgs::default()
         .messages(vec![ChatCompletionRequestMessage::User(
             ChatCompletionRequestUserMessageArgs::default()
@@ -68,6 +68,39 @@ Remember, based on the original question and related contexts, suggest three suc
 
 {question}
 "#
+    );
+
+    let content = request_llm(chat, &prompt).await?;
+    Ok(transform_line_items(&content))
+}
+
+// this is use to input a files tree, and generate some related question relate to repo dirs
+pub async fn pipeline_related_questions_with_repo_dirs(
+    chat: Arc<dyn ChatCompletionStream>,
+    files: Vec<FileEntrySearchResult>,
+) -> Result<Vec<String>> {
+    // Convert files into a formatted string for the prompt
+    let files_content = files
+        .iter()
+        .map(|f| format!("Type: {}, Path: {}", f.r#type, f.path))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let prompt = format!(
+        r#"You are a helpful assistant that helps the user to ask related questions about a codebase structure.
+Based on the following file structure, please generate 3 relevant questions that would help understand the codebase better.
+Each question should be no longer than 20 words and be specific enough to stand alone.
+
+File structure:
+{}
+
+Please generate 3 questions about this codebase structure that would help understand:
+1. The organization and architecture
+2. The main functionality
+3. The potential implementation details
+
+Return only the questions, one per line."#,
+        files_content
     );
 
     let content = request_llm(chat, &prompt).await?;

--- a/ee/tabby-webserver/src/service/answer/prompt_tools.rs
+++ b/ee/tabby-webserver/src/service/answer/prompt_tools.rs
@@ -1,54 +1,11 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
-use async_openai_alt::types::{
-    ChatCompletionRequestMessage, ChatCompletionRequestUserMessageArgs,
-    CreateChatCompletionRequestArgs,
-};
+use anyhow::Result;
 use tabby_inference::ChatCompletionStream;
-use tabby_schema::{repository::FileEntrySearchResult, thread::ThreadAssistantMessageReadingCode};
+use tabby_schema::thread::ThreadAssistantMessageReadingCode;
 use tracing::debug;
 
-pub async fn request_llm(chat: Arc<dyn ChatCompletionStream>, prompt: &str) -> Result<String> {
-    let request = CreateChatCompletionRequestArgs::default()
-        .messages(vec![ChatCompletionRequestMessage::User(
-            ChatCompletionRequestUserMessageArgs::default()
-                .content(prompt)
-                .build()
-                .expect("Failed to create ChatCompletionRequestUserMessage"),
-        )])
-        .build()?;
-
-    let s = chat.chat(request).await?;
-    let content = s.choices[0]
-        .message
-        .content
-        .as_deref()
-        .ok_or_else(|| anyhow!("Failed to get content from chat completion"))?;
-
-    Ok(content.into())
-}
-
-/// Extracts items from the given content.
-/// Assumptions:
-/// 1. Each item is on a new line.
-/// 2. Items may start with a bullet point, which needs to be trimmed.
-fn transform_line_items(content: &str) -> Vec<String> {
-    content
-        .lines()
-        .map(trim_bullet)
-        .filter(|x| !x.is_empty())
-        .collect()
-}
-
-fn trim_bullet(s: &str) -> String {
-    let is_bullet = |c: char| c == '-' || c == '*' || c == '.' || c.is_numeric();
-    s.trim()
-        .trim_start_matches(is_bullet)
-        .trim_end_matches(is_bullet)
-        .trim()
-        .to_owned()
-}
+use crate::service::common_prompt_tools::{detect_content, request_llm, transform_line_items};
 
 /// Given context and a question, generate related questions.
 pub async fn pipeline_related_questions(
@@ -72,43 +29,6 @@ Remember, based on the original question and related contexts, suggest three suc
 
     let content = request_llm(chat, &prompt).await?;
     Ok(transform_line_items(&content))
-}
-
-// this is use to input a files tree, and generate some related question relate to repo dirs
-pub async fn pipeline_related_questions_with_repo_dirs(
-    chat: Arc<dyn ChatCompletionStream>,
-    files: Vec<FileEntrySearchResult>,
-) -> Result<Vec<String>> {
-    // Convert files into a formatted string for the prompt
-    let files_content = files
-        .iter()
-        .map(|f| format!("Type: {}, Path: {}", f.r#type, f.path))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let prompt = format!(
-        r#"You are a helpful assistant that helps the user to ask related questions about a codebase structure.
-Based on the following file structure, please generate 3 relevant questions that would help understand the codebase better.
-Each question should be no longer than 20 words and be specific enough to stand alone.
-
-File structure:
-{}
-
-Please generate 3 questions about this codebase structure that would help understand:
-1. The organization and architecture
-2. The main functionality
-3. The potential implementation details
-
-Return only the questions, one per line."#,
-        files_content
-    );
-
-    let content = request_llm(chat, &prompt).await?;
-    Ok(transform_line_items(&content))
-}
-
-fn detect_content(content: &str, check: &str) -> bool {
-    content.to_lowercase().contains(check)
 }
 
 /// Decide whether the question requires knowledge from codebase content.
@@ -141,32 +61,4 @@ Here's the original question:
     };
     debug!("decide_need_codebase_context: {:?} {:?}", content, context);
     Ok(context)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_trim_bullet() {
-        assert_eq!(trim_bullet("- Hello"), "Hello");
-        assert_eq!(trim_bullet("* World"), "World");
-        assert_eq!(trim_bullet("1. Test"), "Test");
-        assert_eq!(trim_bullet(".Dot"), "Dot");
-
-        assert_eq!(trim_bullet("- Hello -"), "Hello");
-        assert_eq!(trim_bullet("1. Test 1"), "Test");
-
-        assert_eq!(trim_bullet("--** Mixed"), "Mixed");
-
-        assert_eq!(trim_bullet("  - Hello  "), "Hello");
-
-        assert_eq!(trim_bullet("-"), "");
-        assert_eq!(trim_bullet(""), "");
-        assert_eq!(trim_bullet("   "), "");
-
-        assert_eq!(trim_bullet("Hello World"), "Hello World");
-
-        assert_eq!(trim_bullet("1. *Bold* and -italic-"), "*Bold* and -italic");
-    }
 }

--- a/ee/tabby-webserver/src/service/common_prompt_tools.rs
+++ b/ee/tabby-webserver/src/service/common_prompt_tools.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_openai_alt::types::{
+    ChatCompletionRequestMessage, ChatCompletionRequestUserMessageArgs,
+    CreateChatCompletionRequestArgs,
+};
+use tabby_inference::ChatCompletionStream;
+use tabby_schema::repository::FileEntrySearchResult;
+
+/// Sends a prompt to the provided ChatCompletionStream and returns the generated response as a String.
+pub async fn request_llm(chat: Arc<dyn ChatCompletionStream>, prompt: &str) -> Result<String> {
+    let request = CreateChatCompletionRequestArgs::default()
+        .messages(vec![ChatCompletionRequestMessage::User(
+            ChatCompletionRequestUserMessageArgs::default()
+                .content(prompt)
+                .build()
+                .expect("Failed to create ChatCompletionRequestUserMessage"),
+        )])
+        .build()?;
+
+    let s = chat.chat(request).await?;
+    let content = s.choices[0]
+        .message
+        .content
+        .as_deref()
+        .ok_or_else(|| anyhow!("Failed to get content from chat completion"))?;
+
+    Ok(content.into())
+}
+
+/// Extracts items from the given content.
+/// Assumptions:
+/// 1. Each item is on a new line.
+/// 2. Items may start with a bullet point, which needs to be trimmed.
+pub fn transform_line_items(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .map(trim_bullet)
+        .filter(|x| !x.is_empty())
+        .collect()
+}
+
+/// Trims leading and trailing bullet-like characters or digits from the provided string and returns the trimmed result.
+pub fn trim_bullet(s: &str) -> String {
+    let is_bullet = |c: char| c == '-' || c == '*' || c == '.' || c.is_numeric();
+    s.trim()
+        .trim_start_matches(is_bullet)
+        .trim_end_matches(is_bullet)
+        .trim()
+        .to_owned()
+}
+
+/// Checks if the `check` string is contained within `content` in a case-insensitive manner.
+pub fn detect_content(content: &str, check: &str) -> bool {
+    content.to_lowercase().contains(check)
+}
+
+// this is use to input a files tree, and generate some related question relate to repo dirs
+pub async fn pipeline_related_questions_with_repo_dirs(
+    chat: Arc<dyn ChatCompletionStream>,
+    files: Vec<FileEntrySearchResult>,
+) -> Result<Vec<String>> {
+    // Convert files into a formatted string for the prompt
+    let files_content = files
+        .iter()
+        .map(|f| format!("Type: {}, Path: {}", f.r#type, f.path))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let prompt = format!(
+        r#"You are a helpful assistant that helps the user to ask related questions about a codebase structure.
+Based on the following file structure, please generate 3 relevant questions that would help understand the codebase better.
+Each question should be no longer than 20 words and be specific enough to stand alone.
+
+File structure:
+{}
+
+Please generate 3 questions about this codebase structure that would help understand:
+1. The organization and architecture
+2. The main functionality
+3. The potential implementation details
+
+Return only the questions, one per line."#,
+        files_content
+    );
+
+    let content = request_llm(chat, &prompt).await?;
+    Ok(transform_line_items(&content))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trim_bullet() {
+        assert_eq!(trim_bullet("- Hello"), "Hello");
+        assert_eq!(trim_bullet("* World"), "World");
+        assert_eq!(trim_bullet("1. Test"), "Test");
+        assert_eq!(trim_bullet(".Dot"), "Dot");
+
+        assert_eq!(trim_bullet("- Hello -"), "Hello");
+        assert_eq!(trim_bullet("1. Test 1"), "Test");
+
+        assert_eq!(trim_bullet("--** Mixed"), "Mixed");
+
+        assert_eq!(trim_bullet("  - Hello  "), "Hello");
+
+        assert_eq!(trim_bullet("-"), "");
+        assert_eq!(trim_bullet(""), "");
+        assert_eq!(trim_bullet("   "), "");
+
+        assert_eq!(trim_bullet("Hello World"), "Hello World");
+
+        assert_eq!(trim_bullet("1. *Bold* and -italic-"), "*Bold* and -italic");
+    }
+}

--- a/ee/tabby-webserver/src/service/mod.rs
+++ b/ee/tabby-webserver/src/service/mod.rs
@@ -3,7 +3,6 @@ mod analytic;
 pub mod answer;
 mod auth;
 pub mod background_job;
-pub mod common_prompt_tools;
 pub mod context;
 mod email;
 pub mod event_logger;
@@ -17,6 +16,7 @@ mod setting;
 mod thread;
 mod user_event;
 mod user_group;
+pub mod utils;
 pub mod web_documents;
 
 use std::sync::Arc;

--- a/ee/tabby-webserver/src/service/mod.rs
+++ b/ee/tabby-webserver/src/service/mod.rs
@@ -3,6 +3,7 @@ mod analytic;
 pub mod answer;
 mod auth;
 pub mod background_job;
+pub mod common_prompt_tools;
 pub mod context;
 mod email;
 pub mod event_logger;

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -53,7 +53,7 @@ pub fn create(
 
 #[async_trait]
 impl RepositoryService for RepositoryServiceImpl {
-    async fn generate_repo_questions(
+    async fn read_repository_related_questions(
         &self,
         chat: Arc<dyn ChatCompletionStream>,
         policy: &AccessPolicy,

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -4,6 +4,7 @@ mod third_party;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use cached::{Cached, TimedCache};
 use futures::StreamExt;
 use juniper::ID;
 use tabby_common::config::{
@@ -21,15 +22,18 @@ use tabby_schema::{
     },
     Result,
 };
+use tokio::sync::Mutex;
 
-use super::answer::prompt_tools::pipeline_related_questions_with_repo_dirs;
+use super::common_prompt_tools::pipeline_related_questions_with_repo_dirs;
 
 struct RepositoryServiceImpl {
     git: Arc<dyn GitRepositoryService>,
     third_party: Arc<dyn ThirdPartyRepositoryService>,
     config: Vec<RepositoryConfig>,
+    relavent_dirs_questions_cache: Mutex<TimedCache<String, Vec<String>>>,
 }
 
+static RELAVENT_QUESTION_CACHE_LIFESPAN: u64 = 60 * 30; // 30 minutes
 pub fn create(
     db: DbConn,
     integration: Arc<dyn IntegrationService>,
@@ -41,6 +45,9 @@ pub fn create(
         config: Config::load()
             .map(|config| config.repositories)
             .unwrap_or_default(),
+        relavent_dirs_questions_cache: Mutex::new(TimedCache::with_lifespan(
+            RELAVENT_QUESTION_CACHE_LIFESPAN,
+        )),
     })
 }
 
@@ -51,18 +58,38 @@ impl RepositoryService for RepositoryServiceImpl {
         chat: Arc<dyn ChatCompletionStream>,
         policy: &AccessPolicy,
         source_id: String,
-    ) -> Result<Vec<String>, anyhow::Error> {
+    ) -> Result<Vec<String>> {
+        if source_id.is_empty() {
+            return Err(anyhow::anyhow!("Invalid source_id format"))?;
+        }
+
+        let mut cache = self.relavent_dirs_questions_cache.lock().await;
+        if let Some(questions) = cache.cache_get(&source_id) {
+            return Ok(questions.clone());
+        }
+
         let repositories = self.repository_list(Some(policy)).await?;
         let repo = repositories
             .iter()
             .find(|r| r.source_id == source_id)
-            .ok_or_else(|| anyhow::anyhow!("Repository not found"))?;
+            .ok_or_else(|| anyhow::anyhow!("Repository not found: {}", source_id))?;
 
-        let files = self
+        let files = match self
             .list_files(policy, &repo.kind, &repo.id, None, Some(300))
-            .await?;
+            .await
+        {
+            Ok(files) => files,
+            Err(_) => {
+                return Err(anyhow::anyhow!(
+                    "Repository exists but not accessible: {}",
+                    source_id
+                ))?
+            }
+        };
 
-        pipeline_related_questions_with_repo_dirs(chat, files).await
+        let questions = pipeline_related_questions_with_repo_dirs(chat, files).await?;
+        cache.cache_set(source_id, questions.clone());
+        Ok(questions)
     }
 
     async fn list_all_code_repository(&self) -> Result<Vec<CodeRepository>> {

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -1,4 +1,5 @@
 mod git;
+mod prompt_tools;
 mod third_party;
 
 use std::sync::Arc;
@@ -7,6 +8,7 @@ use async_trait::async_trait;
 use cached::{Cached, TimedCache};
 use futures::StreamExt;
 use juniper::ID;
+use prompt_tools::pipeline_related_questions_with_repo_dirs;
 use tabby_common::config::{
     config_id_to_index, config_index_to_id, CodeRepository, Config, RepositoryConfig,
 };
@@ -23,8 +25,6 @@ use tabby_schema::{
     Result,
 };
 use tokio::sync::Mutex;
-
-use super::common_prompt_tools::pipeline_related_questions_with_repo_dirs;
 
 struct RepositoryServiceImpl {
     git: Arc<dyn GitRepositoryService>,

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -33,7 +33,7 @@ struct RepositoryServiceImpl {
     relavent_dirs_questions_cache: Mutex<TimedCache<String, Vec<String>>>,
 }
 
-static RELAVENT_QUESTION_CACHE_LIFESPAN: u64 = 60 * 30; // 30 minutes
+static RELEVANT_QUESTION_CACHE_LIFESPAN: u64 = 60 * 30; // 30 minutes
 pub fn create(
     db: DbConn,
     integration: Arc<dyn IntegrationService>,
@@ -46,7 +46,7 @@ pub fn create(
             .map(|config| config.repositories)
             .unwrap_or_default(),
         relavent_dirs_questions_cache: Mutex::new(TimedCache::with_lifespan(
-            RELAVENT_QUESTION_CACHE_LIFESPAN,
+            RELEVANT_QUESTION_CACHE_LIFESPAN,
         )),
     })
 }
@@ -72,8 +72,12 @@ impl RepositoryService for RepositoryServiceImpl {
         let repo = repositories
             .iter()
             .find(|r| r.source_id == source_id)
-            .ok_or_else(|| anyhow::anyhow!("Repository not found: {}", source_id))?;
-
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Repository not found or 'sourceId' is invalid: {}",
+                    source_id
+                )
+            })?;
         let files = match self
             .list_files(policy, &repo.kind, &repo.id, None, Some(300))
             .await

--- a/ee/tabby-webserver/src/service/repository/prompt_tools.rs
+++ b/ee/tabby-webserver/src/service/repository/prompt_tools.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use std::sync::Arc;
+use tabby_inference::ChatCompletionStream;
+use tabby_schema::repository::FileEntrySearchResult;
+
+use crate::service::utils::prompt::{request_llm, transform_line_items};
+
+// this is use to input a files tree, and generate some related question relate to repo dirs
+pub async fn pipeline_related_questions_with_repo_dirs(
+    chat: Arc<dyn ChatCompletionStream>,
+    files: Vec<FileEntrySearchResult>,
+) -> Result<Vec<String>> {
+    // Convert files into a formatted string for the prompt
+    let files_content = files
+        .iter()
+        .map(|f| format!("Type: {}, Path: {}", f.r#type, f.path))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let prompt = format!(
+        r#"You are a helpful assistant that helps the user to ask related questions about a codebase structure.
+Based on the following file structure, please generate 3 relevant questions that would help understand the codebase better.
+Each question should be no longer than 20 words and be specific enough to stand alone.
+
+File structure:
+{}
+
+Please generate 3 questions about this codebase structure that would help understand:
+1. The organization and architecture
+2. The main functionality
+3. The potential implementation details
+
+Return only the questions, one per line."#,
+        files_content
+    );
+
+    let content = request_llm(chat, &prompt).await?;
+    Ok(transform_line_items(&content))
+}

--- a/ee/tabby-webserver/src/service/utils/mod.rs
+++ b/ee/tabby-webserver/src/service/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod prompt;

--- a/ee/tabby-webserver/src/service/utils/prompt.rs
+++ b/ee/tabby-webserver/src/service/utils/prompt.rs
@@ -6,7 +6,6 @@ use async_openai_alt::types::{
     CreateChatCompletionRequestArgs,
 };
 use tabby_inference::ChatCompletionStream;
-use tabby_schema::repository::FileEntrySearchResult;
 
 /// Sends a prompt to the provided ChatCompletionStream and returns the generated response as a String.
 pub async fn request_llm(chat: Arc<dyn ChatCompletionStream>, prompt: &str) -> Result<String> {
@@ -54,39 +53,6 @@ pub fn trim_bullet(s: &str) -> String {
 /// Checks if the `check` string is contained within `content` in a case-insensitive manner.
 pub fn detect_content(content: &str, check: &str) -> bool {
     content.to_lowercase().contains(check)
-}
-
-// this is use to input a files tree, and generate some related question relate to repo dirs
-pub async fn pipeline_related_questions_with_repo_dirs(
-    chat: Arc<dyn ChatCompletionStream>,
-    files: Vec<FileEntrySearchResult>,
-) -> Result<Vec<String>> {
-    // Convert files into a formatted string for the prompt
-    let files_content = files
-        .iter()
-        .map(|f| format!("Type: {}, Path: {}", f.r#type, f.path))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let prompt = format!(
-        r#"You are a helpful assistant that helps the user to ask related questions about a codebase structure.
-Based on the following file structure, please generate 3 relevant questions that would help understand the codebase better.
-Each question should be no longer than 20 words and be specific enough to stand alone.
-
-File structure:
-{}
-
-Please generate 3 questions about this codebase structure that would help understand:
-1. The organization and architecture
-2. The main functionality
-3. The potential implementation details
-
-Return only the questions, one per line."#,
-        files_content
-    );
-
-    let content = request_llm(chat, &prompt).await?;
-    Ok(transform_line_items(&content))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Provides a query readRepositoryRelatedQuestions interface, as well as a cache of the same source_id with 30mins. This interface allows you to get three questions about the current repository to help you get started with your current project. 

<img width="772" alt="image" src="https://github.com/user-attachments/assets/000ad280-0b51-4979-bef3-81397c9a5368" />

https://jam.dev/c/70930e68-577a-4e12-a71f-d216417b452c

