### PR TITLE
fix(crawler): update URL handling for llms-full.txt 

### DIFF
--- a/crates/tabby-crawler/src/lib.rs
+++ b/crates/tabby-crawler/src/lib.rs
@@ -160,10 +160,16 @@ pub async fn crawler_llms(start_url: &str) -> anyhow::Result<Vec<CrawledDocument
     // Remove trailing slash from the base URL if present.
     let base_url = start_url.trim_end_matches('/');
 
-    let llms_full_url = format!("{}/llms-full.txt", base_url);
+    // Check if the URL already ends with llms-full.txt
+    let llms_full_url = if base_url.ends_with("llms-full.txt") {
+        base_url.to_string()
+    } else {
+        format!("{}/llms-full.txt", base_url)
+    };
+
     let resp = reqwest::get(&llms_full_url).await?;
     if !resp.status().is_success() {
-        anyhow::bail!("Unable to fetch llms-full.txt from {}", base_url);
+        anyhow::bail!("Unable to fetch llms-full.txt from {}", llms_full_url);
     }
     let body = resp.text().await?;
     debug!("Successfully fetched llms-full.txt: {}", llms_full_url);
@@ -171,7 +177,7 @@ pub async fn crawler_llms(start_url: &str) -> anyhow::Result<Vec<CrawledDocument
     // Split the fetched markdown content into sections.
     let docs = llms_txt_parser::split_llms_content(&body, start_url);
     if docs.is_empty() {
-        anyhow::bail!("No sections found in llms-full.txt from {}", base_url);
+        anyhow::bail!("No sections found in llms-full.txt from {}", llms_full_url);
     }
 
     Ok(docs)

--- a/crates/tabby-crawler/src/lib.rs
+++ b/crates/tabby-crawler/src/lib.rs
@@ -160,9 +160,13 @@ pub async fn crawler_llms(start_url: &str) -> anyhow::Result<Vec<CrawledDocument
     // Remove trailing slash from the base URL if present.
     let base_url = start_url.trim_end_matches('/');
 
-    // Check if the URL already ends with llms-full.txt
+    // Check if the URL already ends with llms-full.txt or llms.txt
     let llms_full_url = if base_url.ends_with("llms-full.txt") {
         base_url.to_string()
+    } else if base_url.ends_with("llms.txt") {
+        // If URL ends with llms.txt, try to access llms-full.txt instead
+        let base_without_llms = base_url.trim_end_matches("llms.txt");
+        format!("{}llms-full.txt", base_without_llms)
     } else {
         format!("{}/llms-full.txt", base_url)
     };

--- a/ee/tabby-webserver/src/service/background_job/web_crawler.rs
+++ b/ee/tabby-webserver/src/service/background_job/web_crawler.rs
@@ -77,7 +77,7 @@ impl WebCrawlerJob {
                 return Ok(());
             }
             Err(_) => {
-                logkit::info!("/llms.txt is not available");
+                logkit::info!("/llms-full.txt is not available");
             }
         }
 


### PR DESCRIPTION
Fixed the output not correct, also adding attempt to llms-full.txt when the url endwith llms.txt

### before 
![image](https://github.com/user-attachments/assets/af485da6-1d5a-4f5c-8416-146a0111a691)

### After
![image](https://github.com/user-attachments/assets/502f8c55-415e-4bb7-b264-45a4c4a69daf)

### Other use case
start with base url: https://docs.verdn.com/
![image](https://github.com/user-attachments/assets/b4c72a7f-3be3-4076-a824-08271a5db2b8)

start with base url: https://docs.verdn.com/llms-full.txt
![image](https://github.com/user-attachments/assets/6eb9131a-d2fa-4a37-a5da-1ee8acc5ee40)

