### PR TITLE
fix(chat): set stream_options to None for mistral/chat request

### DIFF
--- a/crates/tabby-inference/src/chat.rs
+++ b/crates/tabby-inference/src/chat.rs
@@ -61,6 +61,7 @@ impl ExtendedOpenAIConfig {
             "mistral/chat" => {
                 request.presence_penalty = None;
                 request.user = None;
+                request.stream_options = None;
             }
             "openai/chat" => {
                 request = process_request_openai(request);


### PR DESCRIPTION
## Background
The Mistral API does not accept the `stream_options` field. When an API request contains this field, we cannot get any response.

![image](https://github.com/user-attachments/assets/d2c162ef-5c21-48f8-a31e-04fe4f57eeea)

Therefore, we have to remove the `stream_options` field whenever it is passed through an API request. The Mistral API by default includes usage information at the end of the stream.