### PR TITLE
fix(http): fix repeated content-type in http headers

### DIFF
--- a/crates/http-api-bindings/src/embedding/openai.rs
+++ b/crates/http-api-bindings/src/embedding/openai.rs
@@ -58,7 +58,6 @@ impl Embedding for OpenAIEmbeddingEngine {
             .client
             .post(&self.api_endpoint)
             .json(&request)
-            .header("content-type", "application/json")
             .bearer_auth(&self.api_key);
 
         let response = request_builder


### PR DESCRIPTION
## Summary
Fixes #4089 - Removes duplicate "content-type" header in HTTP requests to embedding API endpoints.

## Problem
When sending requests to model API endpoints, the "content-type" header was being set twice:
1. Automatically by reqwest's `.json()` method 
2. Explicitly via `.header("content-type", "application/json")`

## Solution
Removed the explicit `.header("content-type", "application/json")` call from the request builder in `/crates/http-api-bindings/src/embedding/openai.rs`.

## Testing
- Manually verified HTTP request headers no longer contain duplicate content-type entries
