### PR TITLE
feat(chat): refactor URI resolution in lookUpSymbol

### DIFF
--- a/clients/vscode/src/chat/utils.ts
+++ b/clients/vscode/src/chat/utils.ts
@@ -79,7 +79,10 @@ export function chatPanelFilepathToLocalUri(filepath: Filepath, gitProvider: Git
     try {
       result = Uri.parse(filepath.uri, true);
     } catch (e) {
-      // nothing
+      const workspaceRoot = workspace.workspaceFolders?.[0];
+      if (workspaceRoot) {
+        result = Uri.joinPath(workspaceRoot.uri, filepath.uri);
+      }
     }
   } else if (filepath.kind === "workspace") {
     try {

--- a/clients/vscode/src/chat/webview.ts
+++ b/clients/vscode/src/chat/webview.ts
@@ -311,21 +311,8 @@ export class ChatWebview {
             this.logger.debug("No filepath in the hint:", hint);
             continue;
           }
-          let uri: Uri | undefined;
-          if (hint.filepath.kind === "git") {
-            const localGitRoot = this.gitProvider.findLocalRootUriByRemoteUrl(hint.filepath.gitUrl);
-            if (localGitRoot) {
-              uri = Uri.joinPath(localGitRoot, hint.filepath.filepath);
-            }
-          } else {
-            if (!workspace.workspaceFolders || !workspace.workspaceFolders[0]) {
-              continue;
-            }
-            uri = Uri.joinPath(
-              workspace.workspaceFolders[0].uri,
-              "uri" in hint.filepath ? hint.filepath.uri : hint.filepath.filepath,
-            );
-          }
+          const uri = chatPanelFilepathToLocalUri(hint.filepath, this.gitProvider);
+
           if (!uri) {
             continue;
           }

--- a/clients/vscode/src/chat/webview.ts
+++ b/clients/vscode/src/chat/webview.ts
@@ -312,10 +312,10 @@ export class ChatWebview {
             continue;
           }
           const uri = chatPanelFilepathToLocalUri(hint.filepath, this.gitProvider);
-
           if (!uri) {
             continue;
           }
+
           let document: TextDocument;
           try {
             document = await workspace.openTextDocument(uri);

--- a/clients/vscode/src/chat/webview.ts
+++ b/clients/vscode/src/chat/webview.ts
@@ -311,11 +311,24 @@ export class ChatWebview {
             this.logger.debug("No filepath in the hint:", hint);
             continue;
           }
-          const uri = chatPanelFilepathToLocalUri(hint.filepath, this.gitProvider);
+          let uri: Uri | undefined;
+          if (hint.filepath.kind === "git") {
+            const localGitRoot = this.gitProvider.findLocalRootUriByRemoteUrl(hint.filepath.gitUrl);
+            if (localGitRoot) {
+              uri = Uri.joinPath(localGitRoot, hint.filepath.filepath);
+            }
+          } else {
+            if (!workspace.workspaceFolders || !workspace.workspaceFolders[0]) {
+              continue;
+            }
+            uri = Uri.joinPath(
+              workspace.workspaceFolders[0].uri,
+              "uri" in hint.filepath ? hint.filepath.uri : hint.filepath.filepath,
+            );
+          }
           if (!uri) {
             continue;
           }
-
           let document: TextDocument;
           try {
             document = await workspace.openTextDocument(uri);


### PR DESCRIPTION
Because lookUpSymbol will only exist in the case of gitUrl existing and gitUrl not existing. When gitUrl does not exist, other situations default to looking for the current rootWorkspaceUri + filepath. filepath as relative path.

![image](https://github.com/user-attachments/assets/b685dcbf-d8a8-425a-a9cd-8d5ca3699c8b)
