### PR TITLE
chore: default use 12.9.0 docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ concurrency:
 
 env:
   RUST_TOOLCHAIN: 1.82.0
+  CUDA_VERSION: 12.9.0
 
 jobs:
   release-docker:
@@ -116,7 +117,42 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
-          build-args: RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
+          build-args: |
+            RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
+            CUDA_VERSION=${{ env.CUDA_VERSION }}
+
+      - name: Docker meta for CUDA 11
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: meta-cuda11
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ env.IMAGE_NAME }}
+            ${{ env.IMAGE_NAME }}
+          # do not generate tags for latest since cuda12 is the latest
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}-cuda11
+
+      # Build and push Docker image with Buildx
+      # Only built on release tags for compatibility with previous versions
+      - name: Build and push Docker image for CUDA 11
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: build-and-push-cuda11
+        uses: docker/build-push-action@v5
+        with:
+          file: docker/Dockerfile.${{ matrix.device-type }}
+          push: true
+          context: .
+          tags: ${{ steps.meta-cuda11.outputs.tags }}
+          labels: ${{ steps.meta-cuda11.outputs.labels }}
+          cache-from: ${{ steps.cache.outputs.cache-from }}
+          cache-to: ${{ steps.cache.outputs.cache-to }}
+          build-args: |
+            RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
+            CUDA_VERSION=11.7.1
+
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4


### PR DESCRIPTION
Test CI: https://github.com/zwpaper/tabby/actions/runs/14973940325/job/42061314783

Test image:
- zwpaper/tabby:0.105.0
- zwpaper/tabby:0.105.0-cuda11

test command:
```console
nerdctl run --gpus all --rm   -p 0.0.0.0:8080:8080 \                                                                                              (base)
                         -v $HOME/.tabby:/data \
                         zwpaper/tabby:0.105.0 \
                         serve \
                         --model Qwen2.5-Coder-1.5B \
                         --chat-model Qwen2.5-Coder-1.5B-Instruct \
                         --device cuda --chat-device cuda
docker.io/zwpaper/tabby:0.105.0:                                                  resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:8f17e50141a54023942160fd391861187b5ad10e52e14600ee22726a9d6d6569:    exists         |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:9992a93a56f111429b95c5e4545b7db6e6360eca24c98686544add7e6287849c: exists         |++++++++++++++++++++++++++++++++++++++|
config-sha256:ab75996a992f4ecf99243dbd71a4c2bfe6a479801bbde256847e4b3f44d8ec25:   exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:215ed5a638430309375291c48a01872859a8dbf1331e54ba0af221918eb8ce2e:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:8e257e2f61b3bb5efa27861c9f528c087effec0ae0df0bc85b425ff12a4628b2:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:6ec52169f4075cf80de2f49076cd5b8db43a64c663efc8ec39579b970071bb7c:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:b4d600b977438c1e74729cafa7158dfe98928d53ec5a0eb189fcd3739752cc20:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:12e96d9ed36f18f96cfa98e2351f018f104a9a51d980407af1fc22e60e4e778c:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:5ada09cfb5af365e37f3ac41858d0e72994953474937dbc460ae5ed1b2d9bba3:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:39a549996d3590b8193689c2f43e8af440a7136026e85e43e46df3a0fbed2732:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:01a77ecc44d681faf2e4514567d1ec0733a24aa52177c3ad36883df1e1e6eb16:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:fade6560457cf3fba6dfb3d8280309ce9e5e0eded9c748f8fa6e611cf6b2a96c:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:38cf2a08e5b04c3cbc6bbe9b2195d9bbc13f38ed602d0daa2e7b2d865e92bbfc:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:1bba15468fcc82586ce921fdc422649a192dcc635f587390cd01beb95ca6dfb5:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:1b1871cb04175218ddf8d02234c35a63e77b6c6ce7c2676ddfdde575c996ee2c:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:47e265d4453d154b2fbda7a482131d7fb31e9c25323117dac51d4315a4aa676a:    exists         |++++++++++++++++++++++++++++++++++++++|
layer-sha256:69dedd74cc89ea89b937e703728a3d57049ad6e4561a3da9e8ef6c0a58638651:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 227.1s                                                                   total:   0.0 B (0.0 B/s)
2025-05-12T15:00:06.691277Z  WARN tabby::serve: crates/tabby/src/serve.rs:384: Overriding completion model from config.toml. The overriding behavior might surprise you. Consider setting the model in config.toml directly.
2025-05-12T15:00:06.691292Z  WARN tabby::serve: crates/tabby/src/serve.rs:391: Overriding chat model from config.toml. The overriding behavior might surprise you. Consider setting the model in config.toml directly.
⠇     3.050 s   Starting...
████████╗ █████╗ ██████╗ ██████╗ ██╗   ██╗
╚══██╔══╝██╔══██╗██╔══██╗██╔══██╗╚██╗ ██╔╝
   ██║   ███████║██████╔╝██████╔╝ ╚████╔╝
   ██║   ██╔══██║██╔══██╗██╔══██╗  ╚██╔╝
   ██║   ██║  ██║██████╔╝██████╔╝   ██║
   ╚═╝   ╚═╝  ╚═╝╚═════╝ ╚═════╝    ╚═╝

📄 Version 0.28.0-dev.0
🚀 Listening at http://0.0.0.0:8080



  JWT secret is not set

  Tabby server will generate a one-time (non-persisted) JWT secret for the current process.
  Please set the TABBY_WEBSERVER_JWT_TOKEN_SECRET environment variable for production usage.
```

Working as expected:
![CleanShot 2025-05-12 at 23 00 43@2x](https://github.com/user-attachments/assets/ec2a3735-390c-4aff-aaf4-8fcfb646e596)
