### PR TITLE
feat(ui): add structured_doc page graphql types

### DIFF
--- a/ee/tabby-ui/app/pages/components/page-main.tsx
+++ b/ee/tabby-ui/app/pages/components/page-main.tsx
@@ -514,7 +514,7 @@ export function Page() {
           pageId,
           titlePrompt: title,
           docQuery: {
-            sourceIds: compact([page?.codeSourceId]),
+            sourceIds: compact([page?.codeSourceId, 'page']),
             content: title,
             searchPublic: true
           },
@@ -619,7 +619,7 @@ export function Page() {
               }
             : null,
           docQuery: {
-            sourceIds: compact([codeSourceId]),
+            sourceIds: compact([codeSourceId, 'page']),
             content: titlePrompt,
             searchPublic: true
           },

--- a/ee/tabby-ui/app/pages/lib/query.ts
+++ b/ee/tabby-ui/app/pages/lib/query.ts
@@ -121,6 +121,11 @@ export const createThreadToPageRunSubscription = graphql(/* GraphQL */ `
               }
               authorAt
             }
+            ... on AttachmentPageDoc {
+              link
+              title
+              content
+            }
           }
           score
         }
@@ -274,6 +279,11 @@ export const createPageRunSubscription = graphql(/* GraphQL */ `
               }
               authorAt
             }
+            ... on AttachmentPageDoc {
+              link
+              title
+              content
+            }
           }
           score
         }
@@ -382,6 +392,11 @@ export const createPageSectionRunSubscription = graphql(/* GraphQL */ `
                 name
               }
               authorAt
+            }
+            ... on AttachmentPageDoc {
+              link
+              title
+              content
             }
           }
           score

--- a/ee/tabby-ui/app/search/components/search.tsx
+++ b/ee/tabby-ui/app/search/components/search.tsx
@@ -1037,7 +1037,7 @@ function getSourceInputs(
   if (ctx) {
     sourceIdsForDocQuery = uniq(
       // Compatible with existing user messages
-      compact([repositorySourceId, ctx?.codeSourceId].concat(ctx.docSourceIds))
+      compact([repositorySourceId, ctx?.codeSourceId, 'page'].concat(ctx.docSourceIds))
     )
     searchPublic = ctx.searchPublic ?? false
     sourceIdForCodeQuery = repositorySourceId || ctx.codeSourceId || undefined

--- a/ee/tabby-ui/components/message-markdown/doc-detail-view.tsx
+++ b/ee/tabby-ui/components/message-markdown/doc-detail-view.tsx
@@ -10,6 +10,7 @@ import {
   getAttachmentDocContent,
   isAttachmentCommitDoc,
   isAttachmentIssueDoc,
+  isAttachmentPageDoc,
   isAttachmentPullDoc,
   isAttachmentWebDoc
 } from '@/lib/utils'
@@ -51,7 +52,7 @@ export function DocDetailView({
     relevantDocument.title
   )
   const sourceUrl = link ? new URL(link) : null
-  const author = isAttachmentWebDoc(relevantDocument)
+  const author = (isAttachmentWebDoc(relevantDocument) || isAttachmentPageDoc(relevantDocument))
     ? undefined
     : relevantDocument.author
   const score = relevantDocument?.extra?.score

--- a/ee/tabby-ui/lib/hooks/use-thread-run.ts
+++ b/ee/tabby-ui/lib/hooks/use-thread-run.ts
@@ -104,6 +104,11 @@ const CreateThreadAndRunSubscription = graphql(/* GraphQL */ `
               }
               authorAt
             }
+            ... on MessageAttachmentPageDoc {
+              link
+              title
+              content
+            }
           }
           score
         }
@@ -204,6 +209,11 @@ const CreateThreadRunSubscription = graphql(/* GraphQL */ `
                 name
               }
               authorAt
+            }
+            ... on MessageAttachmentPageDoc {
+              link
+              title
+              content
             }
           }
           score

--- a/ee/tabby-ui/lib/tabby/query.ts
+++ b/ee/tabby-ui/lib/tabby/query.ts
@@ -465,6 +465,11 @@ export const listThreadMessages = graphql(/* GraphQL */ `
                 }
                 authorAt
               }
+              ... on MessageAttachmentPageDoc {
+                title
+                link
+                content
+              }
             }
             codeFileList {
               fileList
@@ -663,6 +668,11 @@ export const listPageSections = graphql(/* GraphQL */ `
                 }
                 authorAt
               }
+              ... on AttachmentPageDoc {
+              link
+              title
+              content
+            }
             }
           }
         }

--- a/ee/tabby-ui/lib/utils/attachment.ts
+++ b/ee/tabby-ui/lib/utils/attachment.ts
@@ -28,6 +28,13 @@ export function isAttachmentIssueDoc(attachment: AttachmentDocItem) {
   )
 }
 
+export function isAttachmentPageDoc(attachment: AttachmentDocItem) {
+  return (
+    attachment.__typename === 'AttachmentPageDoc' ||
+    attachment.__typename === 'MessageAttachmentPageDoc'
+  )
+}
+
 export function getAttachmentDocContent(attachment: AttachmentDocItem) {
   switch (attachment.__typename) {
     case 'MessageAttachmentWebDoc':


### PR DESCRIPTION
Note: api change only, not Page doc card added.

due to https://github.com/TabbyML/tabby/pull/4133, we must update graphql request to update UI.

![CleanShot 2025-04-15 at 00 48 42@2x](https://github.com/user-attachments/assets/4eb25339-533b-474e-a0ca-7d86d3ac8b12)

