### PR TITLE
fix: ensure endpoint URL matches browser address

### DIFF
--- a/ee/tabby-ui/lib/hooks/use-network-setting.tsx
+++ b/ee/tabby-ui/lib/hooks/use-network-setting.tsx
@@ -28,6 +28,7 @@ const useExternalURL = () => {
     return networkSetting?.externalUrl || ''
   }, [networkSetting])
 }
+
 function getOrigin() {
   if (isClientSide()) {
     return new URL(window.location.href).origin

--- a/ee/tabby-ui/lib/hooks/use-network-setting.tsx
+++ b/ee/tabby-ui/lib/hooks/use-network-setting.tsx
@@ -19,13 +19,15 @@ const useNetworkSetting = (options?: any) => {
 const useExternalURL = () => {
   const [{ data }] = useNetworkSetting()
   const networkSetting = data?.networkSetting
-  const externalUrl = React.useMemo(() => {
-    return networkSetting?.externalUrl || getOrigin()
+  
+  return React.useMemo(() => {
+    const currentOrigin = getOrigin()
+    // Always prefer current origin if available
+    if (currentOrigin) return currentOrigin
+    // Fallback to network setting only when origin is unavailable
+    return networkSetting?.externalUrl || ''
   }, [networkSetting])
-
-  return externalUrl
 }
-
 function getOrigin() {
   if (isClientSide()) {
     return new URL(window.location.href).origin

--- a/ee/tabby-ui/lib/hooks/use-network-setting.tsx
+++ b/ee/tabby-ui/lib/hooks/use-network-setting.tsx
@@ -16,24 +16,34 @@ const useNetworkSetting = (options?: any) => {
   return useQuery({ query: networkSettingQuery, ...options })
 }
 
-const useExternalURL = () => {
+const useExternalURL = (): string | null => {
   const [{ data }] = useNetworkSetting()
   const networkSetting = data?.networkSetting
-  
-  return React.useMemo(() => {
-    const currentOrigin = getOrigin()
-    // Always prefer current origin if available
-    if (currentOrigin) return currentOrigin
-    // Fallback to network setting only when origin is unavailable
-    return networkSetting?.externalUrl || ''
-  }, [networkSetting])
+  const [origin, setOrigin] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    // Client-side only
+    if (isClientSide()) {
+      const updateOrigin = () => {
+        setOrigin(new URL(window.location.href).origin)
+      }
+      
+      // Initialize
+      updateOrigin()
+      
+      // Set up listeners for potential origin changes
+      window.addEventListener('popstate', updateOrigin)
+      window.addEventListener('hashchange', updateOrigin)
+      
+      return () => {
+        window.removeEventListener('popstate', updateOrigin)
+        window.removeEventListener('hashchange', updateOrigin)
+      }
+    }
+  }, [])
+
+  // Return priority: current origin > network setting > null
+  return origin || networkSetting?.externalUrl || null
 }
 
-function getOrigin() {
-  if (isClientSide()) {
-    return new URL(window.location.href).origin
-  }
-  return ''
-}
-
-export { useNetworkSetting, useExternalURL }
+export { useNetworkSetting, useExternalURL }  // Fixed: removed extra }}

--- a/ee/tabby-ui/lib/hooks/use-network-setting.tsx
+++ b/ee/tabby-ui/lib/hooks/use-network-setting.tsx
@@ -46,4 +46,4 @@ const useExternalURL = (): string | null => {
   return origin || networkSetting?.externalUrl || null
 }
 
-export { useNetworkSetting, useExternalURL }  // Fixed: removed extra }}
+export { useNetworkSetting, useExternalURL } 


### PR DESCRIPTION
Fixes: #4291  

- Updated the useExternalURL hook to use the browser's current URL (window.location.origin) by default.
- This fixes issues where the app showed the wrong URL in  the UI.

![250618_15h45m25s_screenshot](https://github.com/user-attachments/assets/ba8a9b00-bdea-4aca-bf89-cb753b5693c3)
