### PR TITLE
refactor(chat): simplify attachment client code structure

### DIFF
--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -300,6 +300,7 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
   const attachmentClientCode: Array<
     Omit<AttachmentCodeItem, '__typename' | 'startLine'> & {
       startLine: number | undefined
+      baseDir?: string
     }
   > = useMemo(() => {
     const formatedAttachmentClientCode =
@@ -307,6 +308,7 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
         content: o.content,
         filepath: o.filepath,
         gitUrl: o.git_url,
+        baseDir: o.baseDir,
         startLine: o.range ? o.range.start : undefined,
         language: filename2prism(o.filepath ?? '')[0],
         isClient: true

--- a/ee/tabby-ui/components/chat/question-answer.tsx
+++ b/ee/tabby-ui/components/chat/question-answer.tsx
@@ -300,8 +300,6 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
   const attachmentClientCode: Array<
     Omit<AttachmentCodeItem, '__typename' | 'startLine'> & {
       startLine: number | undefined
-      endLine: number | undefined
-      baseDir?: string
     }
   > = useMemo(() => {
     const formatedAttachmentClientCode =
@@ -310,10 +308,8 @@ function AssistantMessageCard(props: AssistantMessageCardProps) {
         filepath: o.filepath,
         gitUrl: o.git_url,
         startLine: o.range ? o.range.start : undefined,
-        endLine: o.range ? o.range.end : undefined,
         language: filename2prism(o.filepath ?? '')[0],
-        isClient: true,
-        baseDir: o.baseDir
+        isClient: true
       })) ?? []
     return formatedAttachmentClientCode
   }, [clientCode])

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -226,7 +226,7 @@ export function MessageMarkdown({
           ? {
               kind: 'workspace',
               filepath: code.filepath,
-              baseDir: code.baseDir ?? ''
+              baseDir: code.baseDir
             }
           : {
               kind: 'uri',

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -213,13 +213,25 @@ export function MessageMarkdown({
     const hints: LookupSymbolHint[] = []
 
     attachmentClientCode?.forEach(item => {
-      const code = item as AttachmentCodeItem
+      const code = item as Omit<
+        AttachmentCodeItem,
+        '__typename' | 'startLine'
+      > & {
+        startLine: number | undefined
+        baseDir?: string
+      }
       hints.push({
         filepath: code.gitUrl
           ? {
               kind: 'git',
               gitUrl: code.gitUrl,
               filepath: code.filepath
+            }
+          : code.baseDir
+          ? {
+              kind: 'workspace',
+              filepath: code.filepath,
+              baseDir: code.baseDir ?? ''
             }
           : {
               kind: 'uri',

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -213,13 +213,8 @@ export function MessageMarkdown({
     const hints: LookupSymbolHint[] = []
 
     attachmentClientCode?.forEach(item => {
-      const code = item as Omit<
-        AttachmentCodeItem,
-        '__typename' | 'startLine'
-      > & {
-        startLine: number | undefined
-        baseDir?: string
-      }
+      const code = item as AttachmentCodeItem
+
       hints.push({
         filepath: code.gitUrl
           ? {
@@ -237,13 +232,7 @@ export function MessageMarkdown({
               kind: 'uri',
               uri: code.filepath
             },
-        location:
-          code.startLine && code.content
-            ? {
-                start: code.startLine,
-                end: code.startLine + code.content.split('\n').length - 1
-              }
-            : undefined
+        location: getRangeFromAttachmentCode(code)
       })
     })
 

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -215,6 +215,7 @@ export function MessageMarkdown({
     attachmentClientCode?.forEach(item => {
       const code = item as AttachmentCodeItem
 
+      // FIXME(Sma1lboy): using getFilepathFromContext after refactor FileContext
       hints.push({
         filepath: code.gitUrl
           ? {

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -213,13 +213,7 @@ export function MessageMarkdown({
     const hints: LookupSymbolHint[] = []
 
     attachmentClientCode?.forEach(item => {
-      const code = item as AttachmentCodeItem & {
-        startLine: number | undefined
-        endLine: number | undefined
-        range?: { start: number; end: number }
-        baseDir?: string
-      }
-
+      const code = item as AttachmentCodeItem
       hints.push({
         filepath: code.gitUrl
           ? {
@@ -227,21 +221,15 @@ export function MessageMarkdown({
               gitUrl: code.gitUrl,
               filepath: code.filepath
             }
-          : code.baseDir
-          ? {
-              kind: 'workspace',
-              filepath: code.filepath,
-              baseDir: code.baseDir
-            }
           : {
               kind: 'uri',
               uri: code.filepath
             },
         location:
-          code.startLine && code.endLine
+          code.startLine && code.content
             ? {
                 start: code.startLine,
-                end: code.endLine
+                end: code.startLine + code.content.split('\n').length - 1
               }
             : undefined
       })

--- a/ee/tabby-ui/lib/types/chat.ts
+++ b/ee/tabby-ui/lib/types/chat.ts
@@ -134,6 +134,7 @@ export type AttachmentCodeItem =
   ArrayElementType<ThreadAssistantMessageAttachmentCodeHits>['code'] & {
     isClient?: boolean
     extra?: { scores?: MessageCodeSearchHit['scores'] }
+    baseDir?: string
   }
 
 // for rendering, including score


### PR DESCRIPTION

- Remove endline field
- Remove baseDir and instead make all URIs use relative paths when looking up symbols