### PR TITLE
feat(admin): add security option to hide password login in frontend

### DIFF
--- a/.changes/unreleased/Features-20250318-131219.yaml
+++ b/.changes/unreleased/Features-20250318-131219.yaml
@@ -1,3 +1,3 @@
 kind: Features
-body: Add security option to hide password login in frontend. When enabled, the password login can be revealed by appending the URL search parameter `password_sign_in=true`.
+body: Add security option to hide password login in frontend. When enabled, the password login can be revealed by appending the URL search parameter `passwordSignIn=true`.
 time: 2025-03-18T13:12:19.547444+08:00

--- a/.changes/unreleased/Features-20250318-131219.yaml
+++ b/.changes/unreleased/Features-20250318-131219.yaml
@@ -1,0 +1,3 @@
+kind: Features
+body: Add security option to hide password login in frontend. Reveal it by setting the URL search parameter `password_sign_in=true` when needed.
+time: 2025-03-18T13:12:19.547444+08:00

--- a/.changes/unreleased/Features-20250318-131219.yaml
+++ b/.changes/unreleased/Features-20250318-131219.yaml
@@ -1,3 +1,3 @@
 kind: Features
-body: Add security option to hide password login in frontend. Reveal it by setting the URL search parameter `password_sign_in=true` when needed.
+body: Add security option to hide password login in frontend. When enabled, the password login can be revealed by appending the URL search parameter `password_sign_in=true`.
 time: 2025-03-18T13:12:19.547444+08:00

