### PR TITLE
feat(language): Add Scala support with tree-sitter parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5499,6 +5499,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scala",
  "tree-sitter-solidity",
  "tree-sitter-tags",
  "tree-sitter-typescript",
@@ -6477,6 +6478,16 @@ name = "tree-sitter-rust"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "277690f420bf90741dea984f3da038ace46c4fe6047cba57a66822226cde1c93"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a464d8e2e1837cf20b34204c51c369da3483e55c3ea013c6db81a04439e17895"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/tabby-common/assets/languages.toml
+++ b/crates/tabby-common/assets/languages.toml
@@ -355,7 +355,44 @@ exts = ["sql"]
 
 [[config]]
 languages = ["scala"]
-exts = ["scala"]
+exts = ["scala", "sbt"]
+line_comment = "//"
+top_level_keywords = [
+    "abstract",
+    "case",
+    "class",
+    "def",
+    "do",
+    "else",
+    "enum",
+    "extends",
+    "final",
+    "for",
+    "given",
+    "if",
+    "implicit",
+    "import",
+    "lazy",
+    "match",
+    "new",
+    "object",
+    "override",
+    "package",
+    "private",
+    "protected",
+    "return",
+    "sealed",
+    "then",
+    "throw",
+    "trait",
+    "try",
+    "type",
+    "val",
+    "var",
+    "while",
+    "with",
+    "yield",
+]
 
 [[config]]
 languages = ["shellscript"]

--- a/crates/tabby-index/Cargo.toml
+++ b/crates/tabby-index/Cargo.toml
@@ -12,6 +12,7 @@ tantivy = { workspace = true }
 tracing = { workspace = true }
 tree-sitter-tags = "0.22.6"
 lazy_static = { workspace = true }
+tree-sitter-scala = "0.22.1"
 tree-sitter-python = "0.21.0"
 tree-sitter-java = "0.21.0"
 tree-sitter-kotlin = "0.3.6"

--- a/crates/tabby-index/queries/scala.scm
+++ b/crates/tabby-index/queries/scala.scm
@@ -1,0 +1,68 @@
+
+(class_definition
+  name: (identifier) @name) @definition.class
+
+(enum_definition
+  name: (identifier) @name) @definition.enum
+
+(object_definition
+  name: (identifier) @name) @definition.object
+
+(object_definition
+  name: (identifier) @name) @definition.trait
+
+
+(class_parameter
+  name: (identifier) @name) @definition.class_parameter
+
+(self_type (identifier) @name) @definition.parameter
+
+(type_definition
+  name: (type_identifier) @name) @definition.type
+
+
+(val_definition
+  pattern: (identifier) @name) @definition.val
+
+(var_definition
+  pattern: (identifier) @name) @definition.var
+
+(val_declaration
+  name: (identifier) @name) @definition.val_decl
+
+(var_declaration
+  name: (identifier) @name) @definition.var_decl
+
+
+
+(call_expression
+  function: (identifier) @name) @reference.call
+
+(call_expression
+  function: (operator_identifier) @name) @reference.call
+
+(call_expression
+  function: (field_expression
+    field: (identifier) @name)) @reference.call
+
+((call_expression
+   function: (identifier) @name)
+ (#match? @name "^[A-Z]")) @reference.constructor
+
+(generic_function
+  function: (identifier) @name) @reference.call
+
+(interpolated_string_expression
+  interpolator: (identifier) @name) @reference.call
+
+
+(function_definition
+  name: (identifier) @name) @definition.function
+
+
+(function_declaration
+      name: (identifier) @name) @definition.function
+
+(function_definition
+      name: (identifier) @name) @definition.function
+

--- a/crates/tabby-index/src/code/languages.rs
+++ b/crates/tabby-index/src/code/languages.rs
@@ -59,7 +59,7 @@ lazy_static! {
                     .unwrap(),
                 ),
             ),
-           (
+            (
                 "kotlin",
                 TagsConfigurationSync(
                     TagsConfiguration::new(

--- a/crates/tabby-index/src/code/languages.rs
+++ b/crates/tabby-index/src/code/languages.rs
@@ -49,6 +49,17 @@ lazy_static! {
                 ),
             ),
             (
+                "scala",
+                TagsConfigurationSync(
+                    TagsConfiguration::new(
+                        tree_sitter_scala::language(),
+                        include_str!("../../queries/scala.scm"),
+                        "",
+                    )
+                    .unwrap(),
+                ),
+            ),
+           (
                 "kotlin",
                 TagsConfigurationSync(
                     TagsConfiguration::new(

--- a/website/docs/references/programming-languages.md
+++ b/website/docs/references/programming-languages.md
@@ -39,6 +39,7 @@ For an actual example of an issue or pull request adding the above support, plea
 * [Elixir](https://elixir-lang.org)
 * [OCaml](https://ocaml.org/)
 * [GDScript](https://gdscript.com/)
+* [Scala](https://www.scala-lang.org/)
 
 ## Languages Missing Certain Support
 
@@ -48,4 +49,3 @@ For an actual example of an issue or pull request adding the above support, plea
 | Haskell  |                    🚫                    |                       🚫                        |
 |  Julia   |                    🚫                    |                       🚫                        |
 |   Perl   |                    🚫                    |                       🚫                        |
-|  Scala   |                    🚫                    |                       🚫                        |


### PR DESCRIPTION
This PR introduces syntax support for the Scala language. It expands the stop word list specifically for Scala and integrates syntax tree parsing via Tree-Sitter. These changes improve code analysis and facilitate more accurate completions when working with Scala source files.

Changes:
• Added Scala-specific stop words.  
• Integrated Tree-Sitter to parse Scala syntax trees.  
• Updated configuration to handle Scala language nuances.

Testing:
Tested against a range of small Scala code examples to ensure robust parsing and better code insights. No regressions detected.  

Thank you for reviewing this contribution!