### PR TITLE
fix(page): add doc query when convert thread to page

### DIFF
--- a/ee/tabby-db/src/pages.rs
+++ b/ee/tabby-db/src/pages.rs
@@ -31,7 +31,7 @@ pub struct PageSectionDAO {
 }
 
 impl DbConn {
-    pub async fn create_page(&self, author_id: i64, code_source_id: Option<String>) -> Result<i64> {
+    pub async fn create_page(&self, author_id: i64, code_source_id: Option<&str>) -> Result<i64> {
         let res = query!(
             "INSERT INTO pages(author_id, code_source_id) VALUES (?, ?)",
             author_id,


### PR DESCRIPTION
1. since `convert page`, `new page`, `new sections` need different code query prompt, only pass the code_source_id to page_run
2. use the same source_id with code_query when doc_query is empty but code_query has value(the convert page case)
3. always return doc/code query event with debug data even when no doc/code matched

![CleanShot 2025-04-21 at 18 49 03@2x](https://github.com/user-attachments/assets/72389644-d729-4057-aed7-07a6e0e1d6e5)