--- a/ee/tabby-ui/app/(dashboard)/settings/general/components/security-form.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/general/components/security-form.tsx
@@ -46,6 +46,7 @@ export const securitySetting = graphql(/* GraphQL */ `
 
 const formSchema = z.object({
   disableClientSideTelemetry: z.boolean(),
+  disableNonSsoLogin: z.boolean(),
   // https://github.com/shadcn-ui/ui/issues/384
   // https://github.com/shadcn-ui/ui/blob/main/apps/www/app/examples/forms/profile-form.tsx
   allowedRegisterDomainList: z
@@ -144,6 +145,28 @@ const SecurityForm: React.FC<SecurityFormProps> = ({
                 <FormDescription>
                   When activated, the client-side telemetry (IDE/Extensions)
                   will be disabled, regardless of the client-side settings.
+                </FormDescription>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="disableNonSsoLogin"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-1">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel className="cursor-pointer">
+                    Disabling Non-SSO Logins
+                  </FormLabel>
+                </div>
+                <FormDescription>
+                  When activated, non-SSO logins will be hidden.
                 </FormDescription>
               </FormItem>
             )}

--- a/ee/tabby-ui/app/(dashboard)/settings/general/components/security-form.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/general/components/security-form.tsx
@@ -40,13 +40,14 @@ export const securitySetting = graphql(/* GraphQL */ `
     securitySetting {
       allowedRegisterDomainList
       disableClientSideTelemetry
+      disablePasswordLogin
     }
   }
 `)
 
 const formSchema = z.object({
   disableClientSideTelemetry: z.boolean(),
-  disableNonSsoLogin: z.boolean(),
+  disablePasswordLogin: z.boolean(),
   // https://github.com/shadcn-ui/ui/issues/384
   // https://github.com/shadcn-ui/ui/blob/main/apps/www/app/examples/forms/profile-form.tsx
   allowedRegisterDomainList: z
@@ -151,7 +152,7 @@ const SecurityForm: React.FC<SecurityFormProps> = ({
           />
           <FormField
             control={form.control}
-            name="disableNonSsoLogin"
+            name="disablePasswordLogin"
             render={({ field }) => (
               <FormItem>
                 <div className="flex items-center gap-1">

--- a/ee/tabby-ui/app/(dashboard)/settings/general/components/security-form.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/general/components/security-form.tsx
@@ -163,11 +163,11 @@ const SecurityForm: React.FC<SecurityFormProps> = ({
                     />
                   </FormControl>
                   <FormLabel className="cursor-pointer">
-                    Disabling Non-SSO Logins
+                    Disabling Password Login
                   </FormLabel>
                 </div>
                 <FormDescription>
-                  When activated, non-SSO logins will be hidden.
+                  When activated, password login will be hidden.
                 </FormDescription>
               </FormItem>
             )}

--- a/ee/tabby-ui/app/auth/signin/components/signin-section.tsx
+++ b/ee/tabby-ui/app/auth/signin/components/signin-section.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import Link from 'next/link'
 import { findIndex } from 'lodash-es'
 import { useQuery } from 'urql'
@@ -22,7 +22,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 import LdapSignInForm from './ldap-signin-form'
 import UserSignInForm from './user-signin-form'
-import LoadingWrapper from '@/components/loading-wrapper'
 
 const authProvidersQuery = graphql(/* GraphQL */ `
   query authProviders {
@@ -39,7 +38,8 @@ export default function SigninSection() {
   const errorMessage = searchParams.get('error_message')
   const accessToken = searchParams.get('access_token')
   const refreshToken = searchParams.get('refresh_token')
-  const passwordForceRender = searchParams.get('password_sign_in')?.toString() === 'true'
+  const passwordForceRender =
+    searchParams.get('password_sign_in')?.toString() === 'true'
   const shouldAutoSignin = !!accessToken && !!refreshToken
 
   const [{ data, fetching: fetchingAuthProviders }] = useQuery({
@@ -79,7 +79,6 @@ export default function SigninSection() {
       router.replace('/')
     }
   }, [status])
-
 
   // todo add fetching configuration
   const displayLoading =

--- a/ee/tabby-ui/app/auth/signin/components/signin-section.tsx
+++ b/ee/tabby-ui/app/auth/signin/components/signin-section.tsx
@@ -45,7 +45,7 @@ export default function SigninSection() {
   const accessToken = searchParams.get('access_token')
   const refreshToken = searchParams.get('refresh_token')
   const passwordForceRender =
-    searchParams.get('password_sign_in')?.toString() === 'true'
+    searchParams.get('passwordSignIn')?.toString() === 'true'
   const shouldAutoSignin = !!accessToken && !!refreshToken
 
   const [{ data, fetching: fetchingAuthProviders }] = useQuery({

--- a/ee/tabby-ui/lib/hooks/use-server-info.ts
+++ b/ee/tabby-ui/lib/hooks/use-server-info.ts
@@ -10,6 +10,7 @@ export const getServerInfo = graphql(/* GraphQL */ `
       isChatEnabled
       allowSelfSignup
       isDemoMode
+      disablePasswordLogin
     }
   }
 `)
@@ -44,11 +45,17 @@ const useIsDemoMode = () => {
   return useServerInfo()?.isDemoMode
 }
 
+const useIsDisablePasswordLogin = () => {
+  return useServerInfo()?.disablePasswordLogin
+}
+
 export {
+  useServerInfo,
   useIsChatEnabled,
   useIsAdminInitialized,
   useIsEmailConfigured,
   useAllowSelfSignup,
   useIsDemoMode,
-  useIsFetchingServerInfo
+  useIsFetchingServerInfo,
+  useIsDisablePasswordLogin
 }


### PR DESCRIPTION
## Changes
### 1. Add security option to hide password login in frontend
<img width="1191" alt="image" src="https://github.com/user-attachments/assets/af1e161b-ee2c-472f-ad8d-be2881121262" />


If password login is hidden and LDAP is configured, then only LDAP login is displayed.
<img width="483" alt="image" src="https://github.com/user-attachments/assets/9dd306cc-66d2-4faf-bb9e-4575e54d8f21" />

### 2. Show password with searchParams.
When password login is disabled in settings, it can be forcibly displayed by using the search parameter `passwordSignIn=true`.

<img width="470" alt="image" src="https://github.com/user-attachments/assets/ddb87df0-13af-4d80-a2aa-bd4b208b34ae" />

