### PR TITLE
fix(intellij): undo inline edit in one undo & add code vision setting

### DIFF
--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/actions/chat/ChatAction.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/actions/chat/ChatAction.kt
@@ -1,11 +1,14 @@
 package com.tabbyml.intellijtabby.actions.chat
 
 import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.components.serviceOrNull
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorAction
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.project.Project
 import com.tabbyml.intellijtabby.chat.ChatBrowserFactory
+import com.tabbyml.intellijtabby.events.FeaturesState
 import com.tabbyml.intellijtabby.widgets.openChatToolWindow
 
 abstract class ChatAction(private val chatActionHandler: ChatActionHandler) :
@@ -20,6 +23,12 @@ abstract class ChatAction(private val chatActionHandler: ChatActionHandler) :
 
     override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?): Boolean {
       val chatBrowser = editor.project?.let { ChatBrowserFactory.findActiveChatBrowser(it) }
-      return chatActionHandler.isEnabled(editor, chatBrowser)
+      return isChatFeatureEnabled(editor.project) && chatActionHandler.isEnabled(editor, chatBrowser)
     }
   })
+
+fun isChatFeatureEnabled(project: Project?): Boolean {
+  if (project == null) return false
+  val featuresState = project.serviceOrNull<FeaturesState>()
+  return featuresState?.features?.chat ?: false
+}

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/CodeVisionProvider.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/CodeVisionProvider.kt
@@ -3,6 +3,7 @@ package com.tabbyml.intellijtabby.inlineChat
 import com.google.gson.JsonObject
 import com.intellij.codeInsight.codeVision.*
 import com.intellij.codeInsight.codeVision.CodeVisionState.Companion.READY_EMPTY
+import com.intellij.codeInsight.codeVision.settings.CodeVisionGroupSettingProvider
 import com.intellij.codeInsight.codeVision.ui.model.TextCodeVisionEntry
 import com.intellij.icons.AllIcons
 import com.intellij.ide.DataManager
@@ -28,6 +29,8 @@ abstract class InlineChatCodeVisionProvider : CodeVisionProvider<Any>, DumbAware
     // provider id
     abstract override val id: String
 
+    override val groupId = "Tabby.InlineEdit"
+
     // command name
     abstract val command: String
 
@@ -37,7 +40,6 @@ abstract class InlineChatCodeVisionProvider : CodeVisionProvider<Any>, DumbAware
     // execute action id
     abstract val actionId: String?
     abstract val icon: Icon
