### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@
 [![Docker pulls](https://img.shields.io/docker/pulls/tabbyml/tabby)](https://hub.docker.com/r/tabbyml/tabby)
 [![codecov](https://codecov.io/gh/TabbyML/tabby/graph/badge.svg?token=WYVVH8MKK3)](https://codecov.io/gh/TabbyML/tabby)
 
-[English](/README.md) |
-[简体中文](/README-zh.md) |
-[日本語](/README-ja.md)
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/TabbyML/tabby?lang=de) | 
+[Español](https://www.readme-i18n.com/TabbyML/tabby?lang=es) | 
+[français](https://www.readme-i18n.com/TabbyML/tabby?lang=fr) | 
+[日本語](https://www.readme-i18n.com/TabbyML/tabby?lang=ja) | 
+[한국어](https://www.readme-i18n.com/TabbyML/tabby?lang=ko) | 
+[Português](https://www.readme-i18n.com/TabbyML/tabby?lang=pt) | 
+[Русский](https://www.readme-i18n.com/TabbyML/tabby?lang=ru) | 
+[中文](https://www.readme-i18n.com/TabbyML/tabby?lang=zh)
 
 </div>
 


### PR DESCRIPTION
Added language selection links to the README, allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

This update improves accessibility and helps non-English speakers better understand the project.

I noticed that the previously used Chinese and Japanese translations were not in sync with the latest README content. To address this, I replaced them with new links that automatically reflect updates to the original README.

That said, if you prefer to keep the original Chinese and Japanese content (even if it's slightly outdated), feel free to revert those two links.

You can preview the updated links in my forked repository: https://github.com/dowithless/tabby/tree/patch-1