### PR TITLE
ci: use the built-in rustup in action image for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,19 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
+        if: runner.os != 'Windows'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.target }}
           components: clippy
+
+      - name: Install Rust for Windows
+        if: runner.os == 'Windows'
+        run: |
+          rustup update --no-self-update ${{ env.RUST_TOOLCHAIN }}
+          rustup target add ${{ matrix.target }}
+          rustup component add clippy --toolchain ${{ env.RUST_TOOLCHAIN }}
 
       - name: Set default rust version
         run: rustup default ${{ env.RUST_TOOLCHAIN }}
@@ -195,11 +203,19 @@ jobs:
           submodules: recursive
 
       - name: Install Rust
+        if: runner.os != 'Windows'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.target }}
           components: clippy
+
+      - name: Install Rust for Windows
+        if: runner.os == 'Windows'
+        run: |
+          rustup update --no-self-update ${{ env.RUST_TOOLCHAIN }}
+          rustup target add ${{ matrix.target }}
+          rustup component add clippy --toolchain ${{ env.RUST_TOOLCHAIN }}
 
       - name: Set default rust version
         run: rustup default ${{ env.RUST_TOOLCHAIN }}


### PR DESCRIPTION
fix rustup occasionally failed: https://github.com/TabbyML/tabby/actions/runs/13762221751/job/38482680186

test: https://github.com/zwpaper/tabby/actions/runs/13765096184

ref: https://github.com/rust-lang/rust-analyzer/blob/be4899335135db60f0b12cb0d802c7fc5872aab9/.github/workflows/ci.yaml#L54