### PR TITLE
fix(ui): correct code badge styling in reading code step

### DIFF
--- a/ee/tabby-ui/app/search/components/reading-code-step.tsx
+++ b/ee/tabby-ui/app/search/components/reading-code-step.tsx
@@ -271,7 +271,11 @@ function CodeContextItem({
         >
           <span>{fileName}</span>
           {rangeText ? (
-            <span className="font-normal text-muted-foreground group-hover:text-foreground">
+            <span
+              className={cn('font-normal text-muted-foreground', {
+                'group-hover:text-foreground': clickable
+              })}
+            >
               :{rangeText}
             </span>
           ) : null}


### PR DESCRIPTION
Correct the badge styling for client code in Answer Engine. When hovering over the client code badge, the line number should not be highlighted.

### Before
https://jam.dev/c/9c41f338-6d8d-4589-b4a4-dfcc5010d4fe
### After
https://jam.dev/c/3c6a0d84-d62f-4767-a33e-f30bafe28295