### PR TITLE
refactor(mention-tag): enhance file path handling in mentions by inte…

### DIFF
--- a/ee/tabby-ui/components/mention-tag.tsx
+++ b/ee/tabby-ui/components/mention-tag.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from 'react'
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react'
+import { Filepath } from 'tabby-chat-panel/index'
 
 import {
   MARKDOWN_COMMAND_REGEX,
@@ -20,6 +21,8 @@ import {
   IconGitHub,
   IconGitLab
 } from '@/components/ui/icons'
+
+import { getFilepathStringByChatPanelFilePath } from './chat/form-editor/utils'
 
 export function Mention({
   kind,
@@ -108,8 +111,10 @@ export function ThreadTitleWithMentions({
       textPart = textPart.replace(MARKDOWN_FILE_REGEX, (match, content) => {
         try {
           if (content.startsWith('{') && content.endsWith('}')) {
-            const fileInfo = JSON.parse(content)
-            const filename = resolveFileNameForDisplay(fileInfo.filepath)
+            const fileInfo = JSON.parse(content) as Filepath
+            const filepathString =
+              getFilepathStringByChatPanelFilePath(fileInfo)
+            const filename = resolveFileNameForDisplay(filepathString)
             return `@${filename}`
           }
           // Otherwise just use the content as is
@@ -127,7 +132,10 @@ export function ThreadTitleWithMentions({
             if (symbolInfo.label) {
               return `@${symbolInfo.label}`
             }
-            const filename = resolveFileNameForDisplay(symbolInfo.filepath)
+            const filepathString = getFilepathStringByChatPanelFilePath(
+              symbolInfo.filepath
+            )
+            const filename = resolveFileNameForDisplay(filepathString)
             const range = symbolInfo.range
               ? `:${symbolInfo.range.start}-${symbolInfo.range.end}`
               : ''
@@ -143,6 +151,7 @@ export function ThreadTitleWithMentions({
         return `@${cmdPart.replace(/"/g, '')}`
       })
     })
+
     return finalContent
   }, [sources, message])
   return <div className={cn(className)}>{contentWithTags}</div>


### PR DESCRIPTION
I tested with two files: one from the current repository, which is maintained by Git, and another using an absolute filepath from ~/.tabby/config.toml. I realized that this is an issue with the Filepath interface parsing. Filepath utilities in tabby-server will be standardized in the next PR.

before
![image](https://github.com/user-attachments/assets/cf8dacfa-c82c-4069-9e82-79f6c6faaa88)
![image](https://github.com/user-attachments/assets/f03c9102-8e91-4c1e-a3dc-ae620e840f05)


after
![image](https://github.com/user-attachments/assets/c01bb959-5dfa-4ba2-b599-8b86c65d7e01)
![image](https://github.com/user-attachments/assets/b89d431c-9f94-4c5e-bec1-f8aa5b596f4e)    

