### PR TITLE
refactor(chat-panel): update typedef of filepath.

### DIFF
--- a/clients/tabby-chat-panel/package.json
+++ b/clients/tabby-chat-panel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabby-chat-panel",
   "type": "module",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "keywords": [],
   "sideEffects": false,
   "exports": {

--- a/clients/tabby-chat-panel/src/index.ts
+++ b/clients/tabby-chat-panel/src/index.ts
@@ -107,7 +107,7 @@ export interface ErrorMessage {
 /**
  * Represents a filepath to identify a file.
  */
-export type Filepath = FilepathInGitRepository | FilepathUri
+export type Filepath = FilepathInGitRepository | FilepathInWorkspace | FilepathUri
 
 /**
  * This is used for files in a Git repository, and should be used in priority.
@@ -135,7 +135,26 @@ export interface FilepathInGitRepository {
 }
 
 /**
- * This is used for files not in a Git repository.
+ * This is used for files in the workspace, but not in a Git repository.
+ */
+export interface FilepathInWorkspace {
+  kind: 'workspace'
+
+  /**
+   * A string that is a relative path to `baseDir`.
+   */
+  filepath: string
+
+  /**
+   * A string that can be parsed as a URI, used to identify the directory in the client.
+   * The scheme of the URI could be 'file' or some other protocol to access the directory.
+   */
+  baseDir: string
+}
+
+/**
+ * This is used for files not in a Git repository and not in the workspace.
+ * Also used for untitled files not saved.
  */
 export interface FilepathUri {
   kind: 'uri'

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -13,6 +13,7 @@ import {
   cn,
   convertFilepath,
   encodeMentionPlaceHolder,
+  getFilepathFromContext,
   resolveFileNameForDisplay
 } from '@/lib/utils'
 import {
@@ -206,26 +207,8 @@ export function MessageMarkdown({
     setSymbolLocationMap(map => new Map(map.set(keyword, undefined)))
     const hints: LookupSymbolHint[] = []
     if (activeSelection && activeSelection?.range) {
-      // FIXME(@icycodes): this is intended to convert the filepath to Filepath type
-      // We should remove this after FileContext.filepath use type Filepath instead of string
-      let filepath: Filepath
-      if (
-        activeSelection.git_url.length > 1 &&
-        !activeSelection.filepath.includes(':')
-      ) {
-        filepath = {
-          kind: 'git',
-          filepath: activeSelection.filepath,
-          gitUrl: activeSelection.git_url
-        }
-      } else {
-        filepath = {
-          kind: 'uri',
-          uri: activeSelection.filepath
-        }
-      }
       hints.push({
-        filepath,
+        filepath: getFilepathFromContext(activeSelection),
         location: {
           start: activeSelection.range.start,
           end: activeSelection.range.end

--- a/ee/tabby-ui/lib/types/chat.ts
+++ b/ee/tabby-ui/lib/types/chat.ts
@@ -11,7 +11,16 @@ import { ArrayElementType } from './common'
 
 export interface FileContext {
   kind: 'file'
+  /**
+   * filepath can be:
+   * - uri, file://path/to/file.txt or untitled://Untitled-1
+   * - relative path, path/to/file.txt, in this case, `baseDir` or `git_uri` is required
+   */
   filepath: string
+  /**
+   * Uri to the base dir, provided when filepath is relative path and git_url is not available.
+   */
+  baseDir?: string
   /**
    * The range of the selected content in the file.
    * If the range is not provided, the whole file is considered.

--- a/ee/tabby-ui/lib/utils/index.ts
+++ b/ee/tabby-ui/lib/utils/index.ts
@@ -196,16 +196,22 @@ export function getPromptForChatCommand(command: ChatCommand) {
 }
 
 export const convertFilepath = (filepath: Filepath) => {
-  if (filepath.kind === 'uri') {
+  if (filepath.kind === 'git') {
     return {
-      filepath: filepath.uri,
+      filepath: filepath.filepath,
       git_url: ''
     }
   }
-
+  if (filepath.kind === 'workspace') {
+    return {
+      filepath: filepath.filepath,
+      baseDir: filepath.baseDir,
+      git_url: ''
+    }
+  }
   return {
-    filepath: filepath.filepath,
-    git_url: filepath.gitUrl
+    filepath: filepath.uri,
+    git_url: ''
   }
 }
 
@@ -244,11 +250,21 @@ export function getFilepathFromContext(context: FileContext): Filepath {
       filepath: context.filepath,
       gitUrl: context.git_url
     }
-  } else {
+  }
+  if (
+    context.baseDir &&
+    context.baseDir.length > 1 &&
+    !context.filepath.includes(':')
+  ) {
     return {
-      kind: 'uri',
-      uri: context.filepath
+      kind: 'workspace',
+      filepath: context.filepath,
+      baseDir: context.baseDir
     }
+  }
+  return {
+    kind: 'uri',
+    uri: context.filepath
   }
 }
 


### PR DESCRIPTION
This PR helps to resolve the issue of when the workspace is not a git repository, the file path is displayed as an absolute uri. It would be better to show a relative path to the workspace instead.

![Screenshot from 2025-01-20 10-13-01](https://github.com/user-attachments/assets/bf7bf9b0-4a27-4e57-b02d-deb7d3e57ee8)
