### PR TITLE
ci(llama-server): use windows-2022 to build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             binary: x86_64-manylinux_2_28-cuda123
             container: sameli/manylinux_2_28_x86_64_cuda_12.3@sha256:e12416bf249ab312f9dcfdebd7939b968dd6f1b6f810abbede818df875e86a7c
             build_args: --features binary,cuda
-          - os: windows-2019
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             binary: x86_64-windows-msvc
             build_args: --features binary


### PR DESCRIPTION
ci: https://github.com/TabbyML/tabby/actions/runs/16014572055/job/45178647978