### PR TITLE
chore: log current models upon startup

### DIFF
--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -14,7 +14,7 @@ use tabby_download::ModelKind;
 use tabby_inference::ChatCompletionStream;
 use tokio::{sync::oneshot::Sender, time::sleep};
 use tower_http::timeout::TimeoutLayer;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 use utoipa::{
     openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme},
     Modify, OpenApi,
@@ -203,11 +203,11 @@ pub async fn main(config: &Config, args: &ServeArgs) {
 async fn load_model(config: &Config) {
     match config.model.completion {
         Some(ModelConfig::Local(ref model)) => {
-            info!(model_id = model.model_id, "Using local completion model.");
+            debug!(model_id = model.model_id, "Using local completion model.");
             download_model_if_needed(&model.model_id, ModelKind::Completion).await;
         }
         Some(ModelConfig::Http(ref model)) => {
-            info!(
+            debug!(
                 model_name = model.model_name,
                 endpoint = model.api_endpoint,
                 "Using remote completion model.",
@@ -220,11 +220,11 @@ async fn load_model(config: &Config) {
 
     match config.model.chat {
         Some(ModelConfig::Local(ref model)) => {
-            info!(model_id = model.model_id, "Using local chat model.",);
+            debug!(model_id = model.model_id, "Using local chat model.",);
             download_model_if_needed(&model.model_id, ModelKind::Chat).await;
         }
         Some(ModelConfig::Http(ref model)) => {
-            info!(
+            debug!(
                 model_name = model.model_name,
                 endpoint = model.api_endpoint,
                 "Using remote chat model."
@@ -237,11 +237,11 @@ async fn load_model(config: &Config) {
 
     match config.model.embedding {
         ModelConfig::Local(ref model) => {
-            info!(model_id = model.model_id, "Using local embedding model.");
+            debug!(model_id = model.model_id, "Using local embedding model.");
             download_model_if_needed(&model.model_id, ModelKind::Embedding).await;
         }
         ModelConfig::Http(ref model) => {
-            info!(
+            debug!(
                 model_name = model.model_name,
                 endpoint = model.api_endpoint,
                 "Using remote embedding model."


### PR DESCRIPTION
- local
  ![CleanShot 2025-02-05 at 21 07 13@2x](https://github.com/user-attachments/assets/070aa782-0a0e-416c-a560-5666d336a0ad)
- remote
  ![CleanShot 2025-02-05 at 21 08 07@2x](https://github.com/user-attachments/assets/8bbb1d46-149a-4905-a694-ae06cf1a65cf)
- completion model not set
  ![CleanShot 2025-02-05 at 21 10 03@2x](https://github.com/user-attachments/assets/1ffb2d53-ce1c-449d-a26d-6061d7f33421)
- Chat model not set
  ![CleanShot 2025-02-05 at 21 11 09@2x](https://github.com/user-attachments/assets/2e1363b1-150d-4364-a068-6edc042cb79d)
- with overwrite models
  ![CleanShot 2025-02-05 at 21 12 45@2x](https://github.com/user-attachments/assets/df040182-21bf-4b12-9a2c-9cb2d539ddfe)

