### PR TITLE
feat(markdown): enhance placeholder handling and code block processing

### DIFF
--- a/ee/tabby-ui/components/chat/form-editor/mention.tsx
+++ b/ee/tabby-ui/components/chat/form-editor/mention.tsx
@@ -79,7 +79,7 @@ export const PromptFormMentionExtension = Mention.extend({
     // If symbols can be mentioned later, the placeholder could be [[symbol:{label}]].
     switch (category) {
       case 'command':
-        return `[[contextCommand:"${node.attrs.command || 'default'}"]]`
+        return `[[contextCommand:${node.attrs.command || 'default'}]]`
       case 'symbol':
         return `[[symbol:${JSON.stringify(node.attrs.fileItem)}]]`
       case 'file':

--- a/ee/tabby-ui/components/chat/git/utils.tsx
+++ b/ee/tabby-ui/components/chat/git/utils.tsx
@@ -56,10 +56,10 @@ export function hasChangesCommand(text: string): boolean {
 }
 
 export function extractContextCommand(text: string): string | null {
-  const startIndex = text.indexOf('[[contextCommand:"')
+  const startIndex = text.indexOf('[[contextCommand:')
   if (startIndex === -1) return null
-  const commandStartIndex = startIndex + '[[contextCommand:"'.length
-  const commandEndIndex = text.indexOf('"]]', commandStartIndex)
+  const commandStartIndex = startIndex + '[[contextCommand:'.length
+  const commandEndIndex = text.indexOf(']]', commandStartIndex)
   if (commandEndIndex === -1) return null
   return text.slice(commandStartIndex, commandEndIndex)
 }

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -626,7 +626,7 @@ function ContextCommandTag({
     if (!encodedCommand) return null
     try {
       const decodedCommand = decodeURIComponent(encodedCommand)
-      return JSON.parse(decodedCommand) as string
+      return decodedCommand
     } catch (e) {
       return null
     }

--- a/ee/tabby-ui/lib/constants/regex.ts
+++ b/ee/tabby-ui/lib/constants/regex.ts
@@ -5,7 +5,7 @@ export const PLACEHOLDER_FILE_REGEX = /\[\[file:\s*({.*?})\]\]/g
 export const MARKDOWN_FILE_REGEX = /\[\[file:\s*([^\]]+)\]\]/g
 export const PLACEHOLDER_SYMBOL_REGEX = /\[\[symbol:\s*({.*?})\]\]/g
 export const MARKDOWN_SYMBOL_REGEX = /\[\[symbol:\s*([^\]]+)\]\]/g
-export const PLACEHOLDER_COMMAND_REGEX = /\[\[contextCommand:\s*"(.+?)"\]\]/g
+export const PLACEHOLDER_COMMAND_REGEX = /\[\[contextCommand:\s*(.+?)\]\]/g
 export const MARKDOWN_COMMAND_REGEX = /\[\[contextCommand:\s*([^\]]+)\]\]/g
 
 export const DIFF_CHANGES_REGEX = /```diff label=changes[\s\S]*?```/g

--- a/ee/tabby-ui/lib/utils/chat.ts
+++ b/ee/tabby-ui/lib/utils/chat.ts
@@ -234,7 +234,7 @@ export function encodeMentionPlaceHolder(value: string): string {
     try {
       newValue = newValue.replace(
         match[0],
-        `[[contextCommand:"${encodeURIComponent(match[1])}"]]`
+        `[[contextCommand:${encodeURIComponent(match[1])}]]`
       )
     } catch (error) {
       continue
@@ -291,7 +291,7 @@ export function getTitleFromMessages(
       }
     })
     .replace(PLACEHOLDER_COMMAND_REGEX, value => {
-      const command = value.slice(18, -3)
+      const command = value.slice(17, -3)
       return `@${command}`
     })
     .trim()
@@ -321,12 +321,12 @@ export async function processingPlaceholder(
       const changes = await options.getChanges({})
       const gitChanges = convertChangeItemsToContextContent(changes)
       processedMessage = processedMessage.replaceAll(
-        /\[\[contextCommand:"changes"\]\]/g,
+        /\[\[contextCommand:changes\]\]/g,
         gitChanges
       )
     } catch (error) {
       processedMessage = processedMessage.replaceAll(
-        /\[\[contextCommand:"changes"\]\]/g,
+        /\[\[contextCommand:changes\]\]/g,
         ''
       )
     }

--- a/ee/tabby-ui/lib/utils/chat.ts
+++ b/ee/tabby-ui/lib/utils/chat.ts
@@ -291,7 +291,7 @@ export function getTitleFromMessages(
       }
     })
     .replace(PLACEHOLDER_COMMAND_REGEX, value => {
-      const command = value.slice(17, -3)
+      const command = value.slice(17, -2)
       return `@${command}`
     })
     .trim()

--- a/ee/tabby-ui/lib/utils/markdown.ts
+++ b/ee/tabby-ui/lib/utils/markdown.ts
@@ -1,6 +1,8 @@
-import { Parent, Root, RootContent } from 'mdast'
+import { Root, RootContent } from 'mdast'
 import { remark } from 'remark'
 import remarkStringify, { Options } from 'remark-stringify'
+import { PlaceholderNode, placeholderToString, remarkPlaceholderParser } from './markdown/remark-placeholder-parser'
+import { remarkCodeBlocksToPlaceholders } from './markdown/remark-codeblock-to-placeholder'
 
 const REMARK_STRINGIFY_OPTIONS: Options = {
   bullet: '*',
@@ -10,13 +12,17 @@ const REMARK_STRINGIFY_OPTIONS: Options = {
   tightDefinitions: true,
   handlers: {
     placeholder: (node: PlaceholderNode) => {
-      return ' ' + node.value + ' '
-    }
+      // It's should create a formatted plugin for this, but for now, it's just a simple function
+      return placeholderToString(node)
+    },
   } as any
 }
 
 function createRemarkProcessor() {
-  return remark().use(remarkStringify, REMARK_STRINGIFY_OPTIONS)
+  return remark()
+    .use(remarkPlaceholderParser)
+    .use(remarkCodeBlocksToPlaceholders)
+    .use(remarkStringify, REMARK_STRINGIFY_OPTIONS)
 }
 
 /**
@@ -30,168 +36,24 @@ export function customAstToString(ast: Root): string {
 }
 
 /**
- * Process code blocks with labels and convert them to placeholders
+ * Process markdown text with context commands and convert them to placeholders
+ * @param input The markdown text to process
+ * @returns Processed markdown with placeholders
  */
