### PR TITLE
feat(intellij): use ide proxy settings for tabby agent config

### DIFF
--- a/clients/intellij/build.gradle.kts
+++ b/clients/intellij/build.gradle.kts
@@ -73,7 +73,7 @@ tasks {
 
   register("buildDependencies") {
     exec {
-      commandLine("pnpm.cmd", "turbo", "build")
+      commandLine("pnpm", "turbo", "build")
     }
   }
 

--- a/clients/intellij/build.gradle.kts
+++ b/clients/intellij/build.gradle.kts
@@ -73,7 +73,7 @@ tasks {
 
   register("buildDependencies") {
     exec {
-      commandLine("pnpm", "turbo", "build")
+      commandLine("pnpm.cmd", "turbo", "build")
     }
   }
 
@@ -100,4 +100,3 @@ tasks {
     }
   }
 }
-


### PR DESCRIPTION
#4061 

Changes Made:
Added methods getProxyUrl and getProxyAuthorization to retrieve the proxy URL and authorization from IntelliJ's global proxy settings.

Updated buildClientProvidedConfig to include the proxy settings in the ClientProvidedConfig.ProxyConfig.