### PR TITLE
feat(model): add support for multiple chat models

### DIFF
--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -4,16 +4,49 @@ use async_openai_alt::config::OpenAIConfig;
 use tabby_common::config::HttpModelConfig;
 use tabby_inference::{ChatCompletionStream, ExtendedOpenAIConfig};
 
+use super::multi::MultiChatStream;
 use super::rate_limit;
 use crate::{create_reqwest_client, AZURE_API_VERSION};
 
 pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
+    let mut multi_chat_stream = MultiChatStream::new();
+    add_engine(&mut multi_chat_stream, model);
+    Arc::new(multi_chat_stream)
+}
+
+pub async fn create_multiple(models: &[HttpModelConfig]) -> Arc<dyn ChatCompletionStream> {
+    let mut multi_chat_stream = MultiChatStream::new();
+    models.iter().for_each(|model| {
+        add_engine(&mut multi_chat_stream, model);
+    });
+    Arc::new(multi_chat_stream)
+}
+
+fn add_engine(multi_chat_stream: &mut MultiChatStream, model: &HttpModelConfig) {
+    let (model_title, model_name) = model.model_title_and_name();
+    let engine = Arc::new(rate_limit::new_chat(
+        create_engine(model),
+        model.rate_limit.request_per_minute,
+    ));
+
+    // Handle model_name first just to set default_model to it
+    multi_chat_stream.add_chat_stream(model_title, model_name, engine.clone());
+
+    if let (Some(supported_models), Some(model_name)) = (&model.supported_models, &model.model_name)
+    {
+        for m in supported_models.iter().filter(|m| model_name != *m) {
+            multi_chat_stream.add_chat_stream(m, m, engine.clone());
+        }
+    }
+}
+
+fn create_engine(model: &HttpModelConfig) -> Box<dyn ChatCompletionStream> {
     let api_endpoint = model
         .api_endpoint
         .as_deref()
         .expect("api_endpoint is required");
 
-    let engine: Box<dyn ChatCompletionStream> = match model.kind.as_str() {
+    match model.kind.as_str() {
         "azure/chat" => {
             let config = async_openai_alt::config::AzureConfig::new()
                 .with_api_base(api_endpoint)
@@ -45,10 +78,5 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
             )
         }
         _ => panic!("Unsupported model kind: {}", model.kind),
-    };
-
-    Arc::new(rate_limit::new_chat(
-        engine,
-        model.rate_limit.request_per_minute,
-    ))
+    }
 }

--- a/crates/http-api-bindings/src/lib.rs
+++ b/crates/http-api-bindings/src/lib.rs
@@ -2,8 +2,10 @@ mod chat;
 mod completion;
 mod embedding;
 mod rate_limit;
+mod multi;
 
 pub use chat::create as create_chat;
+pub use chat::create_multiple as create_multiple_chat;
 pub use completion::{build_completion_prompt, create};
 pub use embedding::create as create_embedding;
 

--- a/crates/http-api-bindings/src/multi.rs
+++ b/crates/http-api-bindings/src/multi.rs
@@ -1,0 +1,116 @@
+use async_openai_alt::{
+    error::OpenAIError,
+    types::{
+        ChatCompletionResponseStream, CreateChatCompletionRequest, CreateChatCompletionResponse,
+    },
+};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tabby_inference::ChatCompletionStream;
+
+struct ChatStreamWrapper {
+    model_name: String,
+    chat_stream: Arc<dyn ChatCompletionStream>,
+}
+
+impl ChatStreamWrapper {
+    fn new(model_name: String, chat_stream: Arc<dyn ChatCompletionStream>) -> Self {
+        Self {
+            model_name,
+            chat_stream,
+        }
+    }
+
+    fn process_request(
+        &self,
+        mut request: CreateChatCompletionRequest,
+    ) -> CreateChatCompletionRequest {
+        request.model = self.model_name.clone();
+        request
+    }
+}
+
+#[async_trait]
+impl ChatCompletionStream for ChatStreamWrapper {
+    async fn chat(
+        &self,
+        request: CreateChatCompletionRequest,
+    ) -> Result<CreateChatCompletionResponse, OpenAIError> {
+        let request = self.process_request(request);
+        self.chat_stream.chat(request).await
+    }
+
+    async fn chat_stream(
+        &self,
+        request: CreateChatCompletionRequest,
+    ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        let request = self.process_request(request);
+        self.chat_stream.chat_stream(request).await
+    }
+}
+
+pub struct MultiChatStream {
+    chat_streams: HashMap<String, Box<dyn ChatCompletionStream>>,
+
+    /// Provide a default value to handle the scenario when the request model is None,
+    /// which is usually the model value from the first [add_chat_stream]
+    default_model: Option<String>,
+}
+
+impl MultiChatStream {
+    pub fn new() -> MultiChatStream {
+        Self {
+            chat_streams: HashMap::new(),
+            default_model: None,
+        }
+    }
+
+    pub fn add_chat_stream(
+        &mut self,
+        model_title: impl Into<String>,
+        model: impl Into<String>,
+        completion: Arc<dyn ChatCompletionStream>,
+    ) {
+        let model_title = model_title.into();
+        if self.default_model.is_none() {
+            self.default_model = Some(model_title.to_owned());
+        }
+        self.chat_streams.insert(
+            model_title,
+            Box::new(ChatStreamWrapper::new(model.into(), completion)),
+        );
+    }
+
+    fn get_chat_stream(&self, model: &str) -> Result<&Box<dyn ChatCompletionStream>, OpenAIError> {
+        let model = if model.is_empty() {
+            self.default_model
+                .as_ref()
+                .ok_or_else(|| OpenAIError::InvalidArgument("No available model".to_owned()))?
+        } else {
+            model
+        };
+        self.chat_streams
+            .get(model)
+            .ok_or_else(|| OpenAIError::InvalidArgument(format!("Model {} does not exist", model)))
+    }
+}
+
+#[async_trait]
+impl ChatCompletionStream for MultiChatStream {
+    async fn chat(
+        &self,
+        request: CreateChatCompletionRequest,
+    ) -> Result<CreateChatCompletionResponse, OpenAIError> {
+        let chat_stream = self.get_chat_stream(&request.model)?;
+        chat_stream.chat(request).await
+    }
+
+    async fn chat_stream(
+        &self,
+        request: CreateChatCompletionRequest,
+    ) -> Result<ChatCompletionResponseStream, OpenAIError> {
+        let chat_stream = self.get_chat_stream(&request.model)?;
+        chat_stream.chat_stream(request).await
+    }
+}