-export function processCodeBlocksWithLabel(ast: Root): RootContent[] {
-  const newChildren: RootContent[] = []
-  for (let i = 0; i < ast.children.length; i++) {
-    const node = ast.children[i]
-    const metas: Record<string, string> = {}
-
-    if (node.type === 'code' && node.meta) {
-      node.meta?.split(' ').forEach(item => {
-        const [key, rawValue] = item.split(/=(.+)/)
-        metas[key] = rawValue
-      })
-    }
-
-    if (node.type === 'code' && metas['label']) {
-      const prevNode = newChildren[newChildren.length - 1] as Parent | undefined
-      const nextNode = ast.children[i + 1] as Parent | undefined
-
-      const isPrevNodeSameLine =
-        prevNode &&
-        prevNode.position &&
-        node.position &&
-        node.position.start.line - prevNode.position.end.line === 1
-
-      const isNextNodeSameLine =
-        nextNode &&
-        nextNode.position &&
-        node.position &&
-        nextNode.position.start.line - node.position.end.line === 1
-
-      let finalCommandText = ''
-      let placeholderNode: RootContent | null = null
-      let shouldProcessNode = true
-
-      switch (metas['label']) {
-        case 'changes':
-          finalCommandText = '"changes"'
-          placeholderNode = createPlaceholderNode(
-            `[[contextCommand:${finalCommandText}]]`
-          ) as unknown as RootContent
-          break
-        case 'file':
-          if (metas['object']) {
-            try {
-              placeholderNode = createPlaceholderNode(
-                `[[file:${metas['object']}]]`
-              ) as unknown as RootContent
-              if (!placeholderNode) {
-                shouldProcessNode = false
-                newChildren.push(node)
-              }
-            } catch (error) {
-              shouldProcessNode = false
-              newChildren.push(node)
-            }
-          }
-          break
-        case 'symbol':
-          if (metas['object']) {
-            try {
-              placeholderNode = createPlaceholderNode(
-                `[[symbol:${metas['object']}]]`
-              ) as unknown as RootContent
-              if (!placeholderNode) {
-                shouldProcessNode = false
-                newChildren.push(node)
-              }
-            } catch (error) {
-              shouldProcessNode = false
-              newChildren.push(node)
-            }
-          }
-          break
-        default:
-          newChildren.push(node)
-          continue
-      }
-
-      if (!shouldProcessNode) {
-        continue
-      }
-
-      if (
-        prevNode &&
-        prevNode.type === 'paragraph' &&
-        nextNode &&
-        nextNode.type === 'paragraph' &&
-        isPrevNodeSameLine &&
-        isNextNodeSameLine
-      ) {
-        i++
-        newChildren.pop()
-        newChildren.push({
-          type: 'paragraph',
-          children: [
-            ...(prevNode.children || []),
-            placeholderNode || { type: 'text', value: ` ${finalCommandText} ` },
-            ...(nextNode.children || [])
-          ],
-          position: {
-            start: prevNode.position?.start || {
-              line: 0,
-              column: 0,
-              offset: 0
-            },
-            end: nextNode.position?.end || { line: 0, column: 0, offset: 0 }
-          }
-        } as RootContent)
-      } else if (
-        nextNode &&
-        nextNode.type === 'paragraph' &&
-        isNextNodeSameLine
-      ) {
-        i++
-        newChildren.push({
-          type: 'paragraph',
-          children: [
-            placeholderNode || { type: 'text', value: `${finalCommandText} ` },
-            ...(nextNode.children || [])
-          ],
-          position: {
-            start: node.position?.start || { line: 0, column: 0, offset: 0 },
-            end: nextNode.position?.end || { line: 0, column: 0, offset: 0 }
-          }
-        } as RootContent)
-      } else if (
-        prevNode &&
-        prevNode.type === 'paragraph' &&
-        isPrevNodeSameLine
-      ) {
-        ;(prevNode.children || []).push(
-          placeholderNode || { type: 'text', value: ` ${finalCommandText}` }
-        )
-        if (prevNode.position && node.position) {
-          prevNode.position.end = node.position.end
-        }
-      } else {
-        newChildren.push({
-          type: 'paragraph',
-          children: [
-            placeholderNode || { type: 'text', value: finalCommandText }
-          ],
-          position: node.position
-        } as RootContent)
-      }
-    } else {
-      newChildren.push(node)
-    }
-  }
-  return newChildren
-}
-
-export function processContextCommand(input: string): string {
+export function parseMarkdownWithContextCommands(input: string): string {
   const processor = createRemarkProcessor()
-  const ast = processor.parse(input) as Root
-  ast.children = processCodeBlocksWithLabel(ast)
+  const ast = processor.runSync(processor.parse(input)) as Root
   return customAstToString(ast)
 }
 
+
+/**
+ * Convert context blocks in markdown to placeholder nodes (legacy function name)
+ * @param input The markdown text containing context blocks
+ * @returns Processed markdown with placeholders
+ */
 export function convertContextBlockToPlaceholder(input: string): string {
-  return processContextCommand(input)
+  return parseMarkdownWithContextCommands(input)
 }
 
 /**
@@ -286,16 +148,4 @@ export function shouldAddSuffixNewline(index: number, text: string): boolean {
   }
 
   return false
-}
-
-export interface PlaceholderNode extends Node {
-  type: 'placeholder'
-  value: string
-}
-
-export function createPlaceholderNode(value: string): PlaceholderNode {
-  return {
-    type: 'placeholder',
-    value: value
-  } as PlaceholderNode
 }

--- a/ee/tabby-ui/lib/utils/markdown.ts
+++ b/ee/tabby-ui/lib/utils/markdown.ts
@@ -1,8 +1,13 @@
 import { Root, RootContent } from 'mdast'
 import { remark } from 'remark'
 import remarkStringify, { Options } from 'remark-stringify'
-import { PlaceholderNode, placeholderToString, remarkPlaceholderParser } from './markdown/remark-placeholder-parser'
+
 import { remarkCodeBlocksToPlaceholders } from './markdown/remark-codeblock-to-placeholder'
+import {
+  PlaceholderNode,
+  placeholderToString,
+  remarkPlaceholderParser
+} from './markdown/remark-placeholder-parser'
 
 const REMARK_STRINGIFY_OPTIONS: Options = {
   bullet: '*',
@@ -14,7 +19,7 @@ const REMARK_STRINGIFY_OPTIONS: Options = {
     placeholder: (node: PlaceholderNode) => {
       // It's should create a formatted plugin for this, but for now, it's just a simple function
       return placeholderToString(node)
-    },
+    }
   } as any
 }
 
@@ -45,7 +50,6 @@ export function parseMarkdownWithContextCommands(input: string): string {
   const ast = processor.runSync(processor.parse(input)) as Root
   return customAstToString(ast)
 }
-
 
 /**
  * Convert context blocks in markdown to placeholder nodes (legacy function name)

--- a/ee/tabby-ui/lib/utils/markdown/remark-codeblock-to-placeholder.ts
+++ b/ee/tabby-ui/lib/utils/markdown/remark-codeblock-to-placeholder.ts
@@ -1,0 +1,214 @@
+/**
+ * Transformer plugin for processing code blocks with labels and converting them to placeholders
+ */
+
+import { Parent, Root, RootContent, Code } from 'mdast'
+import { Plugin } from 'unified'
+import { PlaceholderNode } from './remark-placeholder-parser'
+
+/**
+ * Creates a placeholder node from a given type and object
+ */
+export function createPlaceholderNode(placeholderType: string, obj: any): PlaceholderNode {
+  return {
+    type: 'placeholder',
+    placeholderType: placeholderType,
+    attributes: {
+      object: obj
+    }
+  } as PlaceholderNode
+}
+
+/**
+ * Process metadata from code blocks and extract label and object information
+ */
+export function parseCodeBlockMeta(meta: string | null | undefined): Record<string, string> {
+  const metas: Record<string, string> = {}
+  
+  if (meta) {
+    meta.split(' ').forEach(item => {
+      const [key, rawValue] = item.split(/=(.+)/)
+      if (key && rawValue) {
+        metas[key] = rawValue
+      }
+    })
+  }
+  
+  return metas
+}
+
+/**
+ * Remark plugin for processing code blocks with labels and converting them to placeholders
+ */
+export const remarkCodeBlocksToPlaceholders: Plugin = function() {
+  return function transformer(tree) {
+    if (tree.type === 'root') {
+      const root = tree as Root
+      root.children = processCodeBlocksWithLabel(root)
+    }
+    return tree
+  }
+}
+
+/**
+ * Process code blocks with labels and convert them to placeholders
+ * Preserves any sourceDoc nodes that have been extracted by remarkPlaceholderParser
+ */
+function processCodeBlocksWithLabel(ast: Root): RootContent[] {
+  const newChildren: RootContent[] = []
+  for (let i = 0; i < ast.children.length; i++) {
+    const node = ast.children[i]
+    
+    if (node.type !== 'code') {
+      newChildren.push(node)
+      continue
+    }
+    
+    const codeNode = node as Code
+    const metas = parseCodeBlockMeta(codeNode.meta)
+    
+    if (!metas['label']) {
+      newChildren.push(node)
+      continue
+    }
+    
+    const prevNode = newChildren[newChildren.length - 1] as Parent | undefined
+    const nextNode = ast.children[i + 1] as Parent | undefined
+
+    const isPrevNodeSameLine =
+      prevNode &&
+      prevNode.position &&
+      node.position &&
+      node.position.start.line - prevNode.position.end.line === 1
+
+    const isNextNodeSameLine =
+      nextNode &&
+      nextNode.position &&
+      node.position &&
+      nextNode.position.start.line - node.position.end.line === 1
+
+    let finalCommandText = ''
+    let placeholderNode: RootContent | null = null
+    let shouldProcessNode = true
+
+    switch (metas['label']) {
+      case 'changes':
+        finalCommandText = '"changes"'
+        const objNode: PlaceholderNode = {
+          type: 'placeholder',
+          placeholderType: 'contextCommand',
+          attributes: { command: 'changes' }
+        }
+        placeholderNode = objNode as unknown as RootContent
+        break
+      case 'file':
+        if (metas['object']) {
+          try {
+            placeholderNode = createPlaceholderNode(
+              'file',
+              metas['object']
+            ) as unknown as RootContent
+            if (!placeholderNode) {
+              shouldProcessNode = false
+              newChildren.push(node)
+            }
+          } catch (error) {
+            shouldProcessNode = false
+            newChildren.push(node)
+          }
+        }
+        break
+      case 'symbol':
+        if (metas['object']) {
+          try {
+            placeholderNode = createPlaceholderNode(
+              'symbol',
+              metas['object']
+            ) as unknown as RootContent
+            if (!placeholderNode) {
+              shouldProcessNode = false
+              newChildren.push(node)
+            }
+          } catch (error) {
+            shouldProcessNode = false
+            newChildren.push(node)
+          }
+        }
+        break
+      default:
+        newChildren.push(node)
+        continue
+    }
+
+    if (!shouldProcessNode) {
+      continue
+    }
+
+    if (
+      prevNode &&
+      prevNode.type === 'paragraph' &&
+      nextNode &&
+      nextNode.type === 'paragraph' &&
+      isPrevNodeSameLine &&
+      isNextNodeSameLine
+    ) {
+      i++
+      newChildren.pop()
+      newChildren.push({
+        type: 'paragraph',
+        children: [
+          ...(prevNode.children || []),
+          placeholderNode || { type: 'text', value: ` ${finalCommandText} ` },
+          ...(nextNode.children || [])
+        ],
+        position: {
+          start: prevNode.position?.start || {
+            line: 0,
+            column: 0,
+            offset: 0
+          },
+          end: nextNode.position?.end || { line: 0, column: 0, offset: 0 }
+        }
+      } as RootContent)
+    } else if (
+      nextNode &&
+      nextNode.type === 'paragraph' &&
+      isNextNodeSameLine
+    ) {
+      i++
+      newChildren.push({
+        type: 'paragraph',
+        children: [
+          placeholderNode || { type: 'text', value: `${finalCommandText} ` },
+          ...(nextNode.children || [])
+        ],
+        position: {
+          start: node.position?.start || { line: 0, column: 0, offset: 0 },
+          end: nextNode.position?.end || { line: 0, column: 0, offset: 0 }
+        }
+      } as RootContent)
+    } else if (
+      prevNode &&
+      prevNode.type === 'paragraph' &&
+      isPrevNodeSameLine
+    ) {
+      if (Array.isArray(prevNode.children)) {
+        prevNode.children.push(
+          placeholderNode || { type: 'text', value: ` ${finalCommandText}` }
+        )
+      }
+      if (prevNode.position && node.position) {
+        prevNode.position.end = node.position.end
+      }
+    } else {
+      newChildren.push({
+        type: 'paragraph',
+        children: [
+          placeholderNode || { type: 'text', value: finalCommandText }
+        ],
+        position: node.position
+      } as RootContent)
+    }
+  }
+  return newChildren
+}

--- a/ee/tabby-ui/lib/utils/markdown/remark-codeblock-to-placeholder.ts
+++ b/ee/tabby-ui/lib/utils/markdown/remark-codeblock-to-placeholder.ts
@@ -2,14 +2,18 @@
  * Transformer plugin for processing code blocks with labels and converting them to placeholders
  */
 
-import { Parent, Root, RootContent, Code } from 'mdast'
+import { Code, Parent, Root, RootContent } from 'mdast'
 import { Plugin } from 'unified'
+
 import { PlaceholderNode } from './remark-placeholder-parser'
 
 /**
  * Creates a placeholder node from a given type and object
  */
-export function createPlaceholderNode(placeholderType: string, obj: any): PlaceholderNode {
+export function createPlaceholderNode(
+  placeholderType: string,
+  obj: any
+): PlaceholderNode {
   return {
     type: 'placeholder',
     placeholderType: placeholderType,
@@ -22,9 +26,11 @@ export function createPlaceholderNode(placeholderType: string, obj: any): Placeh
 /**
  * Process metadata from code blocks and extract label and object information
  */
-export function parseCodeBlockMeta(meta: string | null | undefined): Record<string, string> {
+export function parseCodeBlockMeta(
+  meta: string | null | undefined
+): Record<string, string> {
   const metas: Record<string, string> = {}
-  
+
   if (meta) {
     meta.split(' ').forEach(item => {
       const [key, rawValue] = item.split(/=(.+)/)
@@ -33,14 +39,14 @@ export function parseCodeBlockMeta(meta: string | null | undefined): Record<stri
       }
     })
   }
-  
+
   return metas
 }
 
 /**
  * Remark plugin for processing code blocks with labels and converting them to placeholders
  */
-export const remarkCodeBlocksToPlaceholders: Plugin = function() {
+export const remarkCodeBlocksToPlaceholders: Plugin = function () {
   return function transformer(tree) {
     if (tree.type === 'root') {
       const root = tree as Root
@@ -58,20 +64,20 @@ function processCodeBlocksWithLabel(ast: Root): RootContent[] {
   const newChildren: RootContent[] = []
   for (let i = 0; i < ast.children.length; i++) {
     const node = ast.children[i]
-    
+
     if (node.type !== 'code') {
       newChildren.push(node)
       continue
     }
-    
+
     const codeNode = node as Code
     const metas = parseCodeBlockMeta(codeNode.meta)
-    
+
     if (!metas['label']) {
       newChildren.push(node)
       continue
     }
-    
+
     const prevNode = newChildren[newChildren.length - 1] as Parent | undefined
     const nextNode = ast.children[i + 1] as Parent | undefined
 

--- a/ee/tabby-ui/lib/utils/markdown/remark-codeblock-to-placeholder.ts
+++ b/ee/tabby-ui/lib/utils/markdown/remark-codeblock-to-placeholder.ts
@@ -99,7 +99,7 @@ function processCodeBlocksWithLabel(ast: Root): RootContent[] {
 
     switch (metas['label']) {
       case 'changes':
-        finalCommandText = '"changes"'
+        finalCommandText = 'changes'
         const objNode: PlaceholderNode = {
           type: 'placeholder',
           placeholderType: 'contextCommand',

--- a/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
+++ b/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
@@ -196,9 +196,7 @@ export function placeholderToString(node: PlaceholderNode): string {
   }
   switch (node.placeholderType) {
     case 'source':
-      return formatPlaceholder(
-        `[[source:${node.attributes.sourceId}]]`
-      )
+      return formatPlaceholder(`[[source:${node.attributes.sourceId}]]`)
     case 'file':
       return formatPlaceholder(`[[file:${node.attributes.object}]]`)
     case 'symbol':

--- a/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
+++ b/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
@@ -43,7 +43,7 @@ export function parsePlaceholder(
         type: 'placeholder',
         placeholderType: 'undefined',
         attributes: {
-          content: content
+          content: text
         }
       },
       matchLength
@@ -55,21 +55,18 @@ export function parsePlaceholder(
 
   switch (prefix) {
     case 'source': {
-      const parts = content.split(':')
-      if (parts.length >= 3) {
+      if (!!restContent) {
         return {
           placeholderNode: {
             type: 'placeholder',
             placeholderType: 'source',
             attributes: {
-              source: parts[1],
-              documentId: parts[2]
+              sourceId: restContent
             }
           },
           matchLength
         }
       }
-      break
     }
     case 'file': {
       const value = restContent
@@ -111,13 +108,12 @@ export function parsePlaceholder(
       }
     }
     default: {
-      const parts = content.split(':')
       return {
         placeholderNode: {
           type: 'placeholder',
           placeholderType: 'undefined',
           attributes: {
-            content: 'undefined'
+            content: match[0]
           }
         },
         matchLength
@@ -201,7 +197,7 @@ export function placeholderToString(node: PlaceholderNode): string {
   switch (node.placeholderType) {
     case 'source':
       return formatPlaceholder(
-        `[[source:${node.attributes.source}:${node.attributes.documentId}]]`
+        `[[source:${node.attributes.sourceId}]]`
       )
     case 'file':
       return formatPlaceholder(`[[file:${node.attributes.object}]]`)
@@ -211,6 +207,6 @@ export function placeholderToString(node: PlaceholderNode): string {
       return formatPlaceholder(`[[contextCommand:${node.attributes.command}]]`)
     case 'undefined':
     default:
-      return 'cannotFindThePlaceholderType'
+      return node.attributes.content ?? ''
   }
 }

--- a/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
+++ b/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
@@ -1,0 +1,211 @@
+/**
+ * Remark plugin for handling source references with syntax [[source:type:id]]
+ */
+
+import { Plugin } from 'unified'
+import { Node } from 'mdast'
+import { Root } from 'remark-stringify/lib'
+
+export interface PlaceholderNode extends Node {
+  type: 'placeholder'
+  // TODO: this mention type or data source type should be defined as type
+  placeholderType: "source" | "file" | "symbol" | "contextCommand" | "undefined"
+  attributes: Record<string, any> 
+}
+
+/**
+ * Remark plugin for parsing and transforming placeholder references
+ * in markdown text with syntax [[type:value]]
+ */
+export const remarkPlaceholderParser: Plugin = function() {
+  return function transformer(tree) {
+    return transformPlaceholders(tree as Root)
+  }
+}
+
+// Export the original name for backward compatibility
+export const remarkPlaceHolderSource = remarkPlaceholderParser
+
+export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNode, matchLength: number } | null {
+  const match = /^\[\[([^\]]+)\]\]/.exec(text)
+  if (!match) return null
+  
+  const content = match[1]
+  const matchLength = match[0].length
+  
+  const colonIndex = content.indexOf(':')
+  if (colonIndex === -1) {
+    // Generic case with no colon
+    return {
+      placeholderNode: {
+        type: 'placeholder',
+        placeholderType: 'undefined',
+        attributes: {
+          content: content
+        },
+      },
+      matchLength
+    }
+  }
+  
+  const prefix = content.substring(0, colonIndex)
+  const restContent = content.substring(colonIndex + 1)
+  
+  switch (prefix) {
+    case 'source': {
+      const parts = content.split(':')
+      if (parts.length >= 3) {
+        return {
+          placeholderNode: {
+            type: 'placeholder',
+            placeholderType: 'source',
+            attributes: {
+              source: parts[1],
+              documentId: parts[2]
+            },
+          },
+          matchLength
+        }
+      }
+      break
+    }
+    case 'file': {
+      const value = restContent
+      return {
+        placeholderNode: {
+          type: 'placeholder',
+          placeholderType: 'file',
+          attributes: {
+            object: value
+          },
+        },
+        matchLength
+      }
+    }
+    case 'symbol': {
+      const value = restContent
+      return {
+        placeholderNode: {
+          type: 'placeholder',
+          placeholderType: 'symbol',
+          attributes: {
+            object: value
+          },
+        },
+        matchLength
+      }
+    }
+    case 'contextCommand': {
+      const value = restContent
+      return {
+        placeholderNode: {
+          type: 'placeholder',
+          placeholderType: 'contextCommand',
+          attributes: {
+            command: value
+          },
+        },
+        matchLength
+      }
+    }
+    default: {
+      const parts = content.split(':')
+      return {
+        placeholderNode: {
+          type: 'placeholder',
+          placeholderType: "undefined",
+          attributes: {
+            content: "undefined"
+          },
+        },
+        matchLength
+      }
+    }
+  }
+  
+  return null
+}
+
+
+export function transformPlaceholders(tree: any): any {
+  if (!tree) return tree;
+  
+  if (tree.type === 'root' && Array.isArray(tree.children)) {
+    for (let i = 0; i < tree.children.length; i++) {
+      const node = tree.children[i];
+      
+      if (node.type === 'paragraph' && Array.isArray(node.children)) {
+        const newChildren = [];
+        for (let j = 0; j < node.children.length; j++) {
+          const child = node.children[j];
+          if (child.type === 'text') {
+            let text = child.value;
+            let position = 0;
+            let placeholderIndex;
+            
+            while ((placeholderIndex = text.indexOf('[[', position)) !== -1) {
+              if (placeholderIndex > position) {
+                newChildren.push({
+                  type: 'text',
+                  value: text.substring(position, placeholderIndex)
+                });
+              }
+              
+              const placeholderText = text.substring(placeholderIndex);
+              const parsed = parsePlaceholder(placeholderText);
+              
+              if (parsed) {
+                newChildren.push(parsed.placeholderNode);
+                position = placeholderIndex + parsed.matchLength;
+              } else {
+                newChildren.push({
+                  type: 'text',
+                  value: '[['
+                });
+                position = placeholderIndex + 2;
+              }
+            }
+            
+            if (position < text.length) {
+              newChildren.push({
+                type: 'text',
+                value: text.substring(position)
+              });
+            }
+          } else {
+            newChildren.push(child);
+          }
+        }
+        
+        node.children = newChildren;
+      }
+      
+      if (node.children && Array.isArray(node.children) && node.type !== 'paragraph') {
+        transformPlaceholders({ type: 'root', children: node.children });
+      }
+    }
+  }
+  
+  return tree;
+}
+
+
+export function placeholderToString(node: PlaceholderNode): string {
+  const formatPlaceholder = (content: string): string => {
+    return ` ${content} `;
+  };
+  switch (node.placeholderType) {
+    case 'source':
+      return formatPlaceholder(`[[source:${node.attributes.source}:${node.attributes.documentId}]]`);
+    case 'file':
+      return formatPlaceholder(`[[file:${node.attributes.object}]]`);
+    case 'symbol':
+      return formatPlaceholder(`[[symbol:${node.attributes.object}]]`);
+    case 'contextCommand':
+      return formatPlaceholder(`[[contextCommand:${node.attributes.command}]]`);
+    case 'undefined':
+    default:
+      return "cannotFindThePlaceholderType";
+  }
+}
+

--- a/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
+++ b/ee/tabby-ui/lib/utils/markdown/remark-placeholder-parser.ts
@@ -2,22 +2,22 @@
  * Remark plugin for handling source references with syntax [[source:type:id]]
  */
 
-import { Plugin } from 'unified'
 import { Node } from 'mdast'
 import { Root } from 'remark-stringify/lib'
+import { Plugin } from 'unified'
 
 export interface PlaceholderNode extends Node {
   type: 'placeholder'
   // TODO: this mention type or data source type should be defined as type
-  placeholderType: "source" | "file" | "symbol" | "contextCommand" | "undefined"
-  attributes: Record<string, any> 
+  placeholderType: 'source' | 'file' | 'symbol' | 'contextCommand' | 'undefined'
+  attributes: Record<string, any>
 }
 
 /**
  * Remark plugin for parsing and transforming placeholder references
  * in markdown text with syntax [[type:value]]
  */
-export const remarkPlaceholderParser: Plugin = function() {
+export const remarkPlaceholderParser: Plugin = function () {
   return function transformer(tree) {
     return transformPlaceholders(tree as Root)
   }
@@ -26,13 +26,15 @@ export const remarkPlaceholderParser: Plugin = function() {
 // Export the original name for backward compatibility
 export const remarkPlaceHolderSource = remarkPlaceholderParser
 
-export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNode, matchLength: number } | null {
+export function parsePlaceholder(
+  text: string
+): { placeholderNode: PlaceholderNode; matchLength: number } | null {
   const match = /^\[\[([^\]]+)\]\]/.exec(text)
   if (!match) return null
-  
+
   const content = match[1]
   const matchLength = match[0].length
-  
+
   const colonIndex = content.indexOf(':')
   if (colonIndex === -1) {
     // Generic case with no colon
@@ -42,15 +44,15 @@ export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNo
         placeholderType: 'undefined',
         attributes: {
           content: content
-        },
+        }
       },
       matchLength
     }
   }
-  
+
   const prefix = content.substring(0, colonIndex)
   const restContent = content.substring(colonIndex + 1)
-  
+
   switch (prefix) {
     case 'source': {
       const parts = content.split(':')
@@ -62,7 +64,7 @@ export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNo
             attributes: {
               source: parts[1],
               documentId: parts[2]
-            },
+            }
           },
           matchLength
         }
@@ -77,7 +79,7 @@ export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNo
           placeholderType: 'file',
           attributes: {
             object: value
-          },
+          }
         },
         matchLength
       }
@@ -90,7 +92,7 @@ export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNo
           placeholderType: 'symbol',
           attributes: {
             object: value
-          },
+          }
         },
         matchLength
       }
@@ -103,7 +105,7 @@ export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNo
           placeholderType: 'contextCommand',
           attributes: {
             command: value
-          },
+          }
         },
         matchLength
       }
@@ -113,99 +115,102 @@ export function parsePlaceholder(text: string): { placeholderNode: PlaceholderNo
       return {
         placeholderNode: {
           type: 'placeholder',
-          placeholderType: "undefined",
+          placeholderType: 'undefined',
           attributes: {
-            content: "undefined"
-          },
+            content: 'undefined'
+          }
         },
         matchLength
       }
     }
   }
-  
+
   return null
 }
 
-
 export function transformPlaceholders(tree: any): any {
-  if (!tree) return tree;
-  
+  if (!tree) return tree
+
   if (tree.type === 'root' && Array.isArray(tree.children)) {
     for (let i = 0; i < tree.children.length; i++) {
-      const node = tree.children[i];
-      
+      const node = tree.children[i]
+
       if (node.type === 'paragraph' && Array.isArray(node.children)) {
-        const newChildren = [];
+        const newChildren = []
         for (let j = 0; j < node.children.length; j++) {
-          const child = node.children[j];
+          const child = node.children[j]
           if (child.type === 'text') {
-            let text = child.value;
-            let position = 0;
-            let placeholderIndex;
-            
+            let text = child.value
+            let position = 0
+            let placeholderIndex
+
             while ((placeholderIndex = text.indexOf('[[', position)) !== -1) {
               if (placeholderIndex > position) {
                 newChildren.push({
                   type: 'text',
                   value: text.substring(position, placeholderIndex)
-                });
+                })
               }
-              
-              const placeholderText = text.substring(placeholderIndex);
-              const parsed = parsePlaceholder(placeholderText);
-              
+
+              const placeholderText = text.substring(placeholderIndex)
+              const parsed = parsePlaceholder(placeholderText)
+
               if (parsed) {
-                newChildren.push(parsed.placeholderNode);
-                position = placeholderIndex + parsed.matchLength;
+                newChildren.push(parsed.placeholderNode)
+                position = placeholderIndex + parsed.matchLength
               } else {
                 newChildren.push({
                   type: 'text',
                   value: '[['
-                });
-                position = placeholderIndex + 2;
+                })
+                position = placeholderIndex + 2
               }
             }
-            
+
             if (position < text.length) {
               newChildren.push({
                 type: 'text',
                 value: text.substring(position)
-              });
+              })
             }
           } else {
-            newChildren.push(child);
+            newChildren.push(child)
           }
         }
-        
-        node.children = newChildren;
+
+        node.children = newChildren
       }
-      
-      if (node.children && Array.isArray(node.children) && node.type !== 'paragraph') {
-        transformPlaceholders({ type: 'root', children: node.children });
+
+      if (
+        node.children &&
+        Array.isArray(node.children) &&
+        node.type !== 'paragraph'
+      ) {
+        transformPlaceholders({ type: 'root', children: node.children })
       }
     }
   }
-  
-  return tree;
-}
 
