### PR TITLE
fix(db): improve connection pool configuration for in-memory databases

### DIFF
--- a/ee/tabby-db/src/lib.rs
+++ b/ee/tabby-db/src/lib.rs
@@ -115,13 +115,17 @@ fn make_pagination_query_with_condition(
 impl DbConn {
     #[cfg(any(test, feature = "testutils"))]
     pub async fn new_in_memory() -> Result<Self> {
-        use std::str::FromStr;
+        use std::{str::FromStr, time::Duration};
 
         use sqlx::sqlite::SqlitePoolOptions;
 
         let options = SqliteConnectOptions::from_str("sqlite::memory:")?;
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
+        let pool: Pool<Sqlite> = SqlitePoolOptions::new()
+            .max_connections(20)
+            .min_connections(2)
+            .acquire_timeout(Duration::from_secs(6))
+            .idle_timeout(Duration::from_secs(300))
+            .max_lifetime(Duration::from_secs(3600))
             .connect_with(options)
             .await?;
         DbConn::init_db(pool).await


### PR DESCRIPTION
## Summary
- Increase max_connections from 1 to 20 for better concurrency in tests
- Add min_connections setting (2) to maintain a minimum pool size
- Add connection timeout configurations:
  - acquire_timeout (6 seconds) to prevent indefinite waits
  - idle_timeout (5 minutes) to clean up unused connections
  - max_lifetime (1 hour) to refresh connections periodically
- Add explicit type annotation for better code clarity

## Test plan
- [ ] Verify that all existing tests continue to pass with the new connection pool settings
- [ ] Run performance tests to confirm improved concurrency handling

These changes should improve performance and stability for in-memory databases used in tests and test utilities by providing better connection pooling configuration.

🤖 Generated with [Pochi](https://getpochi.com)