### PR TITLE
feat(index): add GDScript language support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,6 +5489,7 @@ dependencies = [
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
  "tree-sitter-elixir",
+ "tree-sitter-gdscript",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-kotlin",
@@ -6395,6 +6396,15 @@ name = "tree-sitter-elixir"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94bf7f057768b1cab2ee1f14812ed4ae33f9e04d09254043eeaa797db4ef70"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-gdscript"
+version = "0.0.1"
+source = "git+https://github.com/faceCutWall/tree-sitter-gdscript?rev=8a8c067899d734840e8ce86fdeeeadbe8088446b#8a8c067899d734840e8ce86fdeeeadbe8088446b"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/tabby-common/assets/languages.toml
+++ b/crates/tabby-common/assets/languages.toml
@@ -420,3 +420,17 @@ top_level_keywords = [
   "while",
   "with",
 ]
+
+[[config]]
+languages = ["gdscript"]
+exts = ["gd", "tscn", "tres"]
+line_comment = "#"
+top_level_keywords = [
+    "var",
+    "const",
+    "enum",
+    "func",
+    "class",
+    "class_name",
+    "extends",
+]

--- a/crates/tabby-index/Cargo.toml
+++ b/crates/tabby-index/Cargo.toml
@@ -25,6 +25,7 @@ tree-sitter-c-sharp = "0.21.2"
 tree-sitter-solidity = { git = "https://github.com/JoranHonig/tree-sitter-solidity", rev = "0e86ae647bda22c9bee00ec59752df7b3d3b000b" }
 tree-sitter-lua = "0.1.0"
 tree-sitter-elixir = "0.2.0"
+tree-sitter-gdscript = { git = "https://github.com/faceCutWall/tree-sitter-gdscript", rev = "8a8c067899d734840e8ce86fdeeeadbe8088446b" }
 ignore.workspace = true
 tokio = { workspace = true, features = ["process"] }
 text-splitter = { version = "0.13.3", features = ["code"] }

--- a/crates/tabby-index/queries/gdscript.scm
+++ b/crates/tabby-index/queries/gdscript.scm
@@ -1,0 +1,12 @@
+
+(
+    (class_definition (name) @name) @definition.class
+)
+
+(
+    (function_definition (name) @name) @definition.function
+)
+
+(
+    (call (identifier) @name) @reference.call
+)

--- a/crates/tabby-index/src/code/languages.rs
+++ b/crates/tabby-index/src/code/languages.rs
@@ -158,6 +158,17 @@ lazy_static! {
                     .unwrap(),
                 ),
             ),
+            (
+                "gdscript",
+                TagsConfigurationSync(
+                    TagsConfiguration::new(
+                        tree_sitter_gdscript::language(),
+                        include_str!("../../queries/gdscript.scm"),
+                        "",
+                    )
+                    .unwrap(),
+                ),
+            ),
         ])
     };
 }

--- a/website/docs/references/programming-languages.md
+++ b/website/docs/references/programming-languages.md
@@ -38,6 +38,7 @@ For an actual example of an issue or pull request adding the above support, plea
 * [Lua](https://www.lua.org)
 * [Elixir](https://elixir-lang.org)
 * [OCaml](https://ocaml.org/)
+* [GDScript](https://gdscript.com/)
 
 ## Languages Missing Certain Support
 


### PR DESCRIPTION
There seems to be an annoying dependency problem appeared, [tree-sitter-gdscript](https://crates.io/crates/tree-sitter-gdscript) only release a crate that uses `LanguageFn` supported above [v0.23.0](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.23.0) of tree-sitter. The older version however depends on ~0.20.10, which is incompatible with Tabby. I forked [tree-sitter-gdscript](https://github.com/faceCutWall/tree-sitter-gdscript) and bumped tree-sitter to v0.22.6 to make it work. The functionality has been tested, but I'm not sure if it's okay to do so. Looking forward to more suggestions :)