### PR TITLE
fix(completion): handle empty suffix and inline completion items

### DIFF
--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/completion/InlineCompletionRenderer.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/completion/InlineCompletionRenderer.kt
@@ -76,7 +76,7 @@ class InlineCompletionRenderer {
 
       val inlays = mutableListOf<Inlay<*>>()
       val markups = mutableListOf<RangeHighlighter>()
-      if (suffixReplaceLength == 0) {
+      if (suffixReplaceLength == 0 || currentLineSuffix.isEmpty()) {
         // No replace range to handle
         createInlayText(editor, textLines[0], offset, 0)?.let { inlays.add(it) }
         if (textLines.size > 1) {

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/completion/InlineCompletionService.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/completion/InlineCompletionService.kt
@@ -314,6 +314,9 @@ class InlineCompletionService(private val project: Project) : Disposable {
       val requestContext = InlineCompletionContext.Request.from(editor, offset).withManually(manually)
       val job = launchJobForInlineCompletion(requestContext) { inlineCompletionList ->
         synchronized(currentContextWriteLock) {
+          if (inlineCompletionList?.items?.isEmpty() == true) {
+            return@launchJobForInlineCompletion
+          }
           current = current?.withResponse(convertInlineCompletionList(inlineCompletionList, requestContext))
           renderCurrentResponse()
         }


### PR DESCRIPTION
## Description

Fixed issues with using accept:
- If the current line has only one suffix, an error will occur when using accept
- The completion chars may be filtered by `dropMinimum` in postprocess If there are only a few completion chars at the end
(Empty items skip the rendering process to be consistent with vscode)

## Screenshots
![bug0405](https://github.com/user-attachments/assets/8717de26-7102-42bb-b4ff-2b08a6b66832)

## Test
![fix0405](https://github.com/user-attachments/assets/25153fce-7870-4eef-9ab0-16021c2fa46e)
