### PR TITLE
feat(file-search): implement breadth-first search for file listing

### DIFF
--- a/crates/tabby-git/src/file_search.rs
+++ b/crates/tabby-git/src/file_search.rs
@@ -66,7 +66,7 @@ fn walk_bfs(
             let path = if current_path.is_empty() {
                 PathBuf::from(&entry_name)
             } else {
-                PathBuf::from(&current_path).join(&entry_name)
+                PathBuf::from(&current_path).join(entry_name)
             };
 
             let is_file = entry.kind() == Some(git2::ObjectType::Blob);

--- a/crates/tabby-git/src/file_search.rs
+++ b/crates/tabby-git/src/file_search.rs
@@ -146,8 +146,8 @@ pub async fn list(
     .collect()
     .await;
 
-    let is_clipped = limit.map(|l| entries.len() >= l).unwrap_or(false);
-    Ok((entries, is_clipped))
+    let truncated = limit.map(|l| entries.len() >= l).unwrap_or(false);
+    Ok((entries, truncated))
 }
 
 #[cfg(test)]

--- a/crates/tabby-git/src/file_search.rs
+++ b/crates/tabby-git/src/file_search.rs
@@ -134,7 +134,7 @@ pub async fn list(
     repository: git2::Repository,
     rev: Option<&str>,
     limit: Option<usize>,
-) -> anyhow::Result<Vec<GitFileSearch>> {
+) -> anyhow::Result<(Vec<GitFileSearch>, bool)> {
     let entries: Vec<GitFileSearch> = stream! {
         for await (is_file, basepath) in walk_stream(repository, rev).await {
             let r#type = if is_file { "file" } else { "dir" };
@@ -146,7 +146,8 @@ pub async fn list(
     .collect()
     .await;
 
-    Ok(entries)
+    let is_clipped = limit.map(|l| entries.len() >= l).unwrap_or(false);
+    Ok((entries, is_clipped))
 }
 
 #[cfg(test)]

--- a/crates/tabby-git/src/lib.rs
+++ b/crates/tabby-git/src/lib.rs
@@ -25,7 +25,7 @@ pub async fn list_files(
     root: &Path,
     rev: Option<&str>,
     limit: Option<usize>,
-) -> anyhow::Result<Vec<GitFileSearch>> {
+) -> anyhow::Result<(Vec<GitFileSearch>, bool)> {
     file_search::list(git2::Repository::open(root)?, rev, limit).await
 }
 

--- a/crates/tabby-git/src/lib.rs
+++ b/crates/tabby-git/src/lib.rs
@@ -21,12 +21,18 @@ pub async fn search_files(
     file_search::search(git2::Repository::open(root)?, rev, pattern, limit).await
 }
 
+pub struct ListFile {
+    pub files: Vec<GitFileSearch>,
+    pub truncated: bool,
+}
+
 pub async fn list_files(
     root: &Path,
     rev: Option<&str>,
     limit: Option<usize>,
-) -> anyhow::Result<(Vec<GitFileSearch>, bool)> {
-    file_search::list(git2::Repository::open(root)?, rev, limit).await
+) -> anyhow::Result<ListFile> {
+    let (files, truncated) = file_search::list(git2::Repository::open(root)?, rev, limit).await?;
+    Ok(ListFile { files, truncated })
 }
 
 pub async fn grep(

--- a/crates/tabby-git/src/lib.rs
+++ b/crates/tabby-git/src/lib.rs
@@ -29,6 +29,14 @@ pub async fn list_files(
     file_search::list(git2::Repository::open(root)?, rev, limit).await
 }
 
+pub async fn list_files_bfs(
+    root: &Path,
+    rev: Option<&str>,
+    limit: Option<usize>,
+) -> anyhow::Result<Vec<GitFileSearch>> {
+    file_search::list_files_bfs(git2::Repository::open(root)?, rev, limit).await
+}
+
 pub async fn grep(
     root: &Path,
     rev: Option<&str>,

--- a/crates/tabby-git/src/lib.rs
+++ b/crates/tabby-git/src/lib.rs
@@ -26,7 +26,7 @@ pub async fn list_files(
     rev: Option<&str>,
     limit: Option<usize>,
 ) -> anyhow::Result<Vec<GitFileSearch>> {
-    file_search::list(git2::Repository::open(root)?, rev, limit).await
+    file_search::list(git2::Repository::open(root)?, rev, limit, None).await
 }
 
 pub async fn list_files_bfs(
@@ -34,7 +34,7 @@ pub async fn list_files_bfs(
     rev: Option<&str>,
     limit: Option<usize>,
 ) -> anyhow::Result<Vec<GitFileSearch>> {
-    file_search::list_files_bfs(git2::Repository::open(root)?, rev, limit).await
+    file_search::list(git2::Repository::open(root)?, rev, limit, Some(true)).await
 }
 
 pub async fn grep(

--- a/crates/tabby-git/src/lib.rs
+++ b/crates/tabby-git/src/lib.rs
@@ -26,15 +26,7 @@ pub async fn list_files(
     rev: Option<&str>,
     limit: Option<usize>,
 ) -> anyhow::Result<Vec<GitFileSearch>> {
-    file_search::list(git2::Repository::open(root)?, rev, limit, None).await
-}
-
-pub async fn list_files_bfs(
-    root: &Path,
-    rev: Option<&str>,
-    limit: Option<usize>,
-) -> anyhow::Result<Vec<GitFileSearch>> {
-    file_search::list(git2::Repository::open(root)?, rev, limit, Some(true)).await
+    file_search::list(git2::Repository::open(root)?, rev, limit).await
 }
 
 pub async fn grep(

--- a/ee/tabby-schema/src/schema/repository/mod.rs
+++ b/ee/tabby-schema/src/schema/repository/mod.rs
@@ -278,7 +278,7 @@ pub trait RepositoryService: Send + Sync {
         id: &ID,
         rev: Option<&str>,
         top_n: Option<usize>,
-    ) -> Result<Vec<FileEntrySearchResult>>;
+    ) -> Result<(Vec<FileEntrySearchResult>, bool)>;
 
     async fn grep(
         &self,

--- a/ee/tabby-webserver/src/service/answer.rs
+++ b/ee/tabby-webserver/src/service/answer.rs
@@ -118,7 +118,7 @@ impl AnswerService {
                     if need_codebase_context.file_list {
                         // List at most 300 files in the repository.
                         match self.repository.list_files(&policy, &repository.kind, &repository.id, None, Some(300)).await {
-                            Ok(files) => {
+                            Ok((files, _is_clipped)) => {
                                 let file_list: Vec<_> = files.into_iter().map(|x| x.path).collect();
                                 attachment.code_file_list = Some(MessageAttachmentCodeFileList {
                                     file_list: file_list.clone(),

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -235,7 +235,7 @@ impl RepositoryService for RepositoryServiceImpl {
         top_n: Option<usize>,
     ) -> Result<Vec<FileEntrySearchResult>> {
         let dir = self.resolve_repository(policy, kind, id).await?.dir;
-        let files = tabby_git::list_files(&dir, rev, top_n)
+        let files = tabby_git::list_files_bfs(&dir, rev, top_n)
             .await
             .map(|x| {
                 x.into_iter()

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -235,7 +235,7 @@ impl RepositoryService for RepositoryServiceImpl {
         top_n: Option<usize>,
     ) -> Result<Vec<FileEntrySearchResult>> {
         let dir = self.resolve_repository(policy, kind, id).await?.dir;
-        let files = tabby_git::list_files_bfs(&dir, rev, top_n)
+        let files = tabby_git::list_files(&dir, rev, top_n)
             .await
             .map(|x| {
                 x.into_iter()

--- a/ee/tabby-webserver/src/service/repository/prompt_tools.rs
+++ b/ee/tabby-webserver/src/service/repository/prompt_tools.rs
@@ -10,7 +10,7 @@ use crate::service::utils::prompt::{request_llm, transform_line_items};
 pub async fn pipeline_related_questions_with_repo_dirs(
     chat: Arc<dyn ChatCompletionStream>,
     files: Vec<FileEntrySearchResult>,
-    clipped: bool,
+    truncated: bool,
 ) -> Result<Vec<String>> {
     // Convert files into a formatted string for the prompt
     let files_content = files
@@ -29,8 +29,8 @@ File structure:
         files_content
     );
 
-    if clipped {
-        prompt.push_str("\nNote: The file list has been clipped. There may be more files in subdirectories that were not included due to the limit.\n");
+    if truncated {
+        prompt.push_str("\nNote: The file list has been truncated. There may be more files in subdirectories that were not included due to the limit.\n");
     }
 
     prompt.push_str(

--- a/ee/tabby-webserver/src/service/repository/prompt_tools.rs
+++ b/ee/tabby-webserver/src/service/repository/prompt_tools.rs
@@ -10,7 +10,7 @@ use crate::service::utils::prompt::{request_llm, transform_line_items};
 pub async fn pipeline_related_questions_with_repo_dirs(
     chat: Arc<dyn ChatCompletionStream>,
     files: Vec<FileEntrySearchResult>,
-    is_clipped: bool,
+    clipped: bool,
 ) -> Result<Vec<String>> {
     // Convert files into a formatted string for the prompt
     let files_content = files
@@ -29,7 +29,7 @@ File structure:
         files_content
     );
 
-    if is_clipped {
+    if clipped {
         prompt.push_str("\nNote: The file list has been clipped. There may be more files in subdirectories that were not included due to the limit.\n");
     }
 


### PR DESCRIPTION
Using BFS to search files instead of DFS preorder traversal. Also adding an is_clipped prompt when the list of files exceeds the limit of files.