### PR TITLE
feat(markdown): enhance formatting functions with newline options

### DIFF
--- a/ee/tabby-ui/lib/utils/chat.ts
+++ b/ee/tabby-ui/lib/utils/chat.ts
@@ -27,8 +27,10 @@ import {
 } from '../constants/regex'
 import {
   convertContextBlockToPlaceholder,
-  formatObjectToMarkdownBlock
-} from './markdown'
+  formatObjectToMarkdownBlock,
+  shouldAddPrefixNewline,
+  shouldAddSuffixNewline,
+} from '@/lib/utils/markdown'
 
 export const isCodeSourceContext = (kind: ContextSourceKind) => {
   return [
@@ -355,10 +357,18 @@ export async function processingPlaceholder(
           filepath: fileInfo,
           range: undefined
         })
+        
         let replacement = ''
         if (content) {
-          replacement = formatObjectToMarkdownBlock('file', fileInfo, content)
+          const matchIndex = match.index
+          const matchEnd = matchIndex + match[0].length
+          
+          replacement = formatObjectToMarkdownBlock('file', fileInfo, content, {
+            addPrefixNewline:  shouldAddPrefixNewline(matchIndex, processedMessage),
+            addSuffixNewline: shouldAddSuffixNewline(matchEnd, processedMessage)
+          })
         }
+        
         processedMessage = processedMessage.replace(match[0], replacement)
         tempMessage = tempMessage.replace(match[0], replacement)
         fileRegex.lastIndex = 0
@@ -381,14 +391,18 @@ export async function processingPlaceholder(
           filepath: symbolInfo.filepath,
           range: symbolInfo.range
         })
+        
         let replacement = ''
         if (content) {
-          replacement = formatObjectToMarkdownBlock(
-            'symbol',
-            symbolInfo,
-            content
-          )
+          const matchIndex = match.index
+          const matchEnd = matchIndex + match[0].length
+          
+          replacement = formatObjectToMarkdownBlock('symbol', symbolInfo, content, {
+            addPrefixNewline: shouldAddPrefixNewline(matchIndex, processedMessage),
+            addSuffixNewline: shouldAddSuffixNewline(matchEnd, processedMessage)
+          })
         }
+        
         processedMessage = processedMessage.replace(match[0], replacement)
         tempMessage = tempMessage.replace(match[0], replacement)
         symbolRegex.lastIndex = 0

--- a/ee/tabby-ui/lib/utils/chat.ts
+++ b/ee/tabby-ui/lib/utils/chat.ts
@@ -14,6 +14,12 @@ import {
 } from '@/lib/gql/generates/graphql'
 import type { MentionAttributes } from '@/lib/types'
 import {
+  convertContextBlockToPlaceholder,
+  formatObjectToMarkdownBlock,
+  shouldAddPrefixNewline,
+  shouldAddSuffixNewline
+} from '@/lib/utils/markdown'
+import {
   convertChangeItemsToContextContent,
   hasChangesCommand
 } from '@/components/chat/git/utils'
@@ -25,12 +31,6 @@ import {
   PLACEHOLDER_FILE_REGEX,
   PLACEHOLDER_SYMBOL_REGEX
 } from '../constants/regex'
-import {
-  convertContextBlockToPlaceholder,
-  formatObjectToMarkdownBlock,
-  shouldAddPrefixNewline,
-  shouldAddSuffixNewline,
-} from '@/lib/utils/markdown'
 
 export const isCodeSourceContext = (kind: ContextSourceKind) => {
   return [
@@ -357,18 +357,21 @@ export async function processingPlaceholder(
           filepath: fileInfo,
           range: undefined
         })
-        
+
         let replacement = ''
         if (content) {
           const matchIndex = match.index
           const matchEnd = matchIndex + match[0].length
-          
+
           replacement = formatObjectToMarkdownBlock('file', fileInfo, content, {
-            addPrefixNewline:  shouldAddPrefixNewline(matchIndex, processedMessage),
+            addPrefixNewline: shouldAddPrefixNewline(
+              matchIndex,
+              processedMessage
+            ),
             addSuffixNewline: shouldAddSuffixNewline(matchEnd, processedMessage)
           })
         }
-        
+
         processedMessage = processedMessage.replace(match[0], replacement)
         tempMessage = tempMessage.replace(match[0], replacement)
         fileRegex.lastIndex = 0
@@ -391,18 +394,29 @@ export async function processingPlaceholder(
           filepath: symbolInfo.filepath,
           range: symbolInfo.range
         })
