### PR TITLE
chore: optimize generate commit message regex match

### DIFF
--- a/clients/tabby-agent/src/config/default.test.ts
+++ b/clients/tabby-agent/src/config/default.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "chai";
+import { stringToRegExp } from "../utils/string";
+import { defaultConfigData } from "./default";
+
+describe("Config: generateCommitMessage.responseMatcher", () => {
+  // Test parameters
+  const responseMatcher = defaultConfigData.chat.generateCommitMessage.responseMatcher;
+  const regExp = stringToRegExp(responseMatcher);
+  
+  // Helper function for reusing test logic
+  function testResponseMatch(testCase: string, input: string, expectedMatch: string) {
+    it(testCase, () => {
+      const match = regExp.exec(input);
+      expect(match).to.not.be.null;
+      if (match) {
+        expect(match[1]).to.equal(expectedMatch);
+      }
+    });
+  }
+
+  // Core functionality: Extract commit message from simple response
+  testResponseMatch(
+    "test for extracting conventional commit message from simple response",
+    "Based on the diff, I would suggest the following commit message:\n\nfeat(core): add new feature\n",
+    "feat(core): add new feature"
+  );
+  
+  // Core functionality: Handle commit messages in code blocks
+  testResponseMatch(
+    "test for handling responses with code blocks",
+    `Based on the diff, here's an appropriate commit message:
+
+\`\`\`
+fix(auth): resolve user authentication timeout issue
+\`\`\`
+
+This commit message follows the conventional format with a 'fix' type and 'auth' scope.`,
+    "fix(auth): resolve user authentication timeout issue"
+  );
+
+  // Bug fix: Handle commit messages with double quotes
+  testResponseMatch(
+    "test for handling responses with double quotes",
+    `Based on the provided diff, I recommend using the following commit message:
+
+"docs(readme): update installation instructions"
+
+This commit message follows the conventional format and accurately describes the changes made to the documentation.`,
+    "docs(readme): update installation instructions"
+  );
+
+  // Bug fix: Handle commit messages with single quotes and backticks
+  testResponseMatch(
+    "test for handling responses with single quotes and backticks",
+    `Here are some commit message options:
+'chore(build): update dependencies'
+\`test(components): add unit tests for login form\``,
+    "chore(build): update dependencies"
+  );
+
+  // Bug fix: Handle responses with markdown images
+  testResponseMatch(
+    "test for handling responses with markdown images",
+    `Here's a diagram showing the changes you made:
+![Diagram](https://example.com/diagram.png)
+
+Based on the diff, I suggest the following commit message:
+
+feat(ui): improve button design and layout
+
+[Diagram]: https://example.com/diagram-ref.png`,
+    "feat(ui): improve button design and layout"
+  );
+}); 

--- a/clients/tabby-agent/src/config/default.test.ts
+++ b/clients/tabby-agent/src/config/default.test.ts
@@ -6,7 +6,7 @@ describe("Config: generateCommitMessage.responseMatcher", () => {
   // Test parameters
   const responseMatcher = defaultConfigData.chat.generateCommitMessage.responseMatcher;
   const regExp = stringToRegExp(responseMatcher);
-  
+
   // Helper function for reusing test logic
   function testResponseMatch(testCase: string, input: string, expectedMatch: string) {
     it(testCase, () => {
@@ -22,9 +22,9 @@ describe("Config: generateCommitMessage.responseMatcher", () => {
   testResponseMatch(
     "test for extracting conventional commit message from simple response",
     "Based on the diff, I would suggest the following commit message:\n\nfeat(core): add new feature\n",
-    "feat(core): add new feature"
+    "feat(core): add new feature",
   );
-  
+
   // Core functionality: Handle commit messages in code blocks
   testResponseMatch(
     "test for handling responses with code blocks",
@@ -35,7 +35,7 @@ fix(auth): resolve user authentication timeout issue
 \`\`\`
 
 This commit message follows the conventional format with a 'fix' type and 'auth' scope.`,
-    "fix(auth): resolve user authentication timeout issue"
+    "fix(auth): resolve user authentication timeout issue",
   );
 
   // Bug fix: Handle commit messages with double quotes
@@ -46,7 +46,7 @@ This commit message follows the conventional format with a 'fix' type and 'auth'
 "docs(readme): update installation instructions"
 
 This commit message follows the conventional format and accurately describes the changes made to the documentation.`,
-    "docs(readme): update installation instructions"
+    "docs(readme): update installation instructions",
   );
 
   // Bug fix: Handle commit messages with single quotes and backticks
@@ -55,7 +55,7 @@ This commit message follows the conventional format and accurately describes the
     `Here are some commit message options:
 'chore(build): update dependencies'
 \`test(components): add unit tests for login form\``,
-    "chore(build): update dependencies"
+    "chore(build): update dependencies",
   );
 
   // Bug fix: Handle responses with markdown images
@@ -69,6 +69,6 @@ Based on the diff, I suggest the following commit message:
 feat(ui): improve button design and layout
 
 [Diagram]: https://example.com/diagram-ref.png`,
-    "feat(ui): improve button design and layout"
+    "feat(ui): improve button design and layout",
   );
-}); 
+});

--- a/clients/tabby-agent/src/config/default.ts
+++ b/clients/tabby-agent/src/config/default.ts
@@ -103,7 +103,7 @@ export const defaultConfigData: ConfigData = {
       maxDiffLength: 3600,
       promptTemplate: generateCommitMessagePrompt,
       responseMatcher:
-        /^(?:(?!!\[|^\[.*\]:\s*http).*?)(?:["'`]?)?((?:feat|fix|docs|refactor|style|test|build|ci|chore)(?:\(\S+\))?:.+?)(?:["'`])?(?:\n|$)/mis.toString(),
+        /^(?:(?!!\[|^\[.*\]:\s*http).*?)(?:["'`]?)?((?:feat|fix|docs|refactor|style|test|build|ci|chore)(?:\(\S+\))?:.+?)(?:["'`])?(?:\n|$)/ims.toString(),
     },
     generateBranchName: {
       maxDiffLength: 3600,

--- a/clients/tabby-agent/src/config/default.ts
+++ b/clients/tabby-agent/src/config/default.ts
@@ -103,7 +103,7 @@ export const defaultConfigData: ConfigData = {
       maxDiffLength: 3600,
       promptTemplate: generateCommitMessagePrompt,
       responseMatcher:
-        /(?<=(["'`]+)?\s*)(feat|fix|docs|refactor|style|test|build|ci|chore)(\(\S+\))?:.+(?=\s*\1)/gis.toString(),
+        /^(?:(?!!\[|^\[.*\]:\s*http).*?)(?:["'`]?)?((?:feat|fix|docs|refactor|style|test|build|ci|chore)(?:\(\S+\))?:.+?)(?:["'`])?(?:\n|$)/mis.toString(),
     },
     generateBranchName: {
       maxDiffLength: 3600,


### PR DESCRIPTION
Sometimes the commit message with suffix markdown codeblock syntax

![image](https://github.com/user-attachments/assets/f3c9b400-4575-4748-a1a0-5ad8ee24e23c)


prevent it happen during regex level       
![image](https://github.com/user-attachments/assets/67a4fa6f-2f03-4d07-ae24-f4de41a0bdbe)