+  return tree
+}
 
 export function placeholderToString(node: PlaceholderNode): string {
   const formatPlaceholder = (content: string): string => {
-    return ` ${content} `;
-  };
+    return ` ${content} `
+  }
   switch (node.placeholderType) {
     case 'source':
-      return formatPlaceholder(`[[source:${node.attributes.source}:${node.attributes.documentId}]]`);
+      return formatPlaceholder(
+        `[[source:${node.attributes.source}:${node.attributes.documentId}]]`
+      )
     case 'file':
-      return formatPlaceholder(`[[file:${node.attributes.object}]]`);
+      return formatPlaceholder(`[[file:${node.attributes.object}]]`)
     case 'symbol':
-      return formatPlaceholder(`[[symbol:${node.attributes.object}]]`);
+      return formatPlaceholder(`[[symbol:${node.attributes.object}]]`)
     case 'contextCommand':
-      return formatPlaceholder(`[[contextCommand:${node.attributes.command}]]`);
+      return formatPlaceholder(`[[contextCommand:${node.attributes.command}]]`)
     case 'undefined':
     default:
-      return "cannotFindThePlaceholderType";
+      return 'cannotFindThePlaceholderType'
   }
 }
-

--- a/ee/tabby-ui/package.json
+++ b/ee/tabby-ui/package.json
@@ -60,6 +60,7 @@
     "@tiptap/starter-kit": "^2.6.6",
     "@tiptap/suggestion": "^2.10.4",
     "@types/mdast": "^4.0.4",
