### PR TITLE
chore: bump main to 0.30.0-dev.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "aim-downloader"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "async-stream",
  "clap",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "hash-ids"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 
 [[package]]
 name = "hashbrown"
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "http-api-bindings"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -2733,7 +2733,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "llama-cpp-server"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "ollama-api-bindings"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-migrate-validate"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "tabby"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-common"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-crawler"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-db"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-db-macros"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-download"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "aim-downloader",
  "anyhow",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-git"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5604,7 +5604,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-index"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-index-cli"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5660,7 +5660,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-inference"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-schema"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "async-openai-alt",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "tabby-webserver"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 edition = "2021"
 authors = ["TabbyML Team"]
 homepage = "https://github.com/TabbyML/tabby"

--- a/crates/tabby-download/Cargo.toml
+++ b/crates/tabby-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabby-download"
-version = "0.28.0-dev.0"
+version = "0.30.0-dev.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
aim-downloader@0.30.0-dev.0
hash-ids@0.30.0-dev.0
http-api-bindings@0.30.0-dev.0
llama-cpp-server@0.30.0-dev.0
ollama-api-bindings@0.30.0-dev.0
sqlx-migrate-validate@0.30.0-dev.0
tabby@0.30.0-dev.0
tabby-common@0.30.0-dev.0
tabby-crawler@0.30.0-dev.0
tabby-db@0.30.0-dev.0
tabby-db-macros@0.30.0-dev.0
tabby-download@0.30.0-dev.0
tabby-git@0.30.0-dev.0
tabby-index@0.30.0-dev.0
tabby-index-cli@0.30.0-dev.0
tabby-inference@0.30.0-dev.0
tabby-schema@0.30.0-dev.0
tabby-webserver@0.30.0-dev.0

Generated by cargo-workspaces