### PR TITLE
fix(tabby-agent): sanitize newlines in user-agent header string

### DIFF
--- a/clients/tabby-agent/src/http/tabbyApiClient.ts
+++ b/clients/tabby-agent/src/http/tabbyApiClient.ts
@@ -107,7 +107,10 @@ export class TabbyApiClient extends EventEmitter {
     const tabbyPluginName = clientInfo?.tabbyPlugin?.name;
     const tabbyPluginVersion = clientInfo?.tabbyPlugin?.version;
     const tabbyPluginInfo = tabbyPluginName ? `${tabbyPluginName}/${tabbyPluginVersion}` : "";
-    return `${envInfo} ${tabbyAgentInfo} ${ideInfo} ${tabbyPluginInfo}`.trim();
+    const raw = `${envInfo} ${tabbyAgentInfo} ${ideInfo} ${tabbyPluginInfo}`.trim();
+    // Sanitize newlines from the user-agent string, as some editors (e.g. Emacs)
+    // include newlines in their version info which are invalid in HTTP headers.
+    return raw.replace(/[\r\n]+/g, " ").replace(/\s{2,}/g, " ");
   }
 
   private createTimeOutAbortSignal(): AbortSignal {


### PR DESCRIPTION
## Summary

Fixes #3648.

Some editors (e.g. Emacs) include newlines in their version info string. When this ends up in the `User-Agent` HTTP header, `Headers.set()` throws a `TypeError` ("is an invalid header value"), which breaks health checks entirely and prevents the agent from connecting.

**The fix:** In `buildUserAgentString()`, replace `\r` and `\n` characters with spaces and collapse any resulting consecutive whitespace before returning the string. This is a minimal, safe change — the user-agent value is preserved as-is minus the illegal characters.

**Before (from the issue logs):**
```
Node.js/v20.9.0 tabby-agent/1.8.0 emacs/GNU Emacs 29.1 (build 1, aarch64-apple-darwin21.6.0, Carbon Version 165 AppKit 2113.6)\n of 2023-09-26
```

**After:**
```
Node.js/v20.9.0 tabby-agent/1.8.0 emacs/GNU Emacs 29.1 (build 1, aarch64-apple-darwin21.6.0, Carbon Version 165 AppKit 2113.6) of 2023-09-26
```

## Disclosure

This PR was authored by an AI (Claude Opus 4.6, Anthropic) — operating transparently, not impersonating a human. Supervised by Max Calkin (the account owner). Happy to address any feedback.