### PR TITLE
feat(intellij): add cancel action and loading state for inline chat edits

### DIFF
--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/DiffHighLightingPass.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/DiffHighLightingPass.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.codeInsight.daemon.impl.HighlightInfoType
 import com.intellij.codeInsight.daemon.impl.UpdateHighlightersUtil
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColors
@@ -41,6 +42,8 @@ class DiffHighlightingPassFactory : TextEditorHighlightingPassFactory {
 
 class DiffHighLightingPass(project: Project, document: Document, val editor: Editor) :
     TextEditorHighlightingPass(project, document, true), DumbAware {
+
+    private val logger = Logger.getInstance(DiffHighLightingPass::class.java)
 
     private var lenses = emptyList<CodeLens>()
     private val file = FileDocumentManager.getInstance().getFile(myDocument)
@@ -109,6 +112,7 @@ class DiffHighLightingPass(project: Project, document: Document, val editor: Edi
     override fun doCollectInformation(progress: ProgressIndicator) {
         val uri = file?.url ?: return
         lenses = getCodeLenses(myProject, uri).get() ?: emptyList()
+        logger.debug("Lens: $lenses")
         for (lens in lenses) {
             if ((lens.data as JsonObject?)?.get("type")?.asString != "previewChanges") continue
             val range = lens.range

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatAction.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatAction.kt
@@ -24,7 +24,6 @@ class InlineChatAcceptAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val inlineChatService = project.serviceOrNull<InlineChatService>() ?: return
-        inlineChatService.inlineChatEditing = false
         val location = inlineChatService.location ?: return
         scope.launch {
             val server = project.serviceOrNull<ConnectionService>()?.getServerAsync() ?: return@launch
@@ -39,11 +38,24 @@ class InlineChatDiscardAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val inlineChatService = project.serviceOrNull<InlineChatService>() ?: return
-        inlineChatService.inlineChatEditing = false
         val location = inlineChatService.location ?: return
         scope.launch {
             val server = project.serviceOrNull<ConnectionService>()?.getServerAsync() ?: return@launch
             server.chatFeature.resolveEdit(ChatEditResolveParams(location = location, action = "discard"))
+        }
+    }
+}
+
+class InlineChatCancelAction : DumbAwareAction() {
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val inlineChatService = project.serviceOrNull<InlineChatService>() ?: return
+        val location = inlineChatService.location ?: return
+        scope.launch {
+            val server = project.serviceOrNull<ConnectionService>()?.getServerAsync() ?: return@launch
+            server.chatFeature.resolveEdit(ChatEditResolveParams(location = location, action = "cancel"))
         }
     }
 }

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatIntentionAction.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatIntentionAction.kt
@@ -50,13 +50,13 @@ class InlineChatIntentionAction : BaseIntentionAction(), DumbAware {
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
         val inlineChatService = project.serviceOrNull<InlineChatService>() ?: return
-        if (inlineChatService.inlineChatEditing) return
-        inlineChatService.inlineChatEditing = true
+        if (inlineChatService.inlineChatInputVisible || inlineChatService.hasDiffAction) return
         this.project = project
         this.editor = editor
         if (editor != null) {
             val locationInfo = getCurrentLocation(editor = editor)
             inlineChatService.location = locationInfo.location
+            inlineChatService.inlineChatInputVisible = true
             addInputToEditor(project, editor, locationInfo.startOffset);
         }
 
@@ -83,7 +83,7 @@ class InlineChatIntentionAction : BaseIntentionAction(), DumbAware {
     private fun onClose() {
         inlay?.dispose()
         val inlineChatService = project?.serviceOrNull<InlineChatService>() ?: return
-        inlineChatService.inlineChatEditing = false
+        inlineChatService.inlineChatInputVisible = false
     }
 
     private fun onInputSubmit(value: String) {
@@ -151,8 +151,10 @@ class InlineChatInlayRenderer(
         if (disposed) {
             return
         }
+        val visibleArea = editor.scrollingModel.visibleArea
         if (this.targetRegion == null) {
             this.targetRegion = targetRegion
+            this.targetRegion?.y = targetRegion.y + visibleArea.y
         }
         val firstTargetRegion = this.targetRegion ?: targetRegion
         inlineChatComponent.setSize(firstTargetRegion.width, firstTargetRegion.height)

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatService.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatService.kt
@@ -8,9 +8,16 @@ import org.eclipse.lsp4j.Location
 @Service(Service.Level.PROJECT)
 class InlineChatService(private val project: Project) : Disposable {
 
-    var inlineChatEditing = false
+    var inlineChatInputVisible = false
+    var inlineChatDiffActionState = mutableMapOf<String, Boolean>()
     var location: Location? = null
 
+    val hasDiffAction: Boolean
+        get() = inlineChatDiffActionState.any { it.value }
+
     override fun dispose() {
+        inlineChatInputVisible = false
+        inlineChatDiffActionState.clear()
+        location = null
     }
 }

--- a/clients/intellij/src/main/resources/META-INF/plugin.xml
+++ b/clients/intellij/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,8 @@
         <intentionAction>
             <className>com.tabbyml.intellijtabby.inlineChat.InlineChatIntentionAction</className>
         </intentionAction>
+        <codeInsight.codeVisionProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatLoadingCodeVisionProvider" />
+        <codeInsight.codeVisionProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatCancelCodeVisionProvider" />
         <codeInsight.codeVisionProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatAcceptCodeVisionProvider" />
         <codeInsight.codeVisionProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatDiscardCodeVisionProvider" />
         <highlightingPassFactory implementation="com.tabbyml.intellijtabby.inlineChat.DiffHighlighterRegister" />
@@ -273,6 +275,13 @@
                 class="com.tabbyml.intellijtabby.inlineChat.InlineChatDiscardAction"
                 text="Discard Inline Edit"
                 description="Discard the inline edit suggestion.">
+            <keyboard-shortcut first-keystroke="ctrl ESCAPE" keymap="$default"/>
+        </action>
+
+        <action id="Tabby.InlineChat.Resolve.Cancel"
+                class="com.tabbyml.intellijtabby.inlineChat.InlineChatCancelAction"
+                text="Cancel Inline Edit"
+                description="Cancel the inline edit suggestion.">
             <keyboard-shortcut first-keystroke="ctrl ESCAPE" keymap="$default"/>
         </action>
     </actions>


### PR DESCRIPTION
- feat: add cancel action and loading state for inline chat edits
- fix: wrong inline edit position for scrolled editor
- fix: cant't trigger inline edit when user undo inline diff

![image](https://github.com/user-attachments/assets/69d19235-9f23-4552-8cac-0cc0db4522f4)

![image](https://github.com/user-attachments/assets/a72cb496-b877-48a2-acf8-dc9e9f3e8a12)
