### PR TITLE
chore: bump vulkan to 1.3.296 for both linux and windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
             binary: x86_64-manylinux_2_28-vulkan
             container: quay.io/pypa/manylinux_2_28_x86_64
             build_args: --features binary,vulkan
-            vulkan_sdk: '1.3.239.0'
+            vulkan_sdk: '1.3.296.0'
           - os: windows-2019
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc
@@ -69,7 +69,7 @@ jobs:
             binary: x86_64-windows-msvc-vulkan
             ext: .exe
             build_args: --features vulkan,binary
-            vulkan_sdk: '1.3.280.0'
+            vulkan_sdk: '1.3.296.0'
           # - os: windows-2019
           #   target: x86_64-pc-windows-msvc
           #   binary: x86_64-windows-msvc-cuda117


### PR DESCRIPTION
1.3.239 had been removed from upstream release.

failed CI: https://github.com/TabbyML/tabby/actions/runs/14902885001/job/41858667745

new CI: https://github.com/TabbyML/tabby/actions/runs/14903133478/job/41859433228
