### PR TITLE
feat(ui): Added UI component for reasoning models

### DIFF
--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -174,7 +174,7 @@ export function MessageMarkdown({
     // Add think placeholders to the matches.
     findMatches(
       MARKDOWN_THINK_REGEX,
-      ThinkPlaceholder,
+      ThinkBlock,
       (match: RegExpExecArray) => ({
         content: decodeURIComponent(match[1])
       })
@@ -406,7 +406,7 @@ export function ErrorMessageBlock({
   )
 }
 
-function ThinkPlaceholder({ content }: { content: string }): JSX.Element {
+function ThinkBlock({ content }: { content: string }): JSX.Element {
   return (
     <details
       open

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -411,15 +411,15 @@ function ThinkPlaceholder({ content }: { content: string }): JSX.Element {
     <details
       open
       className={`
-        my-4 w-full rounded-md border p-3 text-sm 
-        border-gray-300 bg-white text-gray-800
+        my-4 w-full rounded-md border border-gray-300 bg-white 
+        p-3 text-sm text-gray-800
         dark:border-zinc-700 dark:bg-zinc-900 dark:text-gray-100
       `}
     >
       <summary
         className={`
-          cursor-pointer list-none font-semibold outline-none 
-          text-gray-600 dark:text-gray-300
+          cursor-pointer list-none font-semibold text-gray-600 
+          outline-none dark:text-gray-300
         `}
       >
         Thinking

--- a/ee/tabby-ui/lib/constants/regex.ts
+++ b/ee/tabby-ui/lib/constants/regex.ts
@@ -7,7 +7,7 @@ export const PLACEHOLDER_SYMBOL_REGEX = /\[\[symbol:\s*({.*?})\]\]/g
 export const MARKDOWN_SYMBOL_REGEX = /\[\[symbol:\s*([^\]]+)\]\]/g
 export const PLACEHOLDER_COMMAND_REGEX = /\[\[contextCommand:\s*"(.+?)"\]\]/g
 export const MARKDOWN_COMMAND_REGEX = /\[\[contextCommand:\s*([^\]]+)\]\]/g
-export const PLACEHOLDER_THINK_REGEX = /\s*<think>([\s\S]*?)(?:<\/think>|$)\s*/g;
-export const MARKDOWN_THINK_REGEX = /\[\[think:([\s\S]*?)\]\]/g;
+export const PLACEHOLDER_THINK_REGEX = /\s*<think>([\s\S]*?)(?:<\/think>|$)\s*/g
+export const MARKDOWN_THINK_REGEX = /\[\[think:([\s\S]*?)\]\]/g
 
 export const DIFF_CHANGES_REGEX = /```diff label=changes[\s\S]*?```/g

--- a/ee/tabby-ui/lib/constants/regex.ts
+++ b/ee/tabby-ui/lib/constants/regex.ts
@@ -7,5 +7,7 @@ export const PLACEHOLDER_SYMBOL_REGEX = /\[\[symbol:\s*({.*?})\]\]/g
 export const MARKDOWN_SYMBOL_REGEX = /\[\[symbol:\s*([^\]]+)\]\]/g
 export const PLACEHOLDER_COMMAND_REGEX = /\[\[contextCommand:\s*"(.+?)"\]\]/g
 export const MARKDOWN_COMMAND_REGEX = /\[\[contextCommand:\s*([^\]]+)\]\]/g
+export const PLACEHOLDER_THINK_REGEX = /\s*<think>([\s\S]*?)(?:<\/think>|$)\s*/g;
+export const MARKDOWN_THINK_REGEX = /\[\[think:([\s\S]*?)\]\]/g;
 
 export const DIFF_CHANGES_REGEX = /```diff label=changes[\s\S]*?```/g

--- a/ee/tabby-ui/lib/utils/chat.ts
+++ b/ee/tabby-ui/lib/utils/chat.ts
@@ -15,7 +15,7 @@ import {
   PLACEHOLDER_COMMAND_REGEX,
   PLACEHOLDER_FILE_REGEX,
   PLACEHOLDER_SYMBOL_REGEX,
-  PLACEHOLDER_THINK_REGEX,
+  PLACEHOLDER_THINK_REGEX
 } from '../constants/regex'
 import { convertContextBlockToLabelName } from './markdown'
 
@@ -233,9 +233,9 @@ export function encodeMentionPlaceHolder(value: string): string {
       newValue = newValue.replace(
         match[0],
         `[[think:${encodeURIComponent(match[1])}]]\n`
-      );
+      )
     } catch (error) {
-      continue;
+      continue
     }
   }
 

--- a/ee/tabby-ui/lib/utils/chat.ts
+++ b/ee/tabby-ui/lib/utils/chat.ts
@@ -1,22 +1,31 @@
 import { uniq } from 'lodash-es'
 import moment from 'moment'
-import type { Filepath } from 'tabby-chat-panel'
-
+import type {
+  ChangeItem,
+  Filepath,
+  FileRange,
+  GetChangesParams
+} from 'tabby-chat-panel'
 import {
   ContextInfo,
   ContextSource,
   ContextSourceKind
 } from '@/lib/gql/generates/graphql'
 import type { MentionAttributes } from '@/lib/types'
+import {
+  convertChangeItemsToContextContent,
+  hasChangesCommand
+} from '@/components/chat/git/utils'
 
 import {
   MARKDOWN_FILE_REGEX,
   MARKDOWN_SOURCE_REGEX,
   PLACEHOLDER_COMMAND_REGEX,
   PLACEHOLDER_FILE_REGEX,
-  PLACEHOLDER_SYMBOL_REGEX
+  PLACEHOLDER_SYMBOL_REGEX,
+  PLACEHOLDER_THINK_REGEX,
 } from '../constants/regex'
-import { convertContextBlockToLabelName } from './markdown'
+import { convertContextBlockToPlaceholder } from './markdown'
 
 export const isCodeSourceContext = (kind: ContextSourceKind) => {
   return [
@@ -192,43 +201,60 @@ export function replaceAtMentionPlaceHolder(value: string) {
  * @returns
  */
 export function encodeMentionPlaceHolder(value: string): string {
-  let newValue = value
-  let match
-  while ((match = PLACEHOLDER_FILE_REGEX.exec(value)) !== null) {
+  let newValue = value;
+
+  // Process file placeholders.
+  let match;
+  while ((match = PLACEHOLDER_FILE_REGEX.exec(newValue)) !== null) {
     try {
       newValue = newValue.replace(
         match[0],
         `[[file:${encodeURIComponent(match[1])}]]`
-      )
+      );
     } catch (error) {
-      continue
+      continue;
     }
   }
-  while ((match = PLACEHOLDER_SYMBOL_REGEX.exec(value)) !== null) {
+  // Process symbol placeholders.
+  while ((match = PLACEHOLDER_SYMBOL_REGEX.exec(newValue)) !== null) {
     try {
       newValue = newValue.replace(
         match[0],
         `[[symbol:${encodeURIComponent(match[1])}]]`
-      )
+      );
     } catch (error) {
-      continue
+      continue;
     }
   }
-
-  // encode the contextCommand placeholder
-  while ((match = PLACEHOLDER_COMMAND_REGEX.exec(value)) !== null) {
+  // Process context command placeholders.
+  while ((match = PLACEHOLDER_COMMAND_REGEX.exec(newValue)) !== null) {
     try {
       newValue = newValue.replace(
         match[0],
         `[[contextCommand:"${encodeURIComponent(match[1])}"]]`
-      )
+      );
     } catch (error) {
-      continue
+      continue;
     }
   }
 
-  return newValue
+  // Process <think> placeholders similar to other placeholders.
+  while ((match = PLACEHOLDER_THINK_REGEX.exec(newValue)) !== null) {
+    try {
+      newValue = newValue.replace(
+        match[0],
+        `[[think:${encodeURIComponent(match[1])}]]\n`
+      );
+    } catch (error) {
+      continue;
+    }
+  }
+
+
+  return newValue;
 }
+
+
 
 export function formatThreadTime(time: string, prefix: string) {
   const targetTime = moment(time)
@@ -251,7 +277,7 @@ export function getTitleFromMessages(
   content: string,
   options?: { maxLength?: number }
 ) {
-  const processedContent = convertContextBlockToLabelName(content)
+  const processedContent = convertContextBlockToPlaceholder(content)
   const firstLine = processedContent.split('\n')[0] ?? ''
 
   const cleanedLine = firstLine
@@ -277,7 +303,7 @@ export function getTitleFromMessages(
       }
     })
     .replace(PLACEHOLDER_COMMAND_REGEX, value => {
-      const command = value.slice(19, -3)
+      const command = value.slice(18, -3)
       return `@${command}`
     })
     .replace(PLACEHOLDER_SYMBOL_REGEX, value => {
@@ -300,4 +326,91 @@ export function getTitleFromMessages(
     title = title.slice(0, options?.maxLength)
   }
   return title
+}
+
+/**
+ * Process all placeholders in a message and replace them with actual content
+ * @param message The original message containing placeholders
+ * @param options Various handlers for different types of placeholders
+ * @returns The processed message with all placeholders replaced
+ */
+export async function processingPlaceholder(
+  message: string,
+  options: {
+    getChanges?: (params: GetChangesParams) => Promise<ChangeItem[]>
+    readFileContent?: (info: FileRange) => Promise<string | null>
+  }
+): Promise<string> {
+  let processedMessage = message
+  if (hasChangesCommand(processedMessage) && options.getChanges) {
+    try {
+      const changes = await options.getChanges({})
+      const gitChanges = convertChangeItemsToContextContent(changes)
+      processedMessage = processedMessage.replaceAll(
+        /\[\[contextCommand:"changes"\]\]/g,
+        gitChanges
+      )
+    } catch (error) {
+      processedMessage = processedMessage.replaceAll(
+        /\[\[contextCommand:"changes"\]\]/g,
+        ''
+      )
+    }
+  }
+  if (options.readFileContent) {
+    const fileRegex = new RegExp(PLACEHOLDER_FILE_REGEX)
+    let match
+    let tempMessage = processedMessage
+    while ((match = fileRegex.exec(tempMessage)) !== null) {
+      try {
+        const fileInfoStr = match[1]
+        const fileInfo = JSON.parse(fileInfoStr) as Filepath
+        const content = await options.readFileContent({
+          filepath: fileInfo,
+          range: undefined
+        })
+        let replacement = ''
+        if (content) {
+          const fileInfoJSON = JSON.stringify(fileInfo).replace(/"/g, '\\"')
+          replacement = `\n\`\`\`context label='file' object='${fileInfoJSON}'\n${content}\n\`\`\`\n`
+        }
+        processedMessage = processedMessage.replace(match[0], replacement)
+        tempMessage = tempMessage.replace(match[0], replacement)
+        fileRegex.lastIndex = 0
+      } catch (error) {
+        const errorMessage = `\n*Error loading file*\n`
+        processedMessage = processedMessage.replace(match[0], errorMessage)
+        tempMessage = tempMessage.replace(match[0], errorMessage)
+        fileRegex.lastIndex = 0
+      }
+    }
+
+    const symbolRegex = new RegExp(PLACEHOLDER_SYMBOL_REGEX)
+    match = null
+    tempMessage = processedMessage
+    while ((match = symbolRegex.exec(tempMessage)) !== null) {
+      try {
+        const symbolInfoStr = match[1]
+        const symbolInfo = JSON.parse(symbolInfoStr)
+        const content = await options.readFileContent({
+          filepath: symbolInfo.filepath,
+          range: symbolInfo.range
+        })
+        let replacement = ''
+        if (content) {
+          const symbolInfoJSON = JSON.stringify(symbolInfo).replace(/"/g, '\\"')
+          replacement = `\n\`\`\`context label='symbol' object='${symbolInfoJSON}'\n${content}\n\`\`\`\n`
+        }
+        processedMessage = processedMessage.replace(match[0], replacement)
+        tempMessage = tempMessage.replace(match[0], replacement)
+        symbolRegex.lastIndex = 0
+      } catch (error) {
+        const errorMessage = `\n*Error loading symbol*\n`
+        processedMessage = processedMessage.replace(match[0], errorMessage)
+        tempMessage = tempMessage.replace(match[0], errorMessage)
+        symbolRegex.lastIndex = 0
+      }
+    }
+  }
+  return processedMessage
 }

--- a/ee/tabby-ui/lib/utils/chat.ts
+++ b/ee/tabby-ui/lib/utils/chat.ts
@@ -1,21 +1,13 @@
 import { uniq } from 'lodash-es'
 import moment from 'moment'
-import type {
-  ChangeItem,
-  Filepath,
-  FileRange,
-  GetChangesParams
-} from 'tabby-chat-panel'
+import type { Filepath } from 'tabby-chat-panel'
+
 import {
   ContextInfo,
   ContextSource,
   ContextSourceKind
 } from '@/lib/gql/generates/graphql'
 import type { MentionAttributes } from '@/lib/types'
-import {
-  convertChangeItemsToContextContent,
-  hasChangesCommand
-} from '@/components/chat/git/utils'
 
 import {
   MARKDOWN_FILE_REGEX,
@@ -25,7 +17,7 @@ import {
   PLACEHOLDER_SYMBOL_REGEX,
   PLACEHOLDER_THINK_REGEX,
 } from '../constants/regex'
-import { convertContextBlockToPlaceholder } from './markdown'
+import { convertContextBlockToLabelName } from './markdown'
 
 export const isCodeSourceContext = (kind: ContextSourceKind) => {
   return [
@@ -201,44 +193,41 @@ export function replaceAtMentionPlaceHolder(value: string) {
  * @returns
  */
 export function encodeMentionPlaceHolder(value: string): string {
-  let newValue = value;
-
-  // Process file placeholders.
-  let match;
-  while ((match = PLACEHOLDER_FILE_REGEX.exec(newValue)) !== null) {
+  let newValue = value
+  let match
+  while ((match = PLACEHOLDER_FILE_REGEX.exec(value)) !== null) {
     try {
       newValue = newValue.replace(
         match[0],
         `[[file:${encodeURIComponent(match[1])}]]`
-      );
+      )
     } catch (error) {
-      continue;
+      continue
     }
   }
-  // Process symbol placeholders.
-  while ((match = PLACEHOLDER_SYMBOL_REGEX.exec(newValue)) !== null) {
+  while ((match = PLACEHOLDER_SYMBOL_REGEX.exec(value)) !== null) {
     try {
       newValue = newValue.replace(
         match[0],
         `[[symbol:${encodeURIComponent(match[1])}]]`
-      );
+      )
     } catch (error) {
-      continue;
+      continue
     }
   }
-  // Process context command placeholders.
-  while ((match = PLACEHOLDER_COMMAND_REGEX.exec(newValue)) !== null) {
+
+  // encode the contextCommand placeholder
+  while ((match = PLACEHOLDER_COMMAND_REGEX.exec(value)) !== null) {
     try {
       newValue = newValue.replace(
         match[0],
         `[[contextCommand:"${encodeURIComponent(match[1])}"]]`
-      );
+      )
     } catch (error) {
-      continue;
+      continue
     }
   }
 
-  // Process <think> placeholders similar to other placeholders.
   while ((match = PLACEHOLDER_THINK_REGEX.exec(newValue)) !== null) {
     try {
       newValue = newValue.replace(
@@ -250,11 +239,8 @@ export function encodeMentionPlaceHolder(value: string): string {
     }
   }
 
-
-  return newValue;
+  return newValue
 }
-
-
 
 export function formatThreadTime(time: string, prefix: string) {
   const targetTime = moment(time)
@@ -277,7 +263,7 @@ export function getTitleFromMessages(
   content: string,
   options?: { maxLength?: number }
 ) {
-  const processedContent = convertContextBlockToPlaceholder(content)
+  const processedContent = convertContextBlockToLabelName(content)
   const firstLine = processedContent.split('\n')[0] ?? ''
 
   const cleanedLine = firstLine
@@ -303,7 +289,7 @@ export function getTitleFromMessages(
       }
     })
     .replace(PLACEHOLDER_COMMAND_REGEX, value => {
-      const command = value.slice(18, -3)
+      const command = value.slice(19, -3)
       return `@${command}`
     })
     .replace(PLACEHOLDER_SYMBOL_REGEX, value => {
@@ -326,91 +312,4 @@ export function getTitleFromMessages(
     title = title.slice(0, options?.maxLength)
   }
   return title
-}
-
-/**
- * Process all placeholders in a message and replace them with actual content
- * @param message The original message containing placeholders
- * @param options Various handlers for different types of placeholders
- * @returns The processed message with all placeholders replaced
- */
-export async function processingPlaceholder(
-  message: string,
-  options: {
-    getChanges?: (params: GetChangesParams) => Promise<ChangeItem[]>
-    readFileContent?: (info: FileRange) => Promise<string | null>
-  }
-): Promise<string> {
-  let processedMessage = message
-  if (hasChangesCommand(processedMessage) && options.getChanges) {
-    try {
-      const changes = await options.getChanges({})
-      const gitChanges = convertChangeItemsToContextContent(changes)
-      processedMessage = processedMessage.replaceAll(
-        /\[\[contextCommand:"changes"\]\]/g,
-        gitChanges
-      )
-    } catch (error) {
-      processedMessage = processedMessage.replaceAll(
-        /\[\[contextCommand:"changes"\]\]/g,
-        ''
-      )
-    }
-  }
-  if (options.readFileContent) {
-    const fileRegex = new RegExp(PLACEHOLDER_FILE_REGEX)
-    let match
-    let tempMessage = processedMessage
-    while ((match = fileRegex.exec(tempMessage)) !== null) {
-      try {
-        const fileInfoStr = match[1]
-        const fileInfo = JSON.parse(fileInfoStr) as Filepath
-        const content = await options.readFileContent({
-          filepath: fileInfo,
-          range: undefined
-        })
-        let replacement = ''
-        if (content) {
-          const fileInfoJSON = JSON.stringify(fileInfo).replace(/"/g, '\\"')
-          replacement = `\n\`\`\`context label='file' object='${fileInfoJSON}'\n${content}\n\`\`\`\n`
-        }
-        processedMessage = processedMessage.replace(match[0], replacement)
-        tempMessage = tempMessage.replace(match[0], replacement)
-        fileRegex.lastIndex = 0
-      } catch (error) {
-        const errorMessage = `\n*Error loading file*\n`
-        processedMessage = processedMessage.replace(match[0], errorMessage)
-        tempMessage = tempMessage.replace(match[0], errorMessage)
-        fileRegex.lastIndex = 0
-      }
-    }
-
-    const symbolRegex = new RegExp(PLACEHOLDER_SYMBOL_REGEX)
-    match = null
-    tempMessage = processedMessage
-    while ((match = symbolRegex.exec(tempMessage)) !== null) {
-      try {
-        const symbolInfoStr = match[1]
-        const symbolInfo = JSON.parse(symbolInfoStr)
-        const content = await options.readFileContent({
-          filepath: symbolInfo.filepath,
-          range: symbolInfo.range
-        })
-        let replacement = ''
-        if (content) {
-          const symbolInfoJSON = JSON.stringify(symbolInfo).replace(/"/g, '\\"')
-          replacement = `\n\`\`\`context label='symbol' object='${symbolInfoJSON}'\n${content}\n\`\`\`\n`
-        }
-        processedMessage = processedMessage.replace(match[0], replacement)
-        tempMessage = tempMessage.replace(match[0], replacement)
-        symbolRegex.lastIndex = 0
-      } catch (error) {
-        const errorMessage = `\n*Error loading symbol*\n`
-        processedMessage = processedMessage.replace(match[0], errorMessage)
-        tempMessage = tempMessage.replace(match[0], errorMessage)
-        symbolRegex.lastIndex = 0
-      }
-    }
-  }
-  return processedMessage
 }


### PR DESCRIPTION
Related issue #3977 

Adds a collapsible section that contains the reasoning steps of models such as deepseek-r1. 
https://jam.dev/c/56380060-dbfa-4746-9cbd-f41ee3a4375c

Has light and dark variation.
Currently unable to collapse component during reasoning.

Before:
<img width="935" alt="image" src="https://github.com/user-attachments/assets/e21a770a-b4db-4dd4-9b28-a6e6f0657dd4" />


