### PR TITLE
fix(intellj,eclipse): correct typo in IntelliJ and Eclipse extension settings panels

### DIFF
--- a/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/preferences/MainPreferencesPage.java
+++ b/clients/eclipse/plugin/src/com/tabbyml/tabby4eclipse/preferences/MainPreferencesPage.java
@@ -63,7 +63,7 @@ public class MainPreferencesPage extends FieldEditorPreferencePage implements IW
 
 		Label tip = new Label(grid, SWT.WRAP);
 		tip.setText(
-				"Note: If leave empty, server endpoint config in `~/.tabby-client/agent/config.toml` will be used.");
+				"Note: If left empty, the server endpoint config in `~/.tabby-client/agent/config.toml` will be used.");
 		GridDataFactory.fillDefaults().indent(10, 2).span(2, 1).applyTo(tip);
 	}
 

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/settings/SettingsPanel.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/settings/SettingsPanel.kt
@@ -106,7 +106,7 @@ class SettingsPanel(private val project: Project) {
         """
       <html>
       A http or https URL of Tabby server endpoint.<br/>
-      If leave empty, server endpoint config in <i>~/.tabby-client/agent/config.toml</i> will be used.<br/>
+      If left empty, the server endpoint config in <i>~/.tabby-client/agent/config.toml</i> will be used.<br/>
       Default to <i>http://localhost:8080</i>.
       </html>
       """.trimIndent()


### PR DESCRIPTION
Slightly improves a user-facing string displayed in the extension settings in both IntelliJ and Eclipse.