### PR TITLE
fix(ui): refine chat history view styles

### DIFF
--- a/ee/tabby-ui/app/chat/components/history-view.tsx
+++ b/ee/tabby-ui/app/chat/components/history-view.tsx
@@ -57,7 +57,7 @@ export function HistoryView({ onClose, onNavigate }: HistoryViewProps) {
   return (
     <div className="fixed inset-0 z-10 overflow-hidden px-[16px] pt-4 md:pt-10">
       <div className="mx-auto h-full max-w-5xl overflow-y-auto pb-8">
-        <div className="editor-bg sticky top-0 flex items-center justify-between">
+        <div className="editor-bg sticky top-0 flex items-center justify-between pb-3">
           <span className="text-lg font-semibold">History</span>
           <Button size="sm" onClick={onClose}>
             Done

--- a/ee/tabby-ui/components/chat/thread-item.tsx
+++ b/ee/tabby-ui/components/chat/thread-item.tsx
@@ -41,10 +41,10 @@ export function ThreadItem({
   return (
     <div
       onClick={e => onNavigate(data.node.id)}
-      className="transform-bg group flex-1 cursor-pointer overflow-hidden rounded-md bg-background/70 px-4 py-3 hover:bg-accent/60"
+      className="group cursor-pointer overflow-hidden rounded-md bg-background/70 px-4 py-3 transition-colors hover:bg-accent/60"
     >
-      <div className="flex flex-none justify-between gap-2">
-        <div className="flex-1">
+      <div className="flex flex-nowrap justify-between gap-2 overflow-hidden">
+        <div className="flex-1 overflow-hidden">
           <LoadingWrapper
             loading={fetching || fetchingSources}
             fallback={
@@ -54,19 +54,15 @@ export function ThreadItem({
             }
           >
             <ThreadTitleWithMentions
-              className="break-anywhere flex-1 truncate text-base font-medium text-foreground/90"
+              className="break-anywhere truncate text-base font-medium text-foreground/90"
               sources={sources}
               message={replaceAtMentionPlaceHolderWithAt(
                 threadMessages?.[0]?.['node']['content'] ?? ''
               )}
             />
           </LoadingWrapper>
-          <div className="flex items-center gap-2">
-            <div className="flex items-baseline gap-0.5">
-              <div className="whitespace-nowrap text-xs text-muted-foreground">
-                {formatThreadTime(data.node.createdAt, 'Asked')}
-              </div>
-            </div>
+          <div className="mt-1 truncate whitespace-nowrap text-xs text-muted-foreground">
+            {formatThreadTime(data.node.createdAt, 'Asked')}
           </div>
         </div>
         {!!onDeleteThread && (


### PR DESCRIPTION
## Changes
1. fix text overflow
2. adjust spacing and element structure

## Screenshot
### Before
<img width="365" alt="image" src="https://github.com/user-attachments/assets/525c049d-4502-4006-b473-e15247881bb6" />

### After
<img width="363" alt="image" src="https://github.com/user-attachments/assets/744989b5-053a-42ae-bfca-56c21dacbb36" />