--- a/crates/tabby/src/routes/models.rs
+++ b/crates/tabby/src/routes/models.rs
@@ -27,10 +27,22 @@ impl From<tabby_common::config::Config> for ModelInfo {
             }
         }
 
-        if let Some(tabby_common::config::ModelConfig::Http(chat_http_config)) = models.chat {
-            if let Some(models) = chat_http_config.supported_models {
-                http_model_configs.chat = Some(models.clone());
+        if let Some(chat) = models.chat {
+            let mut chat_models = vec![];
+            for model in chat.get_http_configs().iter() {
+                chat_models.push(model.model_title_and_name().0);
+                if let (Some(supported_models), Some(model_name)) =
+                    (&model.supported_models, &model.model_name)
+                {
+                    chat_models.extend(
+                        supported_models
+                            .iter()
+                            .filter(|m| model_name != *m)
+                            .cloned(),
+                    );
+                }
             }
+            http_model_configs.chat = Some(chat_models);
         }
 
         http_model_configs

--- a/crates/tabby/src/serve.rs
+++ b/crates/tabby/src/serve.rs
@@ -7,7 +7,7 @@ use spinners::{Spinner, Spinners, Stream};
 use tabby_common::{
     api::{self, code::CodeSearch, event::EventLogger},
     axum::AllowedCodeRepository,
-    config::{Config, ModelConfig},
+    config::{Config, ModelConfig, ModelConfigVariant},
     usage,
 };
 use tabby_download::ModelKind;
@@ -222,7 +222,12 @@ async fn load_model(config: &Config) {
         download_model_if_needed(&model.model_id, ModelKind::Completion).await;
     }
 
-    if let Some(ModelConfig::Local(ref model)) = config.model.chat {
+    if let Some(model) = config
+        .model
+        .chat
+        .as_ref()
+        .and_then(|m| m.get_local_config())
+    {
         download_model_if_needed(&model.model_id, ModelKind::Chat).await;
     }
 
@@ -390,11 +395,12 @@ fn merge_args(config: &Config, args: &ServeArgs) -> Config {
         if config.model.chat.is_some() {
             warn!("Overriding chat model from config.toml. The overriding behavior might surprise you. Consider setting the model in config.toml directly.");
         }
-        config.model.chat = Some(to_local_config(
+        let local_model = ModelConfigVariant::Single(to_local_config(
             chat_model,
             args.parallelism,
             args.chat_device.as_ref().unwrap_or(&args.device),
         ));
+        config.model.chat = Some(local_model)
     }
 
     config

--- a/crates/tabby/src/services/completion.rs
+++ b/crates/tabby/src/services/completion.rs
@@ -12,7 +12,7 @@ use tabby_common::{
         event::{Event, EventLogger},
     },
     axum::AllowedCodeRepository,
-    config::{CompletionConfig, ModelConfig},
+    config::{CompletionConfig, ModelConfig, ModelConfigVariant},
     languages::get_language,
 };
 use tabby_inference::{
@@ -540,7 +540,7 @@ pub async fn create_completion_service_and_chat(
     code: Arc<dyn CodeSearch>,
     logger: Arc<dyn EventLogger>,
     completion: Option<ModelConfig>,
-    chat: Option<ModelConfig>,
+    chat: Option<ModelConfigVariant>,
 ) -> (
     Option<CompletionService>,
     Option<Arc<dyn CompletionStream>>,

--- a/crates/tabby/src/services/health.rs
+++ b/crates/tabby/src/services/health.rs
@@ -37,9 +37,13 @@ impl HealthState {
 
         let cuda_devices = read_cuda_devices().unwrap_or_default();
 
+        let chat_model = &model_config.chat
+            .as_ref()
+            .and_then(|t| Some(t.get_model_configs()[0].clone()));
+        
         Self {
             model: to_model_name(&model_config.completion),
-            chat_model: to_model_name(&model_config.chat),
+            chat_model: to_model_name(chat_model),
             chat_device: chat_device.map(|x| x.to_string()),
             device: device.to_string(),
             arch: ARCH.to_string(),

--- a/crates/tabby/src/services/model/mod.rs
+++ b/crates/tabby/src/services/model/mod.rs
@@ -1,7 +1,7 @@
 use std::{fs, sync::Arc};
 
 pub use llama_cpp_server::PromptInfo;
-use tabby_common::config::ModelConfig;
+use tabby_common::config::{ModelConfig, ModelConfigVariant};
 use tabby_download::{download_model, ModelKind};
 use tabby_inference::{ChatCompletionStream, CodeGeneration, CompletionStream, Embedding};
 use tracing::info;
@@ -12,7 +12,7 @@ pub async fn load_embedding(config: &ModelConfig) -> Arc<dyn Embedding> {
 
 pub async fn load_code_generation_and_chat(
     completion_model: Option<ModelConfig>,
-    chat_model: Option<ModelConfig>,
+    chat_model: Option<ModelConfigVariant>,
 ) -> (
     Option<Arc<CodeGeneration>>,
     Option<Arc<dyn CompletionStream>>,
@@ -29,15 +29,16 @@ pub async fn load_code_generation_and_chat(
 
 async fn load_completion_and_chat(
     completion_model: Option<ModelConfig>,
-    chat_model: Option<ModelConfig>,
+    chat_model: Option<ModelConfigVariant>,
 ) -> (
     Option<Arc<dyn CompletionStream>>,
     Option<PromptInfo>,
     Option<Arc<dyn ChatCompletionStream>>,
 ) {
-    if let (Some(ModelConfig::Local(completion)), Some(ModelConfig::Local(chat))) =
-        (&completion_model, &chat_model)
-    {
+    if let (Some(ModelConfig::Local(completion)), Some(ref chat)) = (
+        &completion_model,
+        chat_model.as_ref().and_then(|m| m.get_local_config()),
+    ) {
         let (completion, prompt, chat) =
             llama_cpp_server::create_completion_and_chat(completion, chat).await;
         return (Some(completion), Some(prompt), Some(chat));
@@ -67,11 +68,12 @@ async fn load_completion_and_chat(
     };
 
     let chat = if let Some(chat_model) = chat_model {
-        match chat_model {
-            ModelConfig::Http(http) => Some(http_api_bindings::create_chat(&http).await),
-            ModelConfig::Local(llama) => {
-                Some(llama_cpp_server::create_chat_completion(&llama).await)
-            }
+        match chat_model.get_local_config() {
+            Some(local) => Some(llama_cpp_server::create_chat_completion(&local).await),
+            None => match chat_model.get_http_configs().as_slice() {
+                [] => None,
+                models => Some(http_api_bindings::create_multiple_chat(models).await),
+            },
         }
     } else {
         None

--- a/ee/tabby-ui/components/textarea-search/model-select.tsx
+++ b/ee/tabby-ui/components/textarea-search/model-select.tsx
@@ -43,7 +43,7 @@ export function ModelSelect({
         </div>
       }
     >
-      {!!models?.length && (
+      {models && models.length > 1 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button


### PR DESCRIPTION
## Description

- Add an optional `title` field (defaults to `model_name` if empty) to HttpModelConfig to customize model name display and avoid conflicts between identical names from different providers

- Maintain backward compatibility with the single chat model configuration, while adding support for multiple models, each with independent settings (e.g., rate_limit, prompt_template)


## Configuration Examples

### Single Model (Legacy Format)

```toml
[model.chat.http]
title = "single_chat"  # <-- New optional field
kind = "openai/chat"
api_endpoint = "http://192.168.1.234:11344/v1"
model_name = "starcoder:1b"
supported_models = ["starcoder:1b", "qwen2.5-coder:1.5b"]
```

### Multiple Models (New Format)

```toml
[[model.chat.http]]  # <-- Array syntax
kind = "openai/chat"
api_endpoint = "http://192.168.1.234:11344/v1"
model_name = "deepseek-chat"

[[model.chat.http]]
title = "dp-chat"  # <-- Unique display name
kind = "openai/chat"
model_name = "deepseek-chat"
api_endpoint = "https://api.deepseek.com/v1"
api_key = "sk-xxxxxxxx"
supported_models = ["deepseek-chat", "deepseek-reasoner"]
```
