### PR TITLE
chore: replace buildjet runners with ubuntu-latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   release-docker:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,12 @@ jobs:
             target: aarch64-apple-darwin
             binary: aarch64-apple-darwin
             build_args: --features binary
-          - os: buildjet-2vcpu-ubuntu-2204
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux_2_28
             container: quay.io/pypa/manylinux_2_28_x86_64
             build_args: --features binary
-          - os: buildjet-2vcpu-ubuntu-2204
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux_2_28-cuda123
             container: sameli/manylinux_2_28_x86_64_cuda_12.3@sha256:e12416bf249ab312f9dcfdebd7939b968dd6f1b6f810abbede818df875e86a7c
@@ -136,7 +136,7 @@ jobs:
             target: aarch64-apple-darwin
             binary: aarch64-apple-darwin
             build_args: --no-default-features --features prod
-          - os: buildjet-2vcpu-ubuntu-2204
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary: x86_64-manylinux_2_28
             container: quay.io/pypa/manylinux_2_28_x86_64


### PR DESCRIPTION
It looks like the GitHub runner still cannot build tabby with CUDA support currently.
Marking this to draft, and will wait and see later.

## Summary
BuildJet is shutting down, so we need to migrate to GitHub-hosted runners.
This change replaces `buildjet-2vcpu-ubuntu-2204` with `ubuntu-latest` in
`release.yml` and `docker.yml`.

## Test plan
- Verify that the workflows run successfully on GitHub-hosted runners.

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-1f3472c372cc4b3985b8b52cc16308a2)