### PR TITLE
ci: upgrade mozilla-actions/sccache-action to 0.0.9

### DIFF
--- a/.github/workflows/autofix-rust.yml
+++ b/.github/workflows/autofix-rust.yml
@@ -41,9 +41,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Sccache cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-        with:
-          version: "v0.10.0"
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Install cargo-machete
         uses: actions-rs/cargo@v1

--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -43,9 +43,7 @@ jobs:
           toolchain: stable
 
       - name: Sccache cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-        with:
-          version: "v0.10.0"
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cargo registry cache
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,9 +114,7 @@ jobs:
         run: rustup default ${{ env.RUST_TOOLCHAIN }}
 
       - name: Sccache cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-        with:
-          version: "v0.10.0"
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cargo registry cache
         uses: actions/cache@v4
@@ -221,9 +219,7 @@ jobs:
         run: rustup default ${{ env.RUST_TOOLCHAIN }}
 
       - name: Sccache cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-        with:
-          version: "v0.10.0"
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cargo registry cache
         uses: actions/cache@v4

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -50,9 +50,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Sccache cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-        with:
-          version: "v0.10.0"
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cargo registry cache
         uses: actions/cache@v4
@@ -97,9 +95,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Sccache cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-        with:
-          version: "v0.10.0"
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cargo registry cache
         uses: actions/cache@v4


### PR DESCRIPTION
CI: https://github.com/TabbyML/tabby/actions/runs/14338320249/job/40191048753