+    "@types/unist": "^3.0.3",
     "@uidotdev/usehooks": "^2.4.1",
     "@uiw/codemirror-extensions-langs": "^4.21.21",
     "@urql/core": "^4.2.3",

--- a/ee/tabby-ui/test/utils/remark-codeblock-to-placeholder.test.ts
+++ b/ee/tabby-ui/test/utils/remark-codeblock-to-placeholder.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { createPlaceholderNode, parseCodeBlockMeta } from '../../lib/utils/markdown/remark-codeblock-to-placeholder'
+
+describe('parseCodeBlockMeta', () => {
+  it('should parse meta with multiple key-value pairs', () => {
+    const meta = 'label=file object={"filepath": "/test.js"}';
+    const result = parseCodeBlockMeta(meta);
+    
+    expect(result.label).toBe('file');
+    // The function only splits by '=' and doesn't parse the JSON content
+    // So we just check that the string contains the start of the object
+    const objectValue = result.object;
+    expect(objectValue).toBeDefined();
+    expect(objectValue.startsWith('{"filepath"')).toBeTruthy();
+  });
+
+  it('should handle empty meta', () => {
+    const result = parseCodeBlockMeta('');
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  it('should handle null meta', () => {
+    const result = parseCodeBlockMeta(null);
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  it('should handle undefined meta', () => {
+    const result = parseCodeBlockMeta(undefined);
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  it('should handle meta with only keys (no values)', () => {
+    const meta = 'key1 key2';
+    const result = parseCodeBlockMeta(meta);
+    expect(Object.keys(result).length).toBe(0);
+  });
+
+  it('should handle meta with complex values', () => {
+    const meta = 'label=file object={"complex": {"nested": true, "array": [1,2,3]}}';
+    const result = parseCodeBlockMeta(meta);
+    
+    expect(result.label).toBe('file');
+    // The function only splits by '=' and doesn't parse the JSON content
+    // So we just check that the string contains the start of the object
+    const objectValue = result.object;
+    expect(objectValue).toBeDefined();
+    expect(objectValue.startsWith('{"complex"')).toBeTruthy();
+  });
+});
+
+describe('createPlaceholderNode', () => {
+  it('should create a file placeholder node', () => {
+    const fileObject = {
+      kind: 'git',
+      filepath: '/path/to/file.js',
+      gitUrl: 'git@github.com:user/repo.git'
+    };
+    
+    const result = createPlaceholderNode('file', fileObject);
+    
+    expect(result.type).toBe('placeholder');
+    expect(result.placeholderType).toBe('file');
+    expect(result.attributes.object).toEqual(fileObject);
+  });
+
+  it('should create a symbol placeholder node', () => {
+    const symbolObject = {
+      name: 'myFunction',
+      type: 'function',
+      filepath: '/path/to/file.js'
+    };
+    
+    const result = createPlaceholderNode('symbol', symbolObject);
+    
+    expect(result.type).toBe('placeholder');
+    expect(result.placeholderType).toBe('symbol');
+    expect(result.attributes.object).toEqual(symbolObject);
+  });
+
+  it('should create a contextCommand placeholder node', () => {
+    const result = createPlaceholderNode('contextCommand', 'changes');
+    
+    expect(result.type).toBe('placeholder');
+    expect(result.placeholderType).toBe('contextCommand');
+    expect(result.attributes.object).toBe('changes');
+  });
+
+  it('should handle string object', () => {
+    const result = createPlaceholderNode('file', 'simple-string');
+    
+    expect(result.type).toBe('placeholder');
+    expect(result.placeholderType).toBe('file');
+    expect(result.attributes.object).toBe('simple-string');
+  });
+
+  it('should handle null object', () => {
+    const result = createPlaceholderNode('file', null);
+    
+    expect(result.type).toBe('placeholder');
+    expect(result.placeholderType).toBe('file');
+    expect(result.attributes.object).toBeNull();
+  });
+}); 

--- a/ee/tabby-ui/test/utils/remark-placeholder-parser.test.ts
+++ b/ee/tabby-ui/test/utils/remark-placeholder-parser.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest'
+import { parsePlaceholder, transformPlaceholders } from '../../lib/utils/markdown/remark-placeholder-parser'
+
+describe('parsePlaceholder', () => {
+  it('should parse source placeholder correctly', () => {
+    const text = '[[source:github:E12n3q]]';
+    const result = parsePlaceholder(text);
+    
+    expect(result).not.toBeNull();
+    expect(result?.matchLength).toBe(text.length);
+    expect(result?.placeholderNode.type).toBe('placeholder');
+    expect(result?.placeholderNode.placeholderType).toBe('source');
+    expect(result?.placeholderNode.attributes.source).toBe('github');
+    expect(result?.placeholderNode.attributes.documentId).toBe('E12n3q');
+  });
+
+  it('should parse file placeholder correctly', () => {
+    const fileInfo = {
+      kind: 'git',
+      filepath: '/path/to/file.js',
+      gitUrl: 'git@github.com:user/repo.git'
+    };
+    const text = `[[file:${JSON.stringify(fileInfo)}]]`;
+    const result = parsePlaceholder(text);
+    
+    expect(result).not.toBeNull();
+    expect(result?.matchLength).toBe(text.length);
+    expect(result?.placeholderNode.type).toBe('placeholder');
+    expect(result?.placeholderNode.placeholderType).toBe('file');
+    
+    // Parse the JSON string back to an object for comparison
+    const parsedObject = JSON.parse(result?.placeholderNode.attributes.object);
+    expect(parsedObject).toEqual(fileInfo);
+  });
+
+  it('should parse file placeholder with Windows path correctly', () => {
+    const fileInfo = {
+      kind: 'uri',
+      uri: 'C:\\Users\\user\\file.js'
+    };
+    const text = `[[file:${JSON.stringify(fileInfo)}]]`;
+    const result = parsePlaceholder(text);
+    
+    expect(result).not.toBeNull();
+    expect(result?.matchLength).toBe(text.length);
+    expect(result?.placeholderNode.type).toBe('placeholder');
+    expect(result?.placeholderNode.placeholderType).toBe('file');
+    
+    // Parse the JSON string back to an object for comparison
+    const parsedObject = JSON.parse(result?.placeholderNode.attributes.object);
+    expect(parsedObject.kind).toBe('uri');
+    expect(parsedObject.uri.includes('C:')).toBe(true);
+    expect(parsedObject.uri.includes('file.js')).toBe(true);
+  });
+
+  it('should parse symbol placeholder correctly', () => {
+    const symbolInfo = {
+      name: 'myFunction',
+      type: 'function',
+      filepath: '/path/to/file.js'
+    };
+    const text = `[[symbol:${JSON.stringify(symbolInfo)}]]`;
+    const result = parsePlaceholder(text);
+    
+    expect(result).not.toBeNull();
+    expect(result?.matchLength).toBe(text.length);
+    expect(result?.placeholderNode.type).toBe('placeholder');
+    expect(result?.placeholderNode.placeholderType).toBe('symbol');
+    
+    // Parse the JSON string back to an object for comparison
+    const parsedObject = JSON.parse(result?.placeholderNode.attributes.object);
+    expect(parsedObject).toEqual(symbolInfo);
+  });
+
+  it('should parse contextCommand placeholder correctly', () => {
+    const text = '[[contextCommand:changes]]';
+    const result = parsePlaceholder(text);
+    
+    expect(result).not.toBeNull();
+    expect(result?.matchLength).toBe(text.length);
+    expect(result?.placeholderNode.type).toBe('placeholder');
+    expect(result?.placeholderNode.placeholderType).toBe('contextCommand');
+    expect(result?.placeholderNode.attributes.command).toBe('changes');
+  });
+
+  it('should handle placeholder without colon correctly', () => {
+    const text = '[[simpleplaceholder]]';
+    const result = parsePlaceholder(text);
+    
+    expect(result).not.toBeNull();
+    expect(result?.matchLength).toBe(text.length);
+    expect(result?.placeholderNode.type).toBe('placeholder');
+    expect(result?.placeholderNode.placeholderType).toBe('undefined');
+    expect(result?.placeholderNode.attributes.content).toBe('simpleplaceholder');
+  });
+
+  it('should handle unknown prefix correctly', () => {
+    const text = '[[unknown:value]]';
+    const result = parsePlaceholder(text);
+    
+    expect(result).not.toBeNull();
+    expect(result?.matchLength).toBe(text.length);
+    expect(result?.placeholderNode.type).toBe('placeholder');
+    expect(result?.placeholderNode.placeholderType).toBe('undefined');
+    expect(result?.placeholderNode.attributes.content).toBe('undefined');
+  });
+
+  it('should return null for invalid placeholder syntax', () => {
+    const text = 'not a placeholder';
+    const result = parsePlaceholder(text);
+    
+    expect(result).toBeNull();
+  });
+
+  it('should handle incomplete placeholder syntax', () => {
+    const text = '[[incomplete';
+    const result = parsePlaceholder(text);
+    
+    expect(result).toBeNull();
+  });
+});
+
+describe('transformPlaceholders', () => {
+  it('should transform text with a source placeholder', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'This is a ' },
+            { type: 'text', value: '[[source:github:E12n3q]]' },
+            { type: 'text', value: ' reference.' }
+          ]
+        }
+      ]
+    };
+    
+    const result = transformPlaceholders(tree);
+    
+    expect(result.children[0].children.length).toBe(3);
+    expect(result.children[0].children[0].type).toBe('text');
+    expect(result.children[0].children[0].value).toBe('This is a ');
+    expect(result.children[0].children[1].type).toBe('placeholder');
+    expect(result.children[0].children[1].placeholderType).toBe('source');
+    expect(result.children[0].children[1].attributes.source).toBe('github');
+    expect(result.children[0].children[1].attributes.documentId).toBe('E12n3q');
+    expect(result.children[0].children[2].type).toBe('text');
+    expect(result.children[0].children[2].value).toBe(' reference.');
+  });
+
+  it('should transform text with multiple placeholders', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'First [[source:github:E12n3q]] and then [[contextCommand:changes]].' }
+          ]
+        }
+      ]
+    };
+    
+    const result = transformPlaceholders(tree);
+    
+    // The function splits the text and creates 5 children:
+    // 1. "First "
+    // 2. Placeholder for source
+    // 3. " and then "
+    // 4. Placeholder for contextCommand
+    // 5. "."
+    expect(result.children[0].children.length).toBe(5);
+    expect(result.children[0].children[0].type).toBe('text');
+    expect(result.children[0].children[0].value).toBe('First ');
+    expect(result.children[0].children[1].type).toBe('placeholder');
+    expect(result.children[0].children[1].placeholderType).toBe('source');
+    expect(result.children[0].children[2].type).toBe('text');
+    expect(result.children[0].children[2].value).toBe(' and then ');
+    expect(result.children[0].children[3].type).toBe('placeholder');
+    expect(result.children[0].children[3].placeholderType).toBe('contextCommand');
+    expect(result.children[0].children[4].type).toBe('text');
+    expect(result.children[0].children[4].value).toBe('.');
+  });
+
+  it('should handle invalid placeholder syntax', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'Text with [[incomplete placeholder.' }
+          ]
+        }
+      ]
+    };
+    
+    const result = transformPlaceholders(tree);
+    
+    // The function splits the text into:
+    // 1. "Text with "
+    // 2. "[["
+    // 3. "incomplete placeholder."
+    expect(result.children[0].children.length).toBe(3);
+    expect(result.children[0].children[0].type).toBe('text');
+    expect(result.children[0].children[0].value).toBe('Text with ');
+    expect(result.children[0].children[1].type).toBe('text');
+    expect(result.children[0].children[1].value).toBe('[[');
+    expect(result.children[0].children[2].type).toBe('text');
+    expect(result.children[0].children[2].value).toBe('incomplete placeholder.');
+  });
+
+  it('should not transform non-text nodes', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'code', value: '[[source:github:E12n3q]]' },
+            { type: 'text', value: 'Normal text.' }
+          ]
+        }
+      ]
+    };
+    
+    const result = transformPlaceholders(tree);
+    
+    expect(result.children[0].children.length).toBe(2);
+    expect(result.children[0].children[0].type).toBe('code');
+    expect(result.children[0].children[0].value).toBe('[[source:github:E12n3q]]');
+    expect(result.children[0].children[1].type).toBe('text');
+    expect(result.children[0].children[1].value).toBe('Normal text.');
+  });
+
+  it('should handle nested children', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'blockquote',
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                { type: 'text', value: 'Nested [[contextCommand:changes]].' }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    
+    const result = transformPlaceholders(tree);
+    
+    const paragraphNode = result.children[0].children[0];
+    // The function splits the text into:
+    // 1. "Nested "
+    // 2. Placeholder for contextCommand
+    // 3. "."
+    expect(paragraphNode.children.length).toBe(3);
+    expect(paragraphNode.children[0].type).toBe('text');
+    expect(paragraphNode.children[0].value).toBe('Nested ');
+    expect(paragraphNode.children[1].type).toBe('placeholder');
+    expect(paragraphNode.children[1].placeholderType).toBe('contextCommand');
+    expect(paragraphNode.children[2].type).toBe('text');
+    expect(paragraphNode.children[2].value).toBe('.');
+  });
+
+  it('should return null for null input', () => {
+    const result = transformPlaceholders(null);
+    expect(result).toBeNull();
+  });
+}); 

