### PR TITLE
ci: fetch latest curl version before downloading it

### DIFF
--- a/ci/prepare_build_environment.sh
+++ b/ci/prepare_build_environment.sh
@@ -27,9 +27,13 @@ if [[ "$OSTYPE" == "linux"* ]]; then
     yum -y install openblas-devel perl-IPC-Cmd unzip openssl-devel
 
     # Install newer version of curl to support `--fail-with-body` on vulkan-sdk-install
-    curl -SLO https://mirror.city-fan.org/ftp/contrib/sysutils/Mirroring/curl-8.12.1-1.0.cf.rhel8.x86_64.rpm
-    curl -SLO https://mirror.city-fan.org/ftp/contrib/sysutils/Mirroring/libcurl-8.12.1-1.0.cf.rhel8.x86_64.rpm
-    rpm -Uvh curl-8.12.1-1.0.cf.rhel8.x86_64.rpm libcurl-8.12.1-1.0.cf.rhel8.x86_64.rpm
+    # The outdated release RPMs will be cleaned up from the city-fan.org mirror; therefore, we must first obtain the latest version.
+    base_url="https://mirror.city-fan.org/ftp/contrib/sysutils/Mirroring"
+    curl_rpm=$(curl -s $base_url/ | grep -oE 'curl-[0-9\.-]+\.cf\.rhel8\.x86_64\.rpm' | sort -V -u | tail -n 1)
+    libcurl_rpm=$(curl -s $base_url/ | grep -oE 'libcurl-[0-9\.-]+\.cf\.rhel8\.x86_64\.rpm' | sort -V -u | tail -n 1)
+    curl -SLO $base_url/$curl_rpm
+    curl -SLO $base_url/$libcurl_rpm
+    rpm -Uvh $curl_rpm $libcurl_rpm
 
     # Disable safe directory in docker
     git config --system --add safe.directory "*"


### PR DESCRIPTION
city-fan.org is recommended from curl official release,
The rpm on city-fan will clean up the old release archives, so we have to get the latest release before downloading them.

ci error: https://github.com/TabbyML/tabby/actions/runs/14313345524/job/40123162578

fixed ci test: https://github.com/zwpaper/tabby/actions/runs/14324472892/job/40147398057