### PR TITLE
feat(index): indexing repo in shard when more than 20

### DIFF
--- a/ee/tabby-webserver/src/service/background_job/helper/cron.rs
+++ b/ee/tabby-webserver/src/service/background_job/helper/cron.rs
@@ -35,14 +35,10 @@ where
                 match next {
                     Some(next) => {
                         let to_sleep = next.clone() - timezone.from_utc_datetime(&Utc::now().naive_utc());
-                        if to_sleep.num_seconds() < 0 {
-                            // If the next time is in the past, skip it and get the next one.
-                            continue
-                        }
                         let to_sleep = match to_sleep.to_std() {
                             Ok(to_sleep) => to_sleep,
-                            Err(err) => {
-                                warn!("Failed to convert to std duration: {}", err);
+                            Err(_) => {
+                                // If the next time is in the past or conversion fails, skip it and get the next one.
                                 continue;
                             }
                         };


### PR DESCRIPTION
Note: this is merging into the branch indexing repo in shard.

When job load is high, there are OutOfRange warning in Tabby console:
<img width="2320" height="540" alt="CleanShot 2025-09-23 at 16 51 43@2x" src="https://github.com/user-attachments/assets/8687bdbe-17dd-4539-a1da-23da7c1de6f3" />

Since this error is caused by `secs < 0`:
<img width="1094" height="386" alt="CleanShot 2025-09-23 at 16 51 58@2x" src="https://github.com/user-attachments/assets/858a6583-313a-46da-ac23-2e95c539b511" />

we can utilize it to check whether the time is past and skip the log