### PR TITLE
chore: update CUDA version from 12.9.0 to 12.4.1 in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   RUST_TOOLCHAIN: 1.82.0
-  CUDA_VERSION: 12.9.0
+  CUDA_VERSION: 12.4.1
 
 jobs:
   release-docker:


### PR DESCRIPTION
## Summary
• Update CUDA version from 12.9.0 to 12.4.1 in the Docker workflow configuration
• This change affects the Docker image build process for CUDA-enabled builds

## Test plan
- [ ] Verify Docker workflow builds successfully with CUDA 12.4.1
- [ ] Check that the generated Docker images work correctly with the new CUDA version
- [ ] Ensure backward compatibility is maintained

🤖 Generated with [Pochi](https://getpochi.com)