### PR TITLE
feat(server): include email in invitation link

### DIFF
--- a/ee/tabby-email/emails/invitation.tsx
+++ b/ee/tabby-email/emails/invitation.tsx
@@ -13,7 +13,7 @@ interface Invitation {
 
 export const Invitation = ({
   email = "{{EMAIL}}",
-  inviteLink = "{{EXTERNAL_URL}}/auth/signup?invitationCode={{CODE}}",
+  inviteLink = "{{EXTERNAL_URL}}/auth/signup?invitationCode={{CODE}}&email={{EMAIL}}",
 }: Invitation) => {
   const title = `You've been invited to join a Tabby server!`;
 
@@ -54,7 +54,7 @@ export const Invitation = ({
 
 Invitation.PreviewProps = {
   email: "user@tabbyml.com",
-  inviteLink: "http://localhost:8080/auth/signup?invitationCode={{CODE}}",
+  inviteLink: "http://localhost:8080/auth/signup?invitationCode={{CODE}}&email={{EMAIL}}",
 } as Invitation;
 
 export default Invitation;

--- a/ee/tabby-ui/app/(dashboard)/settings/team/components/invitation-table.tsx
+++ b/ee/tabby-ui/app/(dashboard)/settings/team/components/invitation-table.tsx
@@ -163,7 +163,7 @@ export default function InvitationTable() {
             )}
             <TableBody>
               {currentPageInvits?.map(x => {
-                const link = `${externalUrl}/auth/signup?invitationCode=${x.node.code}`
+                const link = `${externalUrl}/auth/signup?invitationCode=${x.node.code}&email=${x.node.email}`
                 return (
                   <TableRow key={x.node.id}>
                     <TableCell>{x.node.email}</TableCell>

--- a/ee/tabby-ui/app/auth/signup/components/signup.tsx
+++ b/ee/tabby-ui/app/auth/signup/components/signup.tsx
@@ -39,6 +39,7 @@ function Content({
 }) {
   const searchParams = useSearchParams()
   const invitationCode = searchParams.get('invitationCode') || undefined
+  const email = searchParams.get('email') || undefined
 
   return (
     <div className="w-[350px] space-y-6">
@@ -46,7 +47,7 @@ function Content({
         <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
         <p className="text-sm text-muted-foreground">{description}</p>
       </div>
-      {show && <UserAuthForm invitationCode={invitationCode} />}
+      {show && <UserAuthForm invitationCode={invitationCode} email={email} />}
     </div>
   )
 }

--- a/ee/tabby-ui/app/auth/signup/components/user-register-form.tsx
+++ b/ee/tabby-ui/app/auth/signup/components/user-register-form.tsx
@@ -59,6 +59,7 @@ const formSchema = z.object({
 
 interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {
   invitationCode?: string
+  email?: string
   onSuccess?: () => void
   buttonClass?: string
 }
@@ -66,6 +67,7 @@ interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {
 export function UserAuthForm({
   className,
   invitationCode,
+  email,
   onSuccess,
   buttonClass,
   ...props
@@ -75,7 +77,8 @@ export function UserAuthForm({
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      invitationCode
+      invitationCode,
+      email
     }
   })
 
@@ -135,6 +138,7 @@ export function UserAuthForm({
                     autoCorrect="off"
                     {...field}
                     value={field.value ?? ''}
+                    disabled={!!email}
                   />
                 </FormControl>
                 <FormMessage />


### PR DESCRIPTION
Compatible with previous links:
<img width="1368" height="1672" alt="CleanShot 2025-12-25 at 11 47 00@2x" src="https://github.com/user-attachments/assets/53e9d402-2e5b-4420-98af-e4f99f87207a" />

new invitation link with email:
<img width="960" height="1128" alt="CleanShot 2025-12-25 at 11 43 06@2x" src="https://github.com/user-attachments/assets/f1c464a8-690a-48f4-86c0-e1c6e7fa5347" />

Copied from invitation page:
<img width="1414" height="494" alt="CleanShot 2025-12-25 at 11 42 46@2x" src="https://github.com/user-attachments/assets/afbc4bf1-1c92-4185-9251-8356e23e0b1b" />

Invitation email:
<img width="1064" height="1112" alt="Mail 2025-12-25 11 27 30" src="https://github.com/user-attachments/assets/fba0d6fb-9c9b-4929-8f35-7a4508c9668c" />
