### PR TITLE
feat(http-api-bindings): adapt llama.cpp embedding kind to latest for…

### DIFF
--- a/crates/http-api-bindings/src/embedding/mod.rs
+++ b/crates/http-api-bindings/src/embedding/mod.rs
@@ -23,7 +23,7 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
             config.api_key.clone(),
             false,
         ),
-        "llama.cpp/legacy_embedding" => LlamaCppEngine::create(
+        "llama.cpp/before_b4356_embedding" => LlamaCppEngine::create(
             config
                 .api_endpoint
                 .as_deref()

--- a/crates/http-api-bindings/src/embedding/mod.rs
+++ b/crates/http-api-bindings/src/embedding/mod.rs
@@ -21,6 +21,15 @@ pub async fn create(config: &HttpModelConfig) -> Arc<dyn Embedding> {
                 .as_deref()
                 .expect("api_endpoint is required"),
             config.api_key.clone(),
+            false,
+        ),
+        "llama.cpp/legacy_embedding" => LlamaCppEngine::create(
+            config
+                .api_endpoint
+                .as_deref()
+                .expect("api_endpoint is required"),
+            config.api_key.clone(),
+            true,
         ),
         "openai/embedding" => OpenAIEmbeddingEngine::create(
             config

--- a/website/docs/references/models-http-api/llama.cpp.mdx
+++ b/website/docs/references/models-http-api/llama.cpp.mdx
@@ -1,3 +1,5 @@
+import Collapse from '@site/src/components/Collapse';
+
 # llama.cpp
 
 [llama.cpp](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md#api-endpoints) is a popular C++ library for serving gguf-based models. It provides a server implementation that supports completion, chat, and embedding functionalities through HTTP APIs.
@@ -27,8 +29,23 @@ prompt_template = "<PRE> {prefix} <SUF>{suffix} <MID>"  # Example prompt templat
 
 llama.cpp provides embedding functionality through its HTTP API.
 
+The llama.cpp embedding API interface and response format underwent some changes in version `b4356`.
+Therefore, we have provided two different kinds to accommodate the various versions of the llama.cpp embedding interface.
+
+You can refer to the configuration as follows:
+
 ```toml title="~/.tabby/config.toml"
 [model.embedding.http]
 kind = "llama.cpp/embedding"
 api_endpoint = "http://localhost:8888"
 ```
+
+<Collapse title="For the versions prior to b4356">
+
+```toml title="~/.tabby/config.toml"
+[model.embedding.http]
+kind = "llama.cpp/before_b4356_embedding"
+api_endpoint = "http://localhost:8888"
+```
+
+</Collapse>

--- a/website/docs/references/models-http-api/llamafile.md
+++ b/website/docs/references/models-http-api/llamafile.md
@@ -31,11 +31,15 @@ prompt_template = "<|fim_prefix|>{prefix}<|fim_suffix|>{suffix}<|fim_middle|>" #
 
 ## Embeddings model
 
-llamafile provides embedding functionality through llama.cpp's API interface. Note that the endpoint URL should NOT include the `v1` suffix.
+llamafile provides embedding functionality via llama.cpp's API interface,
+but it utilizes the API interface defined prior to version b4356.
+Therefore, we should use the kind `llama.cpp/before_b4356_embedding`.
+
+Note that the endpoint URL should NOT include the `v1` suffix.
 
 ```toml title="~/.tabby/config.toml"
 [model.embedding.http]
-kind = "llama.cpp/embedding"
+kind = "llama.cpp/before_b4356_embedding"
 model_name = "your_model"
 api_endpoint = "http://localhost:8082"  # DO NOT append the `v1` suffix
 api_key = ""


### PR DESCRIPTION
…mat and add kind the legacy type

ref:
https://github.com/ggerganov/llama.cpp/blob/369be5598ac5f71f6aa6d6606e9aec769a23dafa/examples/server/server.cpp#L4408-L4409

test:

### llamafile

config:
![CleanShot 2025-02-12 at 15 57 51@2x](https://github.com/user-attachments/assets/714131d8-96ca-4f72-8f53-59b0f05d004a)

![CleanShot 2025-02-12 at 15 58 48@2x](https://github.com/user-attachments/assets/cabb55e1-1379-4e39-ab6d-eb769d60614f)

### latest llama.cpp:
![CleanShot 2025-02-12 at 16 00 24@2x](https://github.com/user-attachments/assets/7f77101a-5cee-439e-b4b8-97b1f46747ad)

![CleanShot 2025-02-12 at 16 04 11@2x](https://github.com/user-attachments/assets/769533a3-f80b-4fb9-a95d-45130c32c29b)

## Doc

### llama.cpp
![CleanShot X 2025-02-13 12 11 16](https://github.com/user-attachments/assets/4249734a-1a57-4183-8231-06481927b15f)

### llamafile
![CleanShot 2025-02-13 at 12 13 42@2x](https://github.com/user-attachments/assets/7a4331ab-f1ae-42c1-bc7b-2ae8f90baf47)
