### PR TITLE
fix(webserver): changed ldap search from onelevel to subtree

### DIFF
--- a/crates/tabby-index-cli/src/commands/bench.rs
+++ b/crates/tabby-index-cli/src/commands/bench.rs
@@ -27,8 +27,7 @@ pub struct BenchArgs {
 }
 
 pub fn run_bench_cli(index_path: &Path, args: &BenchArgs) -> Result<(), String> {
-    run_bench(index_path, &args.queries, args.num_repeat).map_err(From::from)
-}
+    run_bench(index_path, &args.queries, args.num_repeat)}
 
 fn extract_search_fields(schema: &Schema) -> Vec<Field> {
     schema

--- a/crates/tabby-index-cli/src/commands/bench.rs
+++ b/crates/tabby-index-cli/src/commands/bench.rs
@@ -27,7 +27,8 @@ pub struct BenchArgs {
 }
 
 pub fn run_bench_cli(index_path: &Path, args: &BenchArgs) -> Result<(), String> {
-    run_bench(index_path, &args.queries, args.num_repeat)}
+    run_bench(index_path, &args.queries, args.num_repeat)
+}
 
 fn extract_search_fields(schema: &Schema) -> Vec<Field> {
     schema

--- a/ee/tabby-webserver/src/ldap.rs
+++ b/ee/tabby-webserver/src/ldap.rs
@@ -86,7 +86,7 @@ impl LdapClient for LdapClientImpl {
         let searched = client
             .search(
                 &self.base_dn,
-                Scope::OneLevel,
+                Scope::Subtree,
                 &self.user_filter.replace("%s", user),
                 attrs,
             )

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -248,20 +248,21 @@ impl RepositoryService for RepositoryServiceImpl {
         top_n: Option<usize>,
     ) -> Result<(Vec<FileEntrySearchResult>, bool)> {
         let dir = self.resolve_repository(policy, kind, id).await?.dir;
-        let (files, truncated) = tabby_git::list_files(&dir, rev, top_n)
-            .await
-            .map(|list_file| {
-                let files = list_file
-                    .files
-                    .into_iter()
-                    .map(|f| FileEntrySearchResult {
-                        r#type: f.r#type,
-                        path: f.path,
-                        indices: f.indices,
-                    })
-                    .collect();
-                (files, list_file.truncated)
-            })?;
+        let (files, truncated) =
+            tabby_git::list_files(&dir, rev, top_n)
+                .await
+                .map(|list_file| {
+                    let files = list_file
+                        .files
+                        .into_iter()
+                        .map(|f| FileEntrySearchResult {
+                            r#type: f.r#type,
+                            path: f.path,
+                            indices: f.indices,
+                        })
+                        .collect();
+                    (files, list_file.truncated)
+                })?;
         Ok((files, truncated))
     }
 

--- a/ee/tabby-webserver/src/service/repository/mod.rs
+++ b/ee/tabby-webserver/src/service/repository/mod.rs
@@ -234,8 +234,7 @@ impl RepositoryService for RepositoryServiceImpl {
                         indices: f.indices,
                     })
                     .collect()
-            })
-            .map_err(anyhow::Error::from)?;
+            })?;
 
         Ok(matching)
     }
@@ -262,8 +261,7 @@ impl RepositoryService for RepositoryServiceImpl {
                     })
                     .collect();
                 (files, list_file.truncated)
-            })
-            .map_err(anyhow::Error::from)?;
+            })?;
         Ok((files, truncated))
     }
 


### PR DESCRIPTION
OneLevel does not do a subtree search which is required for effective use of directory server.  See [ldap3 docs](https://docs.rs/ldap3/latest/ldap3/#synchronous-search).