### PR TITLE
fix: show model name for remote models in system tab

### DIFF
--- a/crates/tabby/src/services/health.rs
+++ b/crates/tabby/src/services/health.rs
@@ -55,7 +55,10 @@ impl HealthState {
 fn to_model_name(model: &Option<ModelConfig>) -> Option<String> {
     if let Some(model) = model {
         match model {
-            ModelConfig::Http(_http) => Some("Remote".to_owned()),
+            ModelConfig::Http(http) => http
+                .model_name
+                .clone()
+                .or_else(|| Some("Remote".to_string())),
             ModelConfig::Local(llama) => Some(llama.model_id.clone()),
         }
     } else {


### PR DESCRIPTION
![CleanShot 2025-02-06 at 17 03 09@2x](https://github.com/user-attachments/assets/0f9a46c6-8e0c-4c1b-9dca-572d0bd79629)

fix https://github.com/TabbyML/tabby/pull/3791#issuecomment-2638597287