### PR TITLE
Fix panic when .netrc entry has no password

### DIFF
--- a/crates/aim-downloader/src/address.rs
+++ b/crates/aim-downloader/src/address.rs
@@ -93,7 +93,9 @@ impl ParsedAddress {
                 }
                 if server == name {
                     user.clone_from(&machine.login);
-                    pass = machine.password.clone().unwrap();
+                    if let Some(password) = &machine.password {
+                        pass = password.clone();
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
Fixes a panic in `get_credentials_from_netrc` when a .netrc entry exists but has no password field.

## Bug Description
In `crates/aim-downloader/src/address.rs`, the `get_credentials_from_netrc` function unconditionally unwraps `machine.password`:

```rust
if server == name {
    user.clone_from(&machine.login);
    pass = machine.password.clone().unwrap();  // Panics if password is None!
    break;
}
```

### Crash Scenario

A .netrc file like this will cause a panic:
```
machine example.com
login myuser
```

When tabby tries to download from `example.com`, it finds the matching host in .netrc, but `machine.password` is `None` because no password was specified. The `.unwrap()` then panics.

## Root Cause
The netrc crate's `Machine` struct has `password: Option<String>`, but the code assumes it's always `Some`.

## Fix
Changed to use `if let` to only update the password if it exists:

```rust
if server == name {
    user.clone_from(&machine.login);
    if let Some(password) = &machine.password {
        pass = password.clone();
    }
    break;
}
```

If no password is in .netrc, the function now falls back to the `password` parameter (default: `"anonymous"`).

## Impact
- Prevents panic when .netrc entries have login but no password
- Maintains existing behavior: password parameter is used as fallback
- Matches how `login` is handled (which doesn't unwrap since it's not `Option<String>`)

## Testing
The fix allows .netrc files with password-less entries to work without crashing. The existing test cases continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)