### PR TITLE
docs: add Hugging Face Inference Providers documentation

### DIFF
--- a/website/docs/references/models-http-api/huggingface.md
+++ b/website/docs/references/models-http-api/huggingface.md
@@ -1,6 +1,8 @@
 # Hugging Face Inference Providers
 
-[Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers) offers access to frontier open models from multiple providers through a unified API.
+[Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers) offers access to frontier open models from multiple providers through a unified API. 
+
+You'll need a [Hugging Face account](https://huggingface.co/join) and an [access token](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained).
 
 ## Chat model
 


### PR DESCRIPTION
- Add documentation for configuring Tabby with HF Inference Providers
- Document chat model support via OpenAI-compatible API
- Info on finding suitable models on the Hub supported by Inference Providers
- Note limitations: no completion (FIM) or embedding support

<img width="1174" height="938" alt="Screenshot 2025-10-29 at 12 25 40" src="https://github.com/user-attachments/assets/4c9e23c7-4c2f-4353-8401-f473d68008b9" />
