### PR TITLE
fix: correct typo 'seperated' to 'separated'

### DIFF
--- a/python/tabby-eval/modal/predict.py
+++ b/python/tabby-eval/modal/predict.py
@@ -160,7 +160,7 @@ def read_dataframe_from_file(language: str, file: str) -> pd.DataFrame:
 
 @stub.local_entrypoint()
 async def main(language: str, files: str):
-    #Multiple files seperated by ','
+    #Multiple files separated by ','
     
     model = Model()
 


### PR DESCRIPTION
Fixes a spelling typo in the evaluation script comment.