-    override val name: String = "Inline Chat Code Vision Provider"
 
     override fun precomputeOnUiThread(editor: Editor): Any {
         return Any()
@@ -101,6 +103,7 @@ abstract class InlineChatCodeVisionProvider : CodeVisionProvider<Any>, DumbAware
 
 class InlineChatLoadingCodeVisionProvider : InlineChatCodeVisionProvider() {
     override val id: String = "Tabby.InlineChat.Loading"
+    override val name ="Tabby Inline Edit Loading"
     override val command: String = " "
     override val action: String? = null
     override val actionId: String? = null
@@ -111,6 +114,7 @@ class InlineChatLoadingCodeVisionProvider : InlineChatCodeVisionProvider() {
 
 class InlineChatCancelCodeVisionProvider : InlineChatCodeVisionProvider() {
     override val id: String = "Tabby.InlineChat.Cancel"
+    override val name ="Tabby Inline Edit Cancel"
     override val command: String = "tabby/chat/edit/resolve"
     override val action: String = "cancel"
     override val actionId: String = "Tabby.InlineChat.Resolve.Cancel"
@@ -121,6 +125,7 @@ class InlineChatCancelCodeVisionProvider : InlineChatCodeVisionProvider() {
 
 class InlineChatAcceptCodeVisionProvider : InlineChatCodeVisionProvider() {
     override val id: String = "Tabby.InlineChat.Accept"
+    override val name ="Tabby Inline Edit Accept"
     override val command: String = "tabby/chat/edit/resolve"
     override val action: String? = "accept"
     override val actionId: String = "Tabby.InlineChat.Resolve.Accept"
@@ -131,10 +136,20 @@ class InlineChatAcceptCodeVisionProvider : InlineChatCodeVisionProvider() {
 
 class InlineChatDiscardCodeVisionProvider : InlineChatCodeVisionProvider() {
     override val id: String = "Tabby.InlineChat.Discard"
+    override val name ="Tabby Inline Edit Discard"
     override val command: String = "tabby/chat/edit/resolve"
     override val action: String = "discard"
     override val actionId: String = "Tabby.InlineChat.Resolve.Discard"
     override val icon: Icon = AllIcons.Actions.Close
     override val relativeOrderings: List<CodeVisionRelativeOrdering> =
         emptyList()
+}
+
+class InlineChatCodeVisionSettingProvider: CodeVisionGroupSettingProvider {
+    override val groupId: String
+        get() = "Tabby.InlineEdit"
+    override val groupName: String
+        get() = "Tabby Inline Edit"
+    override val description: String
+        get() = "Tabby Inline Edit"
 }

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/CommandListComponent.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/CommandListComponent.kt
@@ -79,15 +79,15 @@ class CommandListComponent(
         toolbar.border = JBUI.Borders.empty(3, 5)
         val titleLabel = JBLabel(title)
         titleLabel.font = JBUI.Fonts.label().deriveFont(JBUI.Fonts.label().size + 1.0f)
-        val clearAllButton = IconLabelButton(AllIcons.Actions.GC) {
-            onClearAll()
-        }
-        clearAllButton.toolTipText = "Clear all commands"
-        clearAllButton.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-        clearAllButton.border = BorderFactory.createEmptyBorder(4, 8, 4, 8)
+//        val clearAllButton = IconLabelButton(AllIcons.Actions.GC) {
+//            onClearAll()
+//        }
+//        clearAllButton.toolTipText = "Clear all commands"
+//        clearAllButton.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+//        clearAllButton.border = BorderFactory.createEmptyBorder(4, 8, 4, 8)
 
         toolbar.add(titleLabel, BorderLayout.WEST)
-        toolbar.add(clearAllButton, BorderLayout.EAST)
+//        toolbar.add(clearAllButton, BorderLayout.EAST)
 
         return toolbar
     }
@@ -110,7 +110,7 @@ class CommandListComponent(
         }
     }
 
-    fun setData(newData: List<CommandListItem>) {
+    fun setData(newData: List<CommandListItem>, onUpdated: (() -> Unit)? = null) {
         ApplicationManager.getApplication().invokeLater {
             val selectedValue = list.selectedValue
             model.replaceAll(newData)
@@ -124,11 +124,18 @@ class CommandListComponent(
             } else {
                 list.clearSelection()
             }
+            onUpdated?.invoke()
         }
     }
 
     val component: JComponent
         get() = mainPanel
+
+    fun dispose() {
+        mainPanel.removeAll()
+        scrollPane.viewport.view = null
+        list.model = CollectionListModel()
+    }
 }
 
 
@@ -230,3 +237,4 @@ class CustomListItemRenderer(private val getHoveredIndex: () -> Int) : JPanel(),
         }
     }
 }
+

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatAction.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/InlineChatAction.kt
@@ -4,13 +4,21 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.components.serviceOrNull
 import com.intellij.openapi.project.DumbAwareAction
+import com.tabbyml.intellijtabby.actions.chat.isChatFeatureEnabled
 import com.tabbyml.intellijtabby.lsp.ConnectionService
 import com.tabbyml.intellijtabby.lsp.protocol.ChatEditResolveParams
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class InlineChatAction : DumbAwareAction() {
+abstract class BaseInlineChatAction : DumbAwareAction() {
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabled = isChatFeatureEnabled(project)
+    }
+}
+
+class InlineChatAction : BaseInlineChatAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val editor = e.getRequiredData(CommonDataKeys.EDITOR)
         val project = e.project ?: return
@@ -18,7 +26,7 @@ class InlineChatAction : DumbAwareAction() {
     }
 }
 
-class InlineChatAcceptAction : DumbAwareAction() {
+class InlineChatAcceptAction : BaseInlineChatAction() {
     private val scope = CoroutineScope(Dispatchers.IO)
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -32,7 +40,7 @@ class InlineChatAcceptAction : DumbAwareAction() {
     }
 }
 
-class InlineChatDiscardAction : DumbAwareAction() {
+class InlineChatDiscardAction : BaseInlineChatAction() {
     private val scope = CoroutineScope(Dispatchers.IO)
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -46,7 +54,7 @@ class InlineChatDiscardAction : DumbAwareAction() {
     }
 }
 
-class InlineChatCancelAction : DumbAwareAction() {
+class InlineChatCancelAction : BaseInlineChatAction() {
     private val scope = CoroutineScope(Dispatchers.IO)
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/SelectionGutterIconManager.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/inlineChat/SelectionGutterIconManager.kt
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.util.IconLoader
 import com.intellij.openapi.vfs.VirtualFile
+import com.tabbyml.intellijtabby.actions.chat.isChatFeatureEnabled
 import javax.swing.Icon
 
 class SelectionGutterIconManager : ProjectActivity {
@@ -94,6 +95,7 @@ class SelectionGutterIconManager : ProjectActivity {
     }
 
     private fun updateSelectionGutterIcon(editor: Editor) {
+        if (!isChatFeatureEnabled(editor.project)) return
         invokeLater {
             removeHighlighter(editor)
 

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/lsp/protocol/ProtocolData.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/lsp/protocol/ProtocolData.kt
@@ -379,3 +379,7 @@ data class ChatEditResolveParams(
 data class ChatEditCommandParams(var location: Location)
 
 data class ChatEditCommand(var label: String, var command: String, var source: String = "preset" )
+
+data class TabbyApplyWorkspaceEditOptions(val undoStopBefore: Boolean = false, val undoStopAfter: Boolean = false)
+
+data class TabbyApplyWorkspaceEditParams(val label: String?, val edit: WorkspaceEdit, val options: TabbyApplyWorkspaceEditOptions? = null)

--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/lsp/protocol/client/LanguageClient.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/lsp/protocol/client/LanguageClient.kt
@@ -147,4 +147,9 @@ abstract class LanguageClient {
   open fun refreshDiagnostics(): CompletableFuture<Void> {
     throw UnsupportedOperationException()
   }
+
+  @JsonRequest("tabby/workspace/applyEdit")
+  open fun applyWorkspaceEdit(edit: TabbyApplyWorkspaceEditParams): CompletableFuture<Boolean> {
+    throw UnsupportedOperationException()
+  }
 }

--- a/clients/intellij/src/main/resources/META-INF/plugin.xml
+++ b/clients/intellij/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,7 @@
         <intentionAction>
             <className>com.tabbyml.intellijtabby.inlineChat.InlineChatIntentionAction</className>
         </intentionAction>
+        <config.codeVisionGroupSettingProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatCodeVisionSettingProvider"/>
         <codeInsight.codeVisionProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatLoadingCodeVisionProvider" />
         <codeInsight.codeVisionProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatCancelCodeVisionProvider" />
         <codeInsight.codeVisionProvider implementation="com.tabbyml.intellijtabby.inlineChat.InlineChatAcceptCodeVisionProvider" />


### PR DESCRIPTION
- undo inline edit in one undo
https://jam.dev/c/f3107d66-d56c-48cf-adc1-3134d75e978c

- fix cpu high when inline edit input open

- code vision feature check and code vision setting

![image](https://github.com/user-attachments/assets/7d645ac4-04cb-4ebc-9c6f-03f39b492d91)
![image](https://github.com/user-attachments/assets/8a03499d-ddbc-489c-9197-d6927b7fa8db)


- disable features(inline edit, chat actions menu) when chat api not available
![image](https://github.com/user-attachments/assets/41686fde-548c-4e60-8f5b-166a65626697)

- 