### PR TITLE
chore(embedding): count prompt tokens and use newline to fulfill to 4…

### DIFF
--- a/crates/http-api-bindings/src/embedding/llama.rs
+++ b/crates/http-api-bindings/src/embedding/llama.rs
@@ -6,7 +6,7 @@ use tokio_retry::{
     strategy::{jitter, ExponentialBackoff},
     RetryIf,
 };
-use tracing::Instrument;
+use tracing::{info_span, Instrument};
 
 use crate::{create_reqwest_client, embedding_info_span};
 
@@ -30,17 +30,12 @@ impl LlamaCppEngine {
         before_b4356: bool,
     ) -> Box<dyn Embedding> {
         let client = create_reqwest_client(api_endpoint);
-        let api_endpoint = if before_b4356 {
-            format!("{}/embedding", api_endpoint)
-        } else {
-            format!("{}/embeddings", api_endpoint)
-        };
 
         Box::new(Self {
             before_b4356,
 
             client,
-            api_endpoint,
+            api_endpoint: api_endpoint.trim_end_matches("/").to_owned(),
             api_key,
         })
     }
@@ -64,6 +59,25 @@ struct EmbeddingLegacyResponse {
 #[async_trait]
 impl Embedding for LlamaCppEngine {
     async fn embed(&self, prompt: &str) -> anyhow::Result<Vec<f32>> {
+        // llama.cpp requires a minimum of 4 tokens to generate an embedding.
+        // Typically, `\n` counts as one token,
+        // so we append enough characters to make up for the shortfall
+        // ref: https://github.com/ggml-org/llama.cpp/issues/6722
+        //
+        // If tokenize failed, just use the prompt as is.
+        let prompt = match self.tokenize(prompt).await {
+            Ok(tokens) if tokens.len() < 4 => {
+                format!("{}{}", prompt, "\n".repeat(4 - tokens.len()))
+            }
+            _ => prompt.to_owned(),
+        };
+
+        let api_endpoint = if self.before_b4356 {
+            format!("{}/embedding", self.api_endpoint)
+        } else {
+            format!("{}/embeddings", self.api_endpoint)
+        };
+
         // Occasionally, when the embedding server has been idle for a period,
         // some of the concurrent initial requests to llama.cpp encounter problems,
         // resulting in failures with `Connection reset by peer` or `Broken pipe`.
@@ -78,7 +92,7 @@ impl Embedding for LlamaCppEngine {
                 let request = EmbeddingRequest {
                     content: prompt.to_owned(),
                 };
-                let mut request = self.client.post(&self.api_endpoint).json(&request);
+                let mut request = self.client.post(&api_endpoint).json(&request);
                 if let Some(api_key) = &self.api_key {
                     request = request.bearer_auth(api_key);
                 }
@@ -120,6 +134,47 @@ impl Embedding for LlamaCppEngine {
                 .ok_or_else(|| anyhow!("Error from server: no embedding found"))?
                 .clone())
         }
+    }
+}
+
+#[derive(Serialize)]
+struct TokenizeRequest {
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct TokenizeResponse {
+    tokens: Vec<i32>,
+}
+
+impl LlamaCppEngine {
+    async fn tokenize(&self, prompt: &str) -> anyhow::Result<Vec<i32>> {
+        let request = TokenizeRequest {
+            content: prompt.to_owned(),
+        };
+        let mut request = self
+            .client
+            .post(format!("{}/tokenize", &self.api_endpoint))
+            .json(&request);
+        if let Some(api_key) = &self.api_key {
+            request = request.bearer_auth(api_key);
+        }
+
+        let response = request
+            .send()
+            .instrument(info_span!("tokenize", kind = "llamacpp"))
+            .await?;
+        if !response.status().is_success() {
+            let error = response.text().await?;
+            return Err(anyhow::anyhow!(
+                "Error from server: {}, prompt length: {}",
+                error,
+                prompt.len()
+            ));
+        }
+
+        let response = response.json::<TokenizeResponse>().await?;
+        Ok(response.tokens)
     }
 }
 


### PR DESCRIPTION
… before sending to embedding in llama.cpp

before:
failed shortly after begin.

after:
long run.
![CleanShot 2025-03-12 at 16 13 24@2x](https://github.com/user-attachments/assets/d0e8483a-e79f-4eb8-828f-1509edf7b8a9)

debug output:
![CleanShot 2025-03-12 at 16 15 43@2x](https://github.com/user-attachments/assets/dba236b4-2a8d-4777-8026-8fa87763d959)