--- a/ee/tabby-ui/test/utils/remark-placeholder-parser.test.ts
+++ b/ee/tabby-ui/test/utils/remark-placeholder-parser.test.ts
@@ -90,7 +90,7 @@ describe('parsePlaceholder', () => {
     expect(result?.matchLength).toBe(text.length);
     expect(result?.placeholderNode.type).toBe('placeholder');
     expect(result?.placeholderNode.placeholderType).toBe('undefined');
-    expect(result?.placeholderNode.attributes.content).toBe('simpleplaceholder');
+    expect(result?.placeholderNode.attributes.content).toBe('[[simpleplaceholder]]');
   });
 
   it('should handle unknown prefix correctly', () => {
@@ -101,7 +101,7 @@ describe('parsePlaceholder', () => {
     expect(result?.matchLength).toBe(text.length);
     expect(result?.placeholderNode.type).toBe('placeholder');
     expect(result?.placeholderNode.placeholderType).toBe('undefined');
-    expect(result?.placeholderNode.attributes.content).toBe('undefined');
+    expect(result?.placeholderNode.attributes.content).toBe('[[unknown:value]]');
   });
 
   it('should return null for invalid placeholder syntax', () => {

--- a/ee/tabby-ui/test/utils/remark-placeholder-parser.test.ts
+++ b/ee/tabby-ui/test/utils/remark-placeholder-parser.test.ts
@@ -10,8 +10,7 @@ describe('parsePlaceholder', () => {
     expect(result?.matchLength).toBe(text.length);
     expect(result?.placeholderNode.type).toBe('placeholder');
     expect(result?.placeholderNode.placeholderType).toBe('source');
-    expect(result?.placeholderNode.attributes.source).toBe('github');
-    expect(result?.placeholderNode.attributes.documentId).toBe('E12n3q');
+    expect(result?.placeholderNode.attributes.sourceId).toBe('github:E12n3q');
   });
 
   it('should parse file placeholder correctly', () => {
@@ -143,8 +142,7 @@ describe('transformPlaceholders', () => {
     expect(result.children[0].children[0].value).toBe('This is a ');
     expect(result.children[0].children[1].type).toBe('placeholder');
     expect(result.children[0].children[1].placeholderType).toBe('source');
-    expect(result.children[0].children[1].attributes.source).toBe('github');
-    expect(result.children[0].children[1].attributes.documentId).toBe('E12n3q');
+    expect(result.children[0].children[1].attributes.sourceId).toBe('github:E12n3q');
     expect(result.children[0].children[2].type).toBe('text');
     expect(result.children[0].children[2].value).toBe(' reference.');
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,13 +190,13 @@ importers:
         version: 3.0.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)
+        version: 10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.3.3)
       tsc-watch:
         specifier: ^6.2.0
         version: 6.2.0(typescript@5.3.3)
       tsup:
         specifier: ^8.0.2
-        version: 8.0.2(@swc/core@1.3.101)(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3))(typescript@5.3.3)
+        version: 8.0.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.3.3))(typescript@5.3.3)
       typescript:
         specifier: ^5.3.2
         version: 5.3.3
@@ -441,7 +441,7 @@ importers:
         version: 6.2.0(typescript@5.4.5)
       tsup:
         specifier: ^8.0.2
-        version: 8.0.2(@swc/core@1.3.101)(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)
+        version: 8.0.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)
       typescript:
         specifier: ^5.3.2
         version: 5.4.5
@@ -465,7 +465,7 @@ importers:
         version: 18.2.0
       react-email:
         specifier: 2.1.3
-        version: 2.1.3(@swc/helpers@0.5.2)(eslint@9.3.0)(ts-node@10.9.2)
+        version: 2.1.3(@swc/helpers@0.5.2)(eslint@9.3.0)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2))
 
   ee/tabby-ui:
     dependencies:
