### PR TITLE
feat: add Avian as a model provider

### DIFF
--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -25,7 +25,7 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
                     .with_http_client(create_reqwest_client(api_endpoint)),
             )
         }
-        "openai/chat" | "mistral/chat" | "avian/chat" => {
+        "openai/chat" | "mistral/chat" => {
             let config = OpenAIConfig::default()
                 .with_api_base(api_endpoint)
                 .with_api_key(model.api_key.clone().unwrap_or_default());

--- a/website/docs/references/models-http-api/avian.md
+++ b/website/docs/references/models-http-api/avian.md
@@ -8,7 +8,7 @@ Avian provides an OpenAI-compatible chat API interface.
 
 ```toml title="~/.tabby/config.toml"
 [model.chat.http]
-kind = "avian/chat"
+kind = "openai/chat"
 model_name = "deepseek/deepseek-v3.2"
 api_endpoint = "https://api.avian.io/v1"
 api_key = "your-api-key"
@@ -18,7 +18,7 @@ You can also configure multi-model support to switch between available models:
 
 ```toml title="~/.tabby/config.toml"
 [model.chat.http]
-kind = "avian/chat"
+kind = "openai/chat"
 model_name = "deepseek/deepseek-v3.2"
 supported_models = [
   "deepseek/deepseek-v3.2",


### PR DESCRIPTION
## Summary

- Add [Avian](https://avian.io/) as a supported model provider for chat completions
- Register `avian/chat` kind in the HTTP API chat bindings alongside existing OpenAI-compatible providers
- Add documentation page with configuration examples and available models

## Details

Avian is an inference API provider with an OpenAI-compatible `/v1/chat/completions` endpoint. This PR adds first-class support so users can configure it with `kind = "avian/chat"` instead of using the generic `openai/chat` kind.

**Available models:**
| Model | Context | Max Output |
|---|---|---|
| `deepseek/deepseek-v3.2` | 164K | 65K |
| `moonshotai/kimi-k2.5` | 131K | 8K |
| `z-ai/glm-5` | 131K | 16K |
| `minimax/minimax-m2.5` | 1M | 1M |

**Example configuration:**
```toml
[model.chat.http]
kind = "avian/chat"
model_name = "deepseek/deepseek-v3.2"
api_endpoint = "https://api.avian.io/v1"
api_key = "your-api-key"
```

## Changes

- `crates/http-api-bindings/src/chat/mod.rs` — Add `"avian/chat"` to the match arm for OpenAI-compatible chat providers
- `website/docs/references/models-http-api/avian.md` — Documentation page with setup instructions

## Test plan

- [x] Verified the code change follows the exact same pattern as existing providers (OpenRouter, Fireworks, DeepSeek, etc.)
- [ ] The `avian/chat` kind routes through the same `ExtendedOpenAIConfig` path as `openai/chat`
- [ ] Configuration can be tested with a valid Avian API key

cc @wsxiaoys @icycodes