### PR TITLE
refactor(chat): update file path handling in code references and ment…

### DIFF
--- a/ee/tabby-ui/app/pages/components/section-content.tsx
+++ b/ee/tabby-ui/app/pages/components/section-content.tsx
@@ -21,6 +21,7 @@ import {
   getAttachmentDocContent,
   getRangeFromAttachmentCode,
   isAttachmentCommitDoc,
+  resolveDirectoryPath,
   resolveFileNameForDisplay
 } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -325,8 +326,7 @@ function SourcePreviewCard({
   }
 
   if (isCode) {
-    const pathSegments = source.filepath.split('/')
-    const path = pathSegments.slice(0, pathSegments.length - 1).join('/')
+    const path = resolveDirectoryPath(source.filepath)
     const scores = source?.extra?.scores
     const showScores = enableDeveloperMode && !!scores
     return (

--- a/ee/tabby-ui/app/search/components/reading-code-step.tsx
+++ b/ee/tabby-ui/app/search/components/reading-code-step.tsx
@@ -13,6 +13,7 @@ import {
   cn,
   isAttachmentCommitDoc,
   isCodeSourceContext,
+  resolveDirectoryPath,
   resolveFileNameForDisplay
 } from '@/lib/utils'
 import {
@@ -285,8 +286,7 @@ function CodeContextItem({
   onContextClick,
   enableDeveloperMode
 }: CodeContextItemProps) {
-  const pathSegments = context.filepath.split('/')
-  const path = pathSegments.slice(0, pathSegments.length - 1).join('/')
+  const path = resolveDirectoryPath(context.filepath)
 
   const fileName = useMemo(() => {
     return resolveFileNameForDisplay(context.filepath)

--- a/ee/tabby-ui/components/chat/code-references.tsx
+++ b/ee/tabby-ui/components/chat/code-references.tsx
@@ -2,7 +2,11 @@ import React, { forwardRef, useEffect, useState } from 'react'
 import { isNil } from 'lodash-es'
 
 import { RelevantCodeContext } from '@/lib/types'
-import { cn, resolveFileNameForDisplay } from '@/lib/utils'
+import {
+  cn,
+  resolveDirectoryPath,
+  resolveFileNameForDisplay
+} from '@/lib/utils'
 import {
   Tooltip,
   TooltipContent,
@@ -158,8 +162,7 @@ function ContextItem({
     !isNil(context.range?.start) &&
     !isNil(context.range?.end) &&
     context.range.start < context.range.end
-  const pathSegments = context.filepath.split('/')
-  const path = pathSegments.slice(0, pathSegments.length - 1).join('/')
+  const path = resolveDirectoryPath(context.filepath)
   const scores = context?.extra?.scores
   const onTooltipOpenChange = (v: boolean) => {
     if (!enableTooltip || !scores) return

--- a/ee/tabby-ui/components/chat/form-editor/mention.tsx
+++ b/ee/tabby-ui/components/chat/form-editor/mention.tsx
@@ -24,7 +24,12 @@ import {
 } from 'tabby-chat-panel/index'
 
 import { useDebounceValue } from '@/lib/hooks/use-debounce'
-import { cn, convertFromFilepath, resolveFileNameForDisplay } from '@/lib/utils'
+import {
+  cn,
+  convertFromFilepath,
+  resolveDirectoryPath,
+  resolveFileNameForDisplay
+} from '@/lib/utils'
 import { IconChevronLeft, IconChevronRight } from '@/components/ui/icons'
 
 import type { CategoryItem, CategoryMenu, FileItem, SourceItem } from '../types'
@@ -431,10 +436,7 @@ interface OptionItemView extends HTMLAttributes<HTMLDivElement> {
 function OptionItemView({ isSelected, data, ...rest }: OptionItemView) {
   const ref = useRef<HTMLDivElement>(null)
   const filepathWithoutFilename = useMemo(() => {
-    if (!data.filepath) return ''
-    const parts = data.filepath.split(/[\\/]/)
-    // shown as / for consistency
-    return parts.slice(0, -1).join('/')
+    return resolveDirectoryPath(data.filepath || '')
   }, [data.filepath])
 
   useLayoutEffect(() => {

--- a/ee/tabby-ui/components/chat/reading-repo-stepper.tsx
+++ b/ee/tabby-ui/components/chat/reading-repo-stepper.tsx
@@ -12,6 +12,7 @@ import {
   isAttachmentCommitDoc,
   isAttachmentIssueDoc,
   isAttachmentPullDoc,
+  resolveDirectoryPath,
   resolveFileNameForDisplay
 } from '@/lib/utils'
 import {
@@ -260,8 +261,7 @@ function CodeSummaryView({
     !isNil(context.range?.start) &&
     !isNil(context.range?.end) &&
     context.range.start < context.range.end
-  const pathSegments = context.filepath.split('/')
-  const path = pathSegments.slice(0, pathSegments.length - 1).join('/')
+  const path = resolveDirectoryPath(context.filepath)
   const scores = context?.extra?.scores
   const onTooltipOpenChange = (v: boolean) => {
     if (!enableTooltip || !scores) return

--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -24,6 +24,7 @@ import {
   formatCustomHTMLBlockTags,
   getRangeFromAttachmentCode,
   isAttachmentCommitDoc,
+  resolveDirectoryPath,
   resolveFileNameForDisplay
 } from '@/lib/utils'
 import {
@@ -710,8 +711,7 @@ function RelevantCodeBadge({
     !isNil(context.range?.start) &&
     !isNil(context.range?.end) &&
     context.range.start < context.range.end
-  const pathSegments = context.filepath.split('/')
-  const path = pathSegments.slice(0, pathSegments.length - 1).join('/')
+  const path = resolveDirectoryPath(context.filepath)
 
   const fileName = useMemo(() => {
     return resolveFileNameForDisplay(context.filepath)

--- a/ee/tabby-ui/lib/utils/index.ts
+++ b/ee/tabby-ui/lib/utils/index.ts
@@ -291,3 +291,29 @@ export function buildCodeBrowserUrlForContext(
 
   return url.toString()
 }
+
+export function resolveDirectoryPath(filepath: string): string {
+  if (!filepath) return ''
+  let url: URL
+  try {
+    url = new URL(filepath)
+  } catch (e) {
+    try {
+      url = new URL(filepath, 'file://')
+    } catch (e2) {
+      return ''
+    }
+  }
+
+  try {
+    const parts = url.pathname.split('/')
+    const relevantParts = parts[0] === '' ? parts.slice(1) : parts
+    const dirPath = relevantParts.slice(0, -1).join('/')
+    if (parts[0] === '' && relevantParts.length > 1) {
+      return '/' + dirPath
+    }
+    return dirPath
+  } catch (e) {
+    return ''
+  }
+}


### PR DESCRIPTION
…ion components

- Replaced manual path segment manipulation with utility functions `resolveDirectoryPath` and `resolveFileNameFromPath` for improved readability and maintainability.
- Updated imports in `code-references.tsx` and `mention.tsx` to reflect the new utility functions.

### unix
![image](https://github.com/user-attachments/assets/d78696ab-9868-458e-8368-da4a745566f2)

![image](https://github.com/user-attachments/assets/624ac5b4-cb28-4a7c-ae80-76d875dcf9c1)

### windows



#### before
![image](https://github.com/user-attachments/assets/784b97b0-ac35-4c29-a97a-6dc3e825784c)

![image](https://github.com/user-attachments/assets/617e182f-0a80-40a1-869a-d9ff52ffb78a)

#### after
![image](https://github.com/user-attachments/assets/ebb77f5e-85a9-4f40-aea4-f171e00ff9fd)

![image](https://github.com/user-attachments/assets/356dace7-1bc4-4383-8d33-8e3dc262ec14)

![image](https://github.com/user-attachments/assets/500b3420-b7f6-436f-89b8-c744894810db)

