### PR TITLE
feat(config): add support for remote embedding services via config.toml

### DIFF
--- a/crates/tabby/src/services/model/mod.rs
+++ b/crates/tabby/src/services/model/mod.rs
@@ -8,12 +8,8 @@ use tracing::info;
 
 pub async fn load_embedding(config: &ModelConfig) -> Arc<dyn Embedding> {
     match config {
-        ModelConfig::Http(http_config) => {
-            http_api_bindings::create_embedding(http_config).await
-        }
-        ModelConfig::Local(_) => {
-            llama_cpp_server::create_embedding(config).await
-        }
+        ModelConfig::Http(http_config) => http_api_bindings::create_embedding(http_config).await,
+        ModelConfig::Local(_) => llama_cpp_server::create_embedding(config).await,
     }
 }
 


### PR DESCRIPTION
## Description

This pull request introduces support for remote embedding models in `config.toml`, enabling users to delegate embedding generation to external servers. This is particularly valuable for environments without GPU or lacking the ability to run `llama-server` locally.

## What’s Changed

- Added support for `[embedding]` section with `type = "remote"` and `endpoint` fields in `config.toml`.

- Updated `embedding::create()` and `model::load_embedding()` to support `ModelConfig::Http` (remote models).

- Prevents Tabby from launching the local `llama-server` process when using a remote embedding service.

- Keeps compatibility with local embeddings (no breaking changes).

## Example Usage

```
[embedding]
type = "remote"
endpoint = "http://localhost:5000"
model = "BAAI/bge-small-en"
```

Run an embedding service like:
```bash
uvicorn main:app --host 0.0.0.0 --port 5000
```

Then launch Tabby:
```bash
./target/release/tabby serve
```

## Motivation

Currently, Tabby always attempts to launch its internal `llama-server` binary, which fails on machines without compatible GPU or CUDA libraries. This PR introduces flexibility and portability, enabling Tabby to run in lightweight environments with minimal dependencies.

## How to Test

1. Start Tabby with a valid `config.toml` that includes a remote embedding config.

2. Verify that:
    - Tabby starts without attempting to run `llama-server`
    - Embedding API requests are successfully forwarded to the remote server

## Known Limitations

- This does not disable internal embeddings when `[embedding]` is omitted (default behavior).

- The remote server must follow the expected API (e.g., `/v1/embeddings` in OpenAI-compatible format).

## Request for Review

Would love feedback on:

- Integration approach

- Potential edge cases to test

- Any docs you'd like me to include

---

Let me know if you'd like me to add a sample embedding server (Python FastAPI) or documentation PR as a follow-up!