### PR TITLE
docs(install): add Katana install and WSL2 setup guide

### DIFF
--- a/website/docs/quick-start/installation/linux/index.mdx
+++ b/website/docs/quick-start/installation/linux/index.mdx
@@ -28,6 +28,24 @@ Running Tabby on Linux using Tabby's standalone executable distribution.
   * Check your local CUDA version by running the following command in a terminal: `nvcc --version`
 * For the Vulkan version you'll need the vulkan library. In ubuntu, this would be `sudo apt install libvulkan1`.
 
+## Katana (optional but recommended)
+
+Tabby utilizes [Katana](https://github.com/projectdiscovery/katana) as a crawling backend for the `developer docs` context provider.
+To import and analyze `developer docs` when llms.txt is unavailable at the specified link, Katana is required.
+Please be aware that the minimum Katana version required is `1.1.2`.
+
+The simplest way to install Katana is to download a prebuilt binary from the official releases:
+
+```bash
+curl -L https://github.com/projectdiscovery/katana/releases/download/v1.1.2/katana_1.1.2_linux_amd64.zip -o katana.zip
+unzip katana.zip katana
+sudo mv katana /usr/bin/
+rm katana.zip
+```
+This works well for most Linux environments. If you're using a different environment, please refer to the 
+[official installation instructions](https://github.com/projectdiscovery/katana#installation).
+
+
 ## Find the Linux executable file
 * Unzip the file you downloaded. The `tabby` executable will be in a subdirectory of dist.
 * Change to this subdirectory or relocate `tabby` to a folder of your choice.

--- a/website/docs/quick-start/installation/wsl.mdx
+++ b/website/docs/quick-start/installation/wsl.mdx
@@ -1,0 +1,37 @@
+---
+sidebar_position: 4
+---
+
+# Windows Subsystem for Linux (WSL2)
+
+Run Tabby on Windows using **Ubuntu via WSL2** for a native Linux experience with full GPU support and advanced developer control.
+
+## 1. Install WSL2 and Ubuntu
+
+You can install either **Ubuntu 22.04** or **Ubuntu 24.04** — both work with Tabby.
+
+> **Which version should I choose?**
+>
+> - Ubuntu **22.04** is the default and used in Tabby’s Docker image  
+> - Ubuntu **24.04** is newer and confirmed to work well with this guide  
+>
+> To install WSL2: https://learn.microsoft.com/en-us/windows/wsl/install
+
+Install your preferred Ubuntu version:
+
+```powershell
+wsl --install -d Ubuntu        # for Ubuntu 22.04
+wsl --install -d Ubuntu-24.04  # for Ubuntu 24.04
+```
+After installation, reboot if required, then launch Ubuntu and set up your UNIX user.
+
+## 2. Follow the Linux installation guide
+
+Once inside your Ubuntu WSL terminal, just follow the [Linux instructions](./linux). No extra steps
+needed — Tabby will run locally and privately, with GPU passthrough handled by WSL2 and Windows.
+
+## 3. Access Tabby from Windows
+
+Once Tabby is running in Ubuntu, it will usually be available at:  
+
+`http://localhost:8080` (or your chosen port)


### PR DESCRIPTION
This PR improves the installation experience by updating the documentation for:

- **Linux:** Adds Katana installation instructions, referencing official releases. It is a mandatory dependency to enable developer documentation indexing...
- **WSL2:** Adds a dedicated WSL2 setup page that simplifies local installation with Windows + Ubuntu under WSL2. Encourages users to choose between Ubuntu 22.04 (CUDA 11) or 24.04 (CUDA 12). 

This PR addresses the feedback from PR #4110.