### PR TITLE
docs(wsl): fix linux instructions link path

### DIFF
--- a/website/docs/quick-start/installation/wsl.mdx
+++ b/website/docs/quick-start/installation/wsl.mdx
@@ -12,8 +12,8 @@ You can install either **Ubuntu 22.04** or **Ubuntu 24.04** — both work with T
 
 > **Which version should I choose?**
 >
-> - Ubuntu **22.04** is the default and used in Tabby’s Docker image  
-> - Ubuntu **24.04** is newer and confirmed to work well with this guide  
+> - Ubuntu **22.04** is the default and used in Tabby’s Docker image
+> - Ubuntu **24.04** is newer and confirmed to work well with this guide
 >
 > To install WSL2: https://learn.microsoft.com/en-us/windows/wsl/install
 
@@ -27,11 +27,12 @@ After installation, reboot if required, then launch Ubuntu and set up your UNIX 
 
 ## 2. Follow the Linux installation guide
 
-Once inside your Ubuntu WSL terminal, just follow the [Linux instructions](./linux). No extra steps
+Once inside your Ubuntu WSL terminal, just follow the [Linux instructions](../linux/). No extra steps
 needed — Tabby will run locally and privately, with GPU passthrough handled by WSL2 and Windows.
+
 
 ## 3. Access Tabby from Windows
 
-Once Tabby is running in Ubuntu, it will usually be available at:  
+Once Tabby is running in Ubuntu, it will usually be available at:
 
 `http://localhost:8080` (or your chosen port)


### PR DESCRIPTION
## Summary
fix issue here: https://github.com/TabbyML/tabby/actions/runs/19031855318/job/54347543250

- fix the WSL installation guide link so it targets the linux index page correctly
- remove trailing spaces introduced in the same document so formatting stays consistent

## Test plan
- [ ] pnpm --filter website docs:build

🤖 Generated with [Pochi](https://getpochi.com)