@@ -589,6 +589,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
       '@uidotdev/usehooks':
         specifier: ^2.4.1
         version: 2.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -841,7 +844,7 @@ importers:
         version: 2.3.0
       '@tailwindcss/typography':
         specifier: ^0.5.9
-        version: 0.5.10(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2)))
+        version: 0.5.10(tailwindcss@3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2)))
       '@types/color':
         specifier: ^3.0.6
         version: 3.0.6
@@ -904,7 +907,7 @@ importers:
         version: 8.10.0(eslint@8.50.0)
       eslint-plugin-tailwindcss:
         specifier: ^3.12.0
-        version: 3.13.0(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2)))
+        version: 3.13.0(tailwindcss@3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2)))
       eslint-plugin-unused-imports:
         specifier: ^3.0.0
         version: 3.0.0(@typescript-eslint/eslint-plugin@7.4.0(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint@8.50.0)(typescript@5.8.2))(eslint@8.50.0)
@@ -934,10 +937,10 @@ importers:
         version: 1.14.0
       tailwindcss:
         specifier: ^3.3.1
-        version: 3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2))
+        version: 3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2))
       tailwindcss-animate:
         specifier: ^1.0.5
-        version: 1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2)))
+        version: 1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2)))
       typescript:
         specifier: ^5.6.3
         version: 5.8.2
