### PR TITLE
fix(ui): ensure full width for the pull source card

### DIFF
--- a/ee/tabby-ui/app/pages/components/section-content.tsx
+++ b/ee/tabby-ui/app/pages/components/section-content.tsx
@@ -394,9 +394,9 @@ function SourcePreviewCard({
   if (isDoc) {
     return (
       <div className="flex items-start gap-2">
-        <div className="relative flex flex-1 cursor-pointer gap-2 rounded-lg bg-accent p-3 text-accent-foreground hover:bg-accent/70">
+        <div className="relative flex w-full cursor-pointer gap-2 rounded-lg bg-accent p-3 text-accent-foreground hover:bg-accent/70">
           <div
-            className="relative flex flex-col justify-between"
+            className="relative flex w-full flex-col justify-between"
             onClick={() => window.open(source.link)}
           >
             <DocPreviewCard source={source} />


### PR DESCRIPTION
## Screenshot

### Before
<img width="382" alt="image" src="https://github.com/user-attachments/assets/62f7748f-f142-4ce3-8755-fe1291508ca6" />

### After
<img width="378" alt="image" src="https://github.com/user-attachments/assets/c7df67c9-8d85-46cf-aa01-76c7c0ca01d6" />
