### PR TITLE
chore(page): support cleanup sections without content when creating a…

### DIFF
--- a/ee/tabby-db/src/pages.rs
+++ b/ee/tabby-db/src/pages.rs
@@ -351,6 +351,17 @@ impl DbConn {
         Ok(())
     }
 
+    pub async fn delete_page_sections_without_content(&self, page_id: i64) -> Result<()> {
+        query!(
+            "DELETE FROM page_sections WHERE page_id = ? AND COALESCE(content, '') = ''",
+            page_id
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn delete_page_section(&self, id: i64) -> Result<()> {
         query!("DELETE FROM page_sections WHERE id = ?", id,)
             .execute(&self.pool)


### PR DESCRIPTION
… page

debug log:
![CleanShot 2025-04-11 at 01 31 18@2x](https://github.com/user-attachments/assets/45278020-629c-49f2-baac-2d3997cfe7db)

manually refresh webpage when creating a page, the db is cleaned up:
![CleanShot 2025-04-11 at 01 32 13@2x](https://github.com/user-attachments/assets/b26f92c7-57dd-4845-a0e0-67399ce33a4e)

cc @liangfung 