-        
+
         let replacement = ''
         if (content) {
           const matchIndex = match.index
           const matchEnd = matchIndex + match[0].length
-          
-          replacement = formatObjectToMarkdownBlock('symbol', symbolInfo, content, {
-            addPrefixNewline: shouldAddPrefixNewline(matchIndex, processedMessage),
-            addSuffixNewline: shouldAddSuffixNewline(matchEnd, processedMessage)
-          })
+
+          replacement = formatObjectToMarkdownBlock(
+            'symbol',
+            symbolInfo,
+            content,
+            {
+              addPrefixNewline: shouldAddPrefixNewline(
+                matchIndex,
+                processedMessage
+              ),
+              addSuffixNewline: shouldAddSuffixNewline(
+                matchEnd,
+                processedMessage
+              )
+            }
+          )
         }
-        
+
         processedMessage = processedMessage.replace(match[0], replacement)
         tempMessage = tempMessage.replace(match[0], replacement)
         symbolRegex.lastIndex = 0

--- a/ee/tabby-ui/lib/utils/markdown.ts
+++ b/ee/tabby-ui/lib/utils/markdown.ts
@@ -245,14 +245,17 @@ export function formatObjectToMarkdownBlock(
  */
 export function shouldAddPrefixNewline(index: number, text: string): boolean {
   if (index === 0) return false
-  
+
   let i = index - 1
   while (i >= 0) {
     if (text[i] === '\n') return false
+    if (text[i] === '\r' && i + 1 < text.length && text[i + 1] === '\n') return false
+
     if (!/\s/.test(text[i])) return true
+
     i--
   }
-  
+
   return false
 }
 
@@ -265,16 +268,19 @@ export function shouldAddPrefixNewline(index: number, text: string): boolean {
 export function shouldAddSuffixNewline(index: number, text: string): boolean {
   const len = text.length
   if (index >= len) return false
-  
+
   let i = index
   while (i < len) {
     if (text[i] === '\n') return false
+    if (text[i] === '\r' && i + 1 < len && text[i + 1] === '\n') return false
+
     if (!/\s/.test(text[i])) return true
     i++
   }
-  
+
   return false
 }
+
 
 export interface PlaceholderNode extends Node {
   type: 'placeholder'

--- a/ee/tabby-ui/lib/utils/markdown.ts
+++ b/ee/tabby-ui/lib/utils/markdown.ts
@@ -254,8 +254,9 @@ export function shouldAddPrefixNewline(index: number, text: string): boolean {
   let i = index - 1
   while (i >= 0) {
     if (text[i] === '\n') return false
-    if (text[i] === '\r' && i + 1 < text.length && text[i + 1] === '\n')
+    if (text[i] === '\r' && i + 1 < text.length && text[i + 1] === '\n') {
       return false
+    }
 
     if (!/\s/.test(text[i])) return true
 

--- a/ee/tabby-ui/lib/utils/markdown.ts
+++ b/ee/tabby-ui/lib/utils/markdown.ts
@@ -10,7 +10,7 @@ const REMARK_STRINGIFY_OPTIONS: Options = {
   tightDefinitions: true,
   handlers: {
     placeholder: (node: PlaceholderNode) => {
-      return node.value
+      return " "+ node.value + " "
     }
   } as any
 }

--- a/ee/tabby-ui/lib/utils/markdown.ts
+++ b/ee/tabby-ui/lib/utils/markdown.ts
@@ -65,7 +65,6 @@ export function processCodeBlocksWithLabel(ast: Root): RootContent[] {
       let placeholderNode: RootContent | null = null
       let shouldProcessNode = true
 
-
       switch (metas['label']) {
         case 'changes':
           finalCommandText = '"changes"'
@@ -132,7 +131,11 @@ export function processCodeBlocksWithLabel(ast: Root): RootContent[] {
             ...(nextNode.children || [])
           ],
           position: {
-            start: prevNode.position?.start || { line: 0, column: 0, offset: 0 },
+            start: prevNode.position?.start || {
+              line: 0,
+              column: 0,
+              offset: 0
+            },
             end: nextNode.position?.end || { line: 0, column: 0, offset: 0 }
           }
         } as RootContent)
@@ -162,7 +165,7 @@ export function processCodeBlocksWithLabel(ast: Root): RootContent[] {
           placeholderNode || { type: 'text', value: ` ${finalCommandText}` }
         )
         if (prevNode.position && node.position) {
-          prevNode.position.end = node.position.end;
+          prevNode.position.end = node.position.end
         }
       } else {
         newChildren.push({
@@ -204,8 +207,8 @@ export function formatObjectToMarkdownBlock(
   obj: any,
   content: string,
   options?: {
-    addPrefixNewline?: boolean;
-    addSuffixNewline?: boolean;
+    addPrefixNewline?: boolean
+    addSuffixNewline?: boolean
   }
 ): string {
   try {
@@ -226,14 +229,16 @@ export function formatObjectToMarkdownBlock(
 
     const processor = createRemarkProcessor()
     const formattedContent = processor.stringify(codeNode).trim()
-    
+
     const prefix = addPrefixNewline ? '\n' : ''
     const suffix = addSuffixNewline ? '\n' : ''
-    
+
     return `${prefix}${formattedContent}${suffix}`
   } catch (error) {
     const { addPrefixNewline = true, addSuffixNewline = true } = options || {}
-    return `${addPrefixNewline ? '\n' : ''}*Error formatting ${label}*${addSuffixNewline ? '\n' : ''}`
+    return `${addPrefixNewline ? '\n' : ''}*Error formatting ${label}*${
+      addSuffixNewline ? '\n' : ''
+    }`
   }
 }
 
@@ -249,7 +254,8 @@ export function shouldAddPrefixNewline(index: number, text: string): boolean {
   let i = index - 1
   while (i >= 0) {
     if (text[i] === '\n') return false
-    if (text[i] === '\r' && i + 1 < text.length && text[i + 1] === '\n') return false
+    if (text[i] === '\r' && i + 1 < text.length && text[i + 1] === '\n')
+      return false
 
     if (!/\s/.test(text[i])) return true
 
@@ -280,7 +286,6 @@ export function shouldAddSuffixNewline(index: number, text: string): boolean {
 
   return false
 }
-
 
 export interface PlaceholderNode extends Node {
   type: 'placeholder'

--- a/ee/tabby-ui/lib/utils/markdown.ts
+++ b/ee/tabby-ui/lib/utils/markdown.ts
@@ -10,7 +10,7 @@ const REMARK_STRINGIFY_OPTIONS: Options = {
   tightDefinitions: true,
   handlers: {
     placeholder: (node: PlaceholderNode) => {
-      return " "+ node.value + " "
+      return ' ' + node.value + ' '
     }
   } as any
 }

--- a/ee/tabby-ui/test/utils/markdown.test.ts
+++ b/ee/tabby-ui/test/utils/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatObjectToMarkdownBlock } from '../../lib/utils/markdown'
+import { formatObjectToMarkdownBlock, shouldAddPrefixNewline, shouldAddSuffixNewline } from '../../lib/utils/markdown'
 import { Filepath } from 'tabby-chat-panel/index';
 
 describe('formatObjectToMarkdownBlock - comprehensive tests', () => {
@@ -214,5 +214,108 @@ console.log(newUser);
       expect(result).toContain(tsContent);
       expect(result).toContain('```');
     });
+  });
+});
+
+describe('shouldAddPrefixNewline function', () => {
+  it('should return false when index is at the start of text', () => {
+    const result = shouldAddPrefixNewline(0, 'Some text here');
+    expect(result).toBe(false);
+  });
+
+  it('should return false when there is a newline character before the index', () => {
+    const result = shouldAddPrefixNewline(6, 'Hello\nworld');
+    expect(result).toBe(false);
+  });
+
+  it('should return true when there is text before the index', () => {
+    const result = shouldAddPrefixNewline(6, 'Hello world');
+    expect(result).toBe(true);
+  });
+
+  it('should return false when there is only whitespace before the index', () => {
+    const result = shouldAddPrefixNewline(3, '   Text');
+    expect(result).toBe(false);
+  });
+
+  it('should handle mixed whitespace and text properly', () => {
+    const result = shouldAddPrefixNewline(10, 'Hello    world');
+    expect(result).toBe(true);
+  });
+});
+
+describe('shouldAddSuffixNewline function', () => {
+  it('should return false when index is at the end of text', () => {
+    const text = 'Some text here';
+    const result = shouldAddSuffixNewline(text.length, text);
+    expect(result).toBe(false);
+  });
+
+  it('should return false when there is a newline character after the index', () => {
+    const result = shouldAddSuffixNewline(5, 'Hello\nworld');
+    expect(result).toBe(false);
+  });
+
+  it('should return true when there is text after the index', () => {
+    const result = shouldAddSuffixNewline(5, 'Hello world');
+    expect(result).toBe(true);
+  });
+
+  it('should return false when there is only whitespace after the index', () => {
+    const result = shouldAddSuffixNewline(4, 'Text   ');
+    expect(result).toBe(false);
+  });
+
+  it('should handle consecutive placeholder scenario correctly', () => {
+    // Simulate two placeholders next to each other
+    const text = '[[file:{}]][[file:{}]]';
+    const firstPlaceholderEnd = 11;
+    
+    const result = shouldAddSuffixNewline(firstPlaceholderEnd, text);
+    expect(result).toBe(true);
+  });
+});
+
+describe('formatObjectToMarkdownBlock with options', () => {
+  it('should respect addPrefixNewline and addSuffixNewline options', () => {
+    const unixGitObj = { 
+      kind: "git", 
+      filepath: '/home/user/projects/example.js', 
+      gitUrl: "https://github.com/tabbyml/tabby" 
+    } as Filepath;
+    
+    const jsContent = 'console.log("Hello");';
+    
+    // With both newlines
+    const resultBoth = formatObjectToMarkdownBlock('file', unixGitObj, jsContent, {
+      addPrefixNewline: true,
+      addSuffixNewline: true
+    });
+    expect(resultBoth.startsWith('\n')).toBe(true);
+    expect(resultBoth.endsWith('\n')).toBe(true);
+    
+    // With no newlines
+    const resultNone = formatObjectToMarkdownBlock('file', unixGitObj, jsContent, {
+      addPrefixNewline: false,
+      addSuffixNewline: false
+    });
+    expect(resultNone.startsWith('\n')).toBe(false);
+    expect(resultNone.endsWith('\n')).toBe(false);
+    
+    // With only prefix newline
+    const resultPrefix = formatObjectToMarkdownBlock('file', unixGitObj, jsContent, {
+      addPrefixNewline: true,
+      addSuffixNewline: false
+    });
+    expect(resultPrefix.startsWith('\n')).toBe(true);
+    expect(resultPrefix.endsWith('\n')).toBe(false);
+    
+    // With only suffix newline
+    const resultSuffix = formatObjectToMarkdownBlock('file', unixGitObj, jsContent, {
+      addPrefixNewline: false,
+      addSuffixNewline: true
+    });
+    expect(resultSuffix.startsWith('\n')).toBe(false);
+    expect(resultSuffix.endsWith('\n')).toBe(true);
   });
 });


### PR DESCRIPTION
- Updated `formatObjectToMarkdownBlock` to accept options for adding prefix and suffix newlines.
- Introduced `shouldAddPrefixNewline` and `shouldAddSuffixNewline` utility functions to determine newline requirements based on context.
- Modified `processingPlaceholder` to utilize the new formatting options for improved message processing.
- Added comprehensive tests for the new functions and updated existing tests to cover the new behavior.

### before
https://jam.dev/c/d8e59473-9486-481c-88d8-10c90f05c0ec

### after
https://jam.dev/c/8c877069-1e83-4651-8c72-5141762396a4