### PR TITLE
chore: release 0.27.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "aim-downloader"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "async-stream",
  "clap",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "hash-ids"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 
 [[package]]
 name = "hashbrown"
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "http-api-bindings"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -2641,7 +2641,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "llama-cpp-server"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "ollama-api-bindings"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-migrate-validate"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "tabby"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-common"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-crawler"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-db"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-db-macros"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "quote",
  "syn 2.0.66",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-download"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "aim-downloader",
  "anyhow",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-git"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5463,7 +5463,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-index"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-index-cli"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-inference"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-schema"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-webserver"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 edition = "2021"
 authors = ["TabbyML Team"]
 homepage = "https://github.com/TabbyML/tabby"

--- a/crates/tabby-download/Cargo.toml
+++ b/crates/tabby-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabby-download"
-version = "0.26.0-dev.0"
+version = "0.27.0-dev.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
aim-downloader@0.27.0-dev.0
hash-ids@0.27.0-dev.0
http-api-bindings@0.27.0-dev.0
llama-cpp-server@0.27.0-dev.0
ollama-api-bindings@0.27.0-dev.0
sqlx-migrate-validate@0.27.0-dev.0
tabby@0.27.0-dev.0
tabby-common@0.27.0-dev.0
tabby-crawler@0.27.0-dev.0
tabby-db@0.27.0-dev.0
tabby-db-macros@0.27.0-dev.0
tabby-download@0.27.0-dev.0
tabby-git@0.27.0-dev.0
tabby-index@0.27.0-dev.0
tabby-index-cli@0.27.0-dev.0
tabby-inference@0.27.0-dev.0
tabby-schema@0.27.0-dev.0
tabby-webserver@0.27.0-dev.0

Generated by cargo-workspaces