@@ -15126,13 +15129,13 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tailwindcss/typography@0.5.10(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2)))':
+  '@tailwindcss/typography@0.5.10(tailwindcss@3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2))
+      tailwindcss: 3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2))
 
   '@tiptap/core@2.10.4(@tiptap/pm@2.10.4)':
     dependencies:
@@ -17983,7 +17986,7 @@ snapshots:
       debug: 4.3.4(supports-color@9.4.0)
       enhanced-resolve: 5.15.0
       eslint: 8.50.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.50.0))(eslint@8.50.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.50.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.50.0)
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
@@ -17999,7 +18002,7 @@ snapshots:
     dependencies:
       eslint: 9.3.0
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.50.0))(eslint@8.50.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.50.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -18058,7 +18061,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.50.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.50.0))(eslint@8.50.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.50.0)(typescript@5.8.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.50.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -18195,11 +18198,11 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-tailwindcss@3.13.0(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2))):
+  eslint-plugin-tailwindcss@3.13.0(tailwindcss@3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2))):
     dependencies:
       fast-glob: 3.3.1
       postcss: 8.4.31
-      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2))
+      tailwindcss: 3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2))
 
   eslint-plugin-toml@0.11.0(eslint@9.3.0):
     dependencies:
@@ -21455,37 +21458,37 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.38
 
