### PR TITLE
fix(background_job): expose crawler job error

### DIFF
--- a/crates/tabby-crawler/src/lib.rs
+++ b/crates/tabby-crawler/src/lib.rs
@@ -3,6 +3,7 @@ mod types;
 
 use std::process::Stdio;
 
+use anyhow::anyhow;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
 use readable_readability::Readability;
@@ -45,7 +46,9 @@ async fn crawl_url(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let mut child = command.spawn()?;
+    let mut child = command
+        .spawn()
+        .map_err(|e| anyhow!("Failed to run katana: {}", e))?;
 
     let stdout = child.stdout.take().expect("Failed to acquire stdout");
     let mut stdout = tokio::io::BufReader::new(stdout).lines();


### PR DESCRIPTION
ref: https://github.com/TabbyML/tabby/issues/3901

before:
Job Suc even no katana found:
![CleanShot 2025-02-27 at 10 11 15@2x](https://github.com/user-attachments/assets/2c597f24-059f-4806-8f7c-1a9fb4eac546)


After:
![CleanShot 2025-02-27 at 10 08 25@2x](https://github.com/user-attachments/assets/ac69f546-ed97-4e82-b85a-d0754103b0e5)

