### PR TITLE
feat(ingestion): support delete ingested doc and garbage collection

### DIFF
--- a/crates/tabby-index/src/code/index.rs
+++ b/crates/tabby-index/src/code/index.rs
@@ -61,7 +61,7 @@ pub async fn garbage_collection() {
         let mut num_to_keep = 0;
         let mut num_to_delete = 0;
 
-        for await id in index.iter_ids() {
+        for await (_, id) in index.iter_ids() {
             let Some(source_file_id) = SourceCode::source_file_id_from_id(&id) else {
                 warn!("Failed to extract source file id from index id: {id}");
                 num_to_delete += 1;

--- a/crates/tabby-index/src/lib.rs
+++ b/crates/tabby-index/src/lib.rs
@@ -22,10 +22,10 @@ pub mod public {
     pub use super::{
         code::CodeIndexer,
         structured_doc::public::{
-            StructuredDoc, StructuredDocCommitFields, StructuredDocFields, StructuredDocIndexer,
-            StructuredDocIngestedFields, StructuredDocIssueFields, StructuredDocPageFields,
-            StructuredDocPullDocumentFields, StructuredDocState, StructuredDocWebFields,
-            KIND_COMMIT as STRUCTURED_DOC_KIND_COMMIT,
+            StructuredDoc, StructuredDocCommitFields, StructuredDocFields,
+            StructuredDocGarbageCollector, StructuredDocIndexer, StructuredDocIngestedFields,
+            StructuredDocIssueFields, StructuredDocPageFields, StructuredDocPullDocumentFields,
+            StructuredDocState, StructuredDocWebFields, KIND_COMMIT as STRUCTURED_DOC_KIND_COMMIT,
         },
     };
 

--- a/ee/tabby-schema/src/schema/ingestion.rs
+++ b/ee/tabby-schema/src/schema/ingestion.rs
@@ -29,6 +29,7 @@ pub struct IngestionStats {
 
 #[async_trait]
 pub trait IngestionService: Send + Sync {
+    async fn get(&self, source_id: &str, id: &str) -> Result<IngestedDocument>;
     async fn list(
         &self,
         after: Option<String>,
@@ -44,6 +45,8 @@ pub trait IngestionService: Send + Sync {
     ) -> Result<Vec<String>>;
 
     async fn ingestion(&self, ingestion: IngestionRequest) -> Result<IngestionResponse>;
+    async fn delete(&self, source_id: String, id: String) -> Result<()>;
+    async fn delete_by_source_id(&self, source_id: String) -> Result<()>;
     async fn stats(&self, sources: Option<Vec<String>>) -> Result<Vec<IngestionStats>>;
 
     async fn should_ingest(&self) -> Result<bool>;

--- a/ee/tabby-webserver/src/lib.rs
+++ b/ee/tabby-webserver/src/lib.rs
@@ -19,6 +19,8 @@ use utoipa::OpenApi;
 #[openapi(
     paths(
         routes::ingestion::ingestion,
+        routes::ingestion::delete_ingestion_source,
+        routes::ingestion::delete_ingestion,
     ),
     components(schemas(
         api::ingestion::IngestionRequest,

--- a/ee/tabby-webserver/src/routes/ingestion.rs
+++ b/ee/tabby-webserver/src/routes/ingestion.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use axum::{extract::State, Json};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
 use hyper::StatusCode;
 use tabby_common::api::ingestion::{IngestionRequest, IngestionResponse};
 use tabby_schema::ingestion::IngestionService;
@@ -46,4 +49,74 @@ pub async fn ingestion(
         })?;
 
     Ok((StatusCode::ACCEPTED, Json(response)))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1beta/ingestion/{source}",
+    operation_id = "delete_ingestion_source",
+    tag = "v1beta",
+    responses(
+        (status = 202, description = "Accepted, Waiting to be processed", content_type = "application/json"),
+        (status = 400, description = "Bad Request"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+    ),
+    security(
+        ("token" = [])
+    )
+)]
+#[instrument(skip(state))]
+pub async fn delete_ingestion_source(
+    State(state): State<Arc<IngestionState>>,
+    Path(source): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    if source.is_empty() {
+        warn!("Invalid request: source is empty");
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    state
+        .ingestion
+        .delete_by_source_id(source)
+        .await
+        .map_err(|e| {
+            error!("Failed to process ingestion: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(StatusCode::ACCEPTED)
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1beta/ingestion/{source}/{id}",
+    operation_id = "delete_ingestion",
+    tag = "v1beta",
+    responses(
+        (status = 202, description = "Accepted, Waiting to be processed", content_type = "application/json"),
+        (status = 400, description = "Bad Request"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+    ),
+    security(
+        ("token" = [])
+    )
+)]
+#[instrument(skip(state))]
+pub async fn delete_ingestion(
+    State(state): State<Arc<IngestionState>>,
+    Path((source, id)): Path<(String, String)>,
+) -> Result<StatusCode, StatusCode> {
+    if source.is_empty() || id.is_empty() {
+        warn!("Invalid request: source or id is empty");
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    state.ingestion.delete(source, id).await.map_err(|e| {
+        error!("Failed to process ingestion: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(StatusCode::ACCEPTED)
 }

--- a/ee/tabby-webserver/src/routes/mod.rs
+++ b/ee/tabby-webserver/src/routes/mod.rs
@@ -63,6 +63,22 @@ pub fn create(
                 ingestion: ctx.ingestion(),
             })),
         )
+        .route(
+            "/v1beta/ingestion/{source}",
+            routing::delete(ingestion::delete_ingestion_source).with_state(Arc::new(
+                ingestion::IngestionState {
+                    ingestion: ctx.ingestion(),
+                },
+            )),
+        )
+        .route(
+            "/v1beta/ingestion/{source}/{id}",
+            routing::delete(ingestion::delete_ingestion).with_state(Arc::new(
+                ingestion::IngestionState {
+                    ingestion: ctx.ingestion(),
+                },
+            )),
+        )
         .layer(from_fn_with_state(ctx.clone(), distributed_tabby_layer))
         .route(
             "/graphql",

--- a/ee/tabby-webserver/src/service/background_job/hourly.rs
+++ b/ee/tabby-webserver/src/service/background_job/hourly.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use tabby_db::DbConn;
 use tabby_schema::{
     context::ContextService,
+    ingestion::IngestionService,
     integration::IntegrationService,
     job::JobService,
     repository::{GitRepositoryService, RepositoryService, ThirdPartyRepositoryService},
@@ -30,6 +31,7 @@ impl HourlyJob {
         context_service: Arc<dyn ContextService>,
         git_repository_service: Arc<dyn GitRepositoryService>,
         job_service: Arc<dyn JobService>,
+        ingestion_service: Arc<dyn IngestionService>,
         integration_service: Arc<dyn IntegrationService>,
         third_party_repository_service: Arc<dyn ThirdPartyRepositoryService>,
         repository_service: Arc<dyn RepositoryService>,
@@ -68,7 +70,11 @@ impl HourlyJob {
         }
 
         if let Err(err) = IndexGarbageCollection
-            .run(repository_service.clone(), context_service.clone())
+            .run(
+                repository_service.clone(),
+                context_service.clone(),
+                ingestion_service.clone(),
+            )
             .await
         {
             has_error = true;

--- a/ee/tabby-webserver/src/service/background_job/index_garbage_collection.rs
+++ b/ee/tabby-webserver/src/service/background_job/index_garbage_collection.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 
-use tabby_index::public::{run_index_garbage_collection, CodeIndexer};
-use tabby_schema::{context::ContextService, repository::RepositoryService};
+use tabby_index::public::{
+    run_index_garbage_collection, CodeIndexer, StructuredDocGarbageCollector,
+};
+use tabby_schema::{
+    context::ContextService, ingestion::IngestionService, repository::RepositoryService,
+};
 
 use super::helper::Job;
 
@@ -16,7 +20,9 @@ impl IndexGarbageCollection {
         self,
         repository: Arc<dyn RepositoryService>,
         context: Arc<dyn ContextService>,
+        ingestion: Arc<dyn IngestionService>,
     ) -> tabby_schema::Result<()> {
+        let mut failed = false;
         // Run garbage collection on the index
         let sources = context
             .read(None)
@@ -25,13 +31,38 @@ impl IndexGarbageCollection {
             .into_iter()
             .map(|x| x.source_id())
             .collect::<Vec<_>>();
-        run_index_garbage_collection(sources)?;
+        if let Err(e) = run_index_garbage_collection(sources) {
+            failed = true;
+            logkit::warn!("Failed to run index garbage collection: {}", e);
+        }
 
         // Run garbage collection on the code repositories (cloned directories)
         let repositories = repository.list_all_code_repository().await?;
         let mut code = CodeIndexer::default();
         code.garbage_collection(&repositories).await;
 
-        Ok(())
+        let should_keep_structured_doc = |source_id: String, id: String| {
+            let ingestion = ingestion.clone();
+            async move { ingestion.get(&source_id, &id).await.is_ok() }
+        };
+
+        let structured_doc_garbage_collector = StructuredDocGarbageCollector::default();
+        if let Err(e) = structured_doc_garbage_collector
+            .run(should_keep_structured_doc)
+            .await
+        {
+            failed = true;
+            logkit::warn!("Failed to run structured doc garbage collection: {}", e);
+        }
+
+        if failed {
+            logkit::warn!("Index garbage collection job failed");
+            Err(tabby_schema::CoreError::Other(anyhow::anyhow!(
+                "Index garbage collection job failed"
+            )))
+        } else {
+            logkit::info!("Index garbage collection job completed successfully");
+            Ok(())
+        }
     }
 }

--- a/ee/tabby-webserver/src/service/background_job/mod.rs
+++ b/ee/tabby-webserver/src/service/background_job/mod.rs
@@ -261,7 +261,7 @@ pub async fn start(
                         }
                         BackgroundJobEvent::IndexGarbageCollection => {
                             let job = IndexGarbageCollection;
-                            job.run(repository_service.clone(), context_service.clone()).await
+                            job.run(repository_service.clone(), context_service.clone(), ingestion_service.clone()).await
                         }
                         BackgroundJobEvent::SyncIngestionIndex => {
                             let job = SyncIngestionIndexJob;
@@ -277,6 +277,7 @@ pub async fn start(
                                 context_service.clone(),
                                 git_repository_service.clone(),
                                 job_service.clone(),
+                                ingestion_service.clone(),
                                 integration_service.clone(),
                                 third_party_repository_service.clone(),
                                 repository_service.clone(),


### PR DESCRIPTION
## API
![CleanShot 2025-04-29 at 21 42 20@2x](https://github.com/user-attachments/assets/a15b2b5b-6dc1-4e12-9a96-9277e952e2e3)

## GC
1. for deleting by source, GC by source id would do the cleanup.
2. for deleting by id, list every structured doc source and id, and then range to check whether it is ingested doc and still existed in sqlite.

As for `2.`, Tantivy can not query ingested doc with streaming return, so we are iterating all structured docs

## Test

ingested docs:

![Postman 2025-04-29 21 36 19](https://github.com/user-attachments/assets/dca9a3d9-aed1-4ce6-94b8-fbcf21f9a743)

ingested index:

![CleanShot 2025-04-29 at 21 38 51@2x](https://github.com/user-attachments/assets/fbcf9a78-b480-45ec-8466-e1a998a4c62b)

deleted doc:
![CleanShot 2025-04-29 at 21 40 38@2x](https://github.com/user-attachments/assets/2428711f-86bc-48f4-82e4-a9f859df1889)

after GC:

ingested doc with id `page 123 456 678` has gone in index:

![CleanShot 2025-04-29 at 21 41 07@2x](https://github.com/user-attachments/assets/5101d701-721a-40d7-b960-84f9a6863a69)
