### PR TITLE
Apply a SELinux label to the volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The easiest way to start a Tabby server is by using the following Docker command
 
 ```bash
 docker run -it \
-  --gpus all -p 8080:8080 -v $HOME/.tabby:/data \
+  --gpus all -p 8080:8080 -v $HOME/.tabby:/data:Z \
   tabbyml/tabby \
   serve --model StarCoder-1B --device cuda --chat-model Qwen2-1.5B-Instruct
 ```


### PR DESCRIPTION
This is needed to label the directory correctly (as private/unshared between containers) in SELinux-enabled environments such as Fedora.

If SELinux isn't available/used, this flag does nothing.

See https://github.com/TabbyML/tabby/issues/1808#issuecomment-2624214684 See https://projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/