### PR TITLE
feat(api): add rate limiting to endpoint passthrough API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5809,6 +5809,7 @@ dependencies = [
  "hyper 1.3.1",
  "insta",
  "lazy_static",
+ "leaky-bucket",
  "llama-cpp-server",
  "nvml-wrapper",
  "openssl",

--- a/crates/tabby/Cargo.toml
+++ b/crates/tabby/Cargo.toml
@@ -61,6 +61,7 @@ reqwest.workspace = true
 async-openai-alt.workspace = true
 spinners = "4.1.1"
 regex.workspace = true
+leaky-bucket = "1.1.2"
 
 [dependencies.openssl]
 optional = true

--- a/crates/tabby/src/routes/mod.rs
+++ b/crates/tabby/src/routes/mod.rs
@@ -52,18 +52,20 @@ pub async fn run_app(api: Router, ui: Option<Router>, host: IpAddr, port: u16) {
     .unwrap_or_else(|err| fatal!("Error happens during serving: {}", err))
 }
 
-mod agent;
 mod chat;
 mod completions;
+mod endpoint;
 mod events;
 mod health;
 mod models;
+mod rate_limit;
 mod server_setting;
 
-pub use agent::*;
 pub use chat::*;
 pub use completions::*;
+pub use endpoint::*;
 pub use events::*;
 pub use health::*;
 pub use models::*;
+pub use rate_limit::*;
 pub use server_setting::*;

--- a/crates/tabby/src/routes/rate_limit.rs
+++ b/crates/tabby/src/routes/rate_limit.rs
@@ -1,0 +1,58 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use leaky_bucket::RateLimiter;
+use tokio::time::Duration;
+
+/// Creates a rate limiter for the given requests per minute.
+fn new_rate_limiter(rpm: u32) -> RateLimiter {
+    let rps = (rpm as f64 / 60.0).ceil() as usize;
+    RateLimiter::builder()
+        .initial(rps)
+        .interval(Duration::from_secs(1))
+        .refill(rps)
+        .build()
+}
+
+/// Key for rate limiting: (endpoint_name, user_id)
+type RateLimitKey = (String, String);
+
+/// Shared state for rate limiters, keyed by (endpoint_name, user_id)
+#[derive(Default)]
+pub struct EndpointRateLimiters {
+    limiters: RwLock<HashMap<RateLimitKey, Arc<RateLimiter>>>,
+}
+
+impl EndpointRateLimiters {
+    pub fn new() -> Self {
+        Self {
+            limiters: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Get or create a rate limiter for the given endpoint and user.
+    pub fn get_or_create(&self, endpoint_name: &str, user_id: &str, rpm: u32) -> Arc<RateLimiter> {
+        let key = (endpoint_name.to_string(), user_id.to_string());
+
+        // Try read lock first
+        {
+            let limiters = self.limiters.read().unwrap();
+            if let Some(limiter) = limiters.get(&key) {
+                return limiter.clone();
+            }
+        }
+
+        // Need to create a new limiter, acquire write lock
+        let mut limiters = self.limiters.write().unwrap();
+        // Double-check in case another thread created it
+        if let Some(limiter) = limiters.get(&key) {
+            return limiter.clone();
+        }
+
+        let limiter = Arc::new(new_rate_limiter(rpm));
+        limiters.insert(key, limiter.clone());
+        limiter
+    }
+}


### PR DESCRIPTION
## Summary
- Add per-user rate limiting using leaky-bucket algorithm for endpoint forwarding
- Require authentication for endpoint access (returns 401 if no user)
- Return 429 Too Many Requests when rate limit is exceeded
- Improve error handling: forward 4xx errors from upstream, return 504 Gateway Timeout on timeout errors
- Refactor: rename `agent.rs` to `endpoint.rs`, extract `rate_limit.rs` module

## Configuration
Rate limiting is configured per-endpoint via the `user_quota.requests_per_minute` field in config.toml:

```toml
[[endpoints]]
name = "pochi"
api_route = "https://api.openai.com"
timeout = 5000
user_quota = { requests_per_minute = 30 }
headers = { Authorization = "Bearer xxx" }
```

## Test plan
- [ ] Test endpoint access without authentication returns 401
- [ ] Test rate limiting triggers 429 after exceeding requests_per_minute
- [ ] Test upstream 4xx errors are forwarded correctly
- [ ] Test timeout returns 504 Gateway Timeout

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-49150d4e75774590b90800576e6c68c4)

---
Requests per minute would be converted into qps, and applied every second:

1800 requests per minutes:

<img width="1141" height="580" alt="image" src="https://github.com/user-attachments/assets/c3649fc0-a05b-4e2c-8939-042ac08a6af7" />
