### PR TITLE
ranking bugfix

### DIFF
--- a/crates/tabby/src/services/code.rs
+++ b/crates/tabby/src/services/code.rs
@@ -157,7 +157,7 @@ fn retain_at_most_two_hits_per_file(scored_hits: &mut Vec<CodeSearchHit>) {
 fn compute_rank_score(resp: Vec<(f32, TantivyDocument)>) -> Vec<(f32, f32, TantivyDocument)> {
     resp.into_iter()
         .enumerate()
-        .map(|(_rank, (score, doc))| (1.0 / (RANK_CONSTANT + (score + 1) as f32), score, doc))
+        .map(|(_rank, (score, doc))| (1.0 / (RANK_CONSTANT + (score + 1.0) as f32), score, doc))
         .collect()
 }
 


### PR DESCRIPTION
In my tests, the compute_rank_score doesn't behave correctly: it returns the same ranking score 0.16 for an embedding with score 0.7 and a bm25 with score 7. I believe this is due to a side effect of using rank in the calculation. I get the expected result when using score to calculate the output.