-  postcss-load-config@4.0.1(postcss@8.4.31)(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2)):
+  postcss-load-config@4.0.1(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.4
     optionalDependencies:
       postcss: 8.4.31
-      ts-node: 10.9.2(@types/node@17.0.45)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.4.38
-      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2)
 
-  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)):
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.5.3
-      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.3.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)):
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.5.3
-      ts-node: 10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.4.5)
 
   postcss-merge-longhand@7.0.4(postcss@8.5.3):
     dependencies:
@@ -21933,7 +21936,7 @@ snapshots:
       react: 18.2.0
       scheduler: 0.23.0
 
-  react-email@2.1.3(@swc/helpers@0.5.2)(eslint@9.3.0)(ts-node@10.9.2):
+  react-email@2.1.3(@swc/helpers@0.5.2)(eslint@9.3.0)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2)):
     dependencies:
       '@babel/parser': 7.24.1
       '@radix-ui/colors': 1.0.1
@@ -21974,7 +21977,7 @@ snapshots:
       source-map-js: 1.0.2
       stacktrace-parser: 0.1.10
       tailwind-merge: 2.2.0
-      tailwindcss: 3.4.0(ts-node@10.9.2)
+      tailwindcss: 3.4.0(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2))
       typescript: 5.1.6
     transitivePeerDependencies:
       - '@babel/core'
@@ -23032,11 +23035,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.24.4
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2))):
     dependencies:
-      tailwindcss: 3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2))
+      tailwindcss: 3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2))
 
-  tailwindcss@3.3.3(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2)):
+  tailwindcss@3.3.3(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23055,7 +23058,7 @@ snapshots:
       postcss: 8.4.31
       postcss-import: 15.1.0(postcss@8.4.31)
       postcss-js: 4.0.1(postcss@8.4.31)
-      postcss-load-config: 4.0.1(postcss@8.4.31)(ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2))
+      postcss-load-config: 4.0.1(postcss@8.4.31)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2))
       postcss-nested: 6.0.1(postcss@8.4.31)
       postcss-selector-parser: 6.0.13
       resolve: 1.22.8
@@ -23063,7 +23066,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.0(ts-node@10.9.2):
+  tailwindcss@3.4.0(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23082,7 +23085,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2))
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.0.16
       resolve: 1.22.8
@@ -23132,7 +23135,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.3.101(@swc/helpers@0.5.2))(esbuild@0.19.11)(webpack@5.91.0):
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.101(@swc/helpers@0.5.2))(esbuild@0.19.11)(webpack@5.91.0(@swc/core@1.3.101(@swc/helpers@0.5.2))(esbuild@0.19.11)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -23256,7 +23259,28 @@ snapshots:
 
   ts-log@2.2.5: {}
 
-  ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3):
+  ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@17.0.45)(typescript@5.8.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 17.0.45
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.3.101(@swc/helpers@0.5.2)
+    optional: true
+
+  ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -23276,7 +23300,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.3.101(@swc/helpers@0.5.2)
 
-  ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5):
+  ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -23297,14 +23321,14 @@ snapshots:
       '@swc/core': 1.3.101(@swc/helpers@0.5.2)
     optional: true
 
-  ts-node@10.9.2(@types/node@17.0.45)(typescript@5.8.2):
+  ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@20.12.12)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 17.0.45
+      '@types/node': 20.12.12
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -23314,6 +23338,8 @@ snapshots:
       typescript: 5.8.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.3.101(@swc/helpers@0.5.2)
     optional: true
 
   tsc-watch@6.2.0(typescript@5.3.3):
@@ -23347,7 +23373,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.0.2(@swc/core@1.3.101)(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3))(typescript@5.3.3):
+  tsup@8.0.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
       bundle-require: 4.1.0(esbuild@0.19.12)
       cac: 6.7.14
@@ -23357,7 +23383,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.3.3))
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.3.3))
       resolve-from: 5.0.0
       rollup: 4.36.0
       source-map: 0.8.0-beta.0
@@ -23371,7 +23397,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@8.0.2(@swc/core@1.3.101)(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5):
+  tsup@8.0.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       bundle-require: 4.1.0(esbuild@0.19.12)
       cac: 6.7.14
@@ -23381,7 +23407,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101)(@types/node@18.19.33)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@swc/core@1.3.101(@swc/helpers@0.5.2))(@types/node@18.19.33)(typescript@5.4.5))
       resolve-from: 5.0.0
       rollup: 4.36.0
       source-map: 0.8.0-beta.0
@@ -24046,7 +24072,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.3.101(@swc/helpers@0.5.2))(esbuild@0.19.11)(webpack@5.91.0)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.101(@swc/helpers@0.5.2))(esbuild@0.19.11)(webpack@5.91.0(@swc/core@1.3.101(@swc/helpers@0.5.2))(esbuild@0.19.11))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
- Introduced new remark plugins for parsing and transforming placeholders in markdown, allowing for syntax like [[source:type:id]].
- Added functionality to convert code blocks with labels into placeholder nodes, improving markdown processing capabilities.
- Refactored existing markdown utilities to integrate new placeholder features and streamline processing.
- Added comprehensive tests for new functionality, ensuring robust handling of various placeholder types and code block metadata.

This update enhances the flexibility and usability of markdown processing within the application.

### Before
![image](https://github.com/user-attachments/assets/d10c0fd5-c254-4e81-b754-21ba33df09f5)

### After

![image](https://github.com/user-attachments/assets/8a5773b4-1835-4f92-9d7b-b4a491900473)
