### PR TITLE
feat: add MiniMax as a first-class chat model provider

### DIFF
--- a/crates/http-api-bindings/src/chat/mod.rs
+++ b/crates/http-api-bindings/src/chat/mod.rs
@@ -25,7 +25,7 @@ pub async fn create(model: &HttpModelConfig) -> Arc<dyn ChatCompletionStream> {
                     .with_http_client(create_reqwest_client(api_endpoint)),
             )
         }
-        "openai/chat" | "mistral/chat" => {
+        "openai/chat" | "mistral/chat" | "minimax/chat" => {
             let config = OpenAIConfig::default()
                 .with_api_base(api_endpoint)
                 .with_api_key(model.api_key.clone().unwrap_or_default());

--- a/crates/tabby-inference/src/chat.rs
+++ b/crates/tabby-inference/src/chat.rs
@@ -66,6 +66,15 @@ impl ExtendedOpenAIConfig {
             "openai/chat" => {
                 request = process_request_openai(request);
             }
+            "minimax/chat" => {
+                // MiniMax temperature must be in (0.0, 1.0]; default to 1.0 if unset or zero
+                request.temperature = Some(
+                    request
+                        .temperature
+                        .map(|t| if t <= 0.0 { 1.0 } else { t.min(1.0) })
+                        .unwrap_or(1.0),
+                );
+            }
             _ => {}
         }
 
@@ -142,5 +151,75 @@ impl ChatCompletionStream for async_openai_alt::Client<async_openai_alt::config:
     ) -> Result<ChatCompletionResponseStream, OpenAIError> {
         let request = process_request_openai(request);
         self.chat().create_stream(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config(kind: &str) -> ExtendedOpenAIConfig {
+        ExtendedOpenAIConfig::builder()
+            .base(OpenAIConfig::default())
+            .kind(kind.to_string())
+            .model_name("test-model")
+            .supported_models(None)
+            .build()
+            .unwrap()
+    }
+
+    fn make_request(model: &str, temperature: Option<f32>) -> CreateChatCompletionRequest {
+        let mut req = CreateChatCompletionRequest::default();
+        req.model = model.to_string();
+        req.temperature = temperature;
+        req
+    }
+
+    #[test]
+    fn test_minimax_temperature_clamped_to_default_when_zero() {
+        let config = make_config("minimax/chat");
+        let req = make_request("MiniMax-M2.7", Some(0.0));
+        let processed = config.process_request(req);
+        assert_eq!(processed.temperature, Some(1.0));
+    }
+
+    #[test]
+    fn test_minimax_temperature_clamped_to_default_when_negative() {
+        let config = make_config("minimax/chat");
+        let req = make_request("MiniMax-M2.7", Some(-0.5));
+        let processed = config.process_request(req);
+        assert_eq!(processed.temperature, Some(1.0));
+    }
+
+    #[test]
+    fn test_minimax_temperature_clamped_to_max_when_above_one() {
+        let config = make_config("minimax/chat");
+        let req = make_request("MiniMax-M2.7", Some(1.5));
+        let processed = config.process_request(req);
+        assert_eq!(processed.temperature, Some(1.0));
+    }
+
+    #[test]
+    fn test_minimax_temperature_preserved_when_valid() {
+        let config = make_config("minimax/chat");
+        let req = make_request("MiniMax-M2.7", Some(0.7));
+        let processed = config.process_request(req);
+        assert_eq!(processed.temperature, Some(0.7));
+    }
+
+    #[test]
+    fn test_minimax_temperature_defaults_when_none() {
+        let config = make_config("minimax/chat");
+        let req = make_request("MiniMax-M2.7", None);
+        let processed = config.process_request(req);
+        assert_eq!(processed.temperature, Some(1.0));
+    }
+
+    #[test]
+    fn test_minimax_model_fallback_when_empty() {
+        let config = make_config("minimax/chat");
+        let req = make_request("", Some(0.5));
+        let processed = config.process_request(req);
+        assert_eq!(processed.model, "test-model");
     }
 }

--- a/website/docs/references/models-http-api/minimax.md
+++ b/website/docs/references/models-http-api/minimax.md
@@ -1,0 +1,53 @@
+# MiniMax
+
+[MiniMax](https://www.minimax.io/) is an AI company that develops large language models for general tasks. Their models include [MiniMax-M2.7](https://platform.minimax.io/docs/api-reference/text-openai-api) for high-performance language understanding and generation.
+
+## Chat model
+
+MiniMax provides an OpenAI-compatible chat API interface. Tabby includes a dedicated `minimax/chat` kind that handles MiniMax-specific constraints such as temperature clamping.
+
+```toml title="~/.tabby/config.toml"
+[model.chat.http]
+kind = "minimax/chat"
+model_name = "MiniMax-M2.7"
+api_endpoint = "https://api.minimax.io/v1"
+api_key = "your-minimax-api-key"
+```
+
+You can also configure multi-model support to switch between available models:
+
+```toml title="~/.tabby/config.toml"
+[model.chat.http]
+kind = "minimax/chat"
+model_name = "MiniMax-M2.7"
+supported_models = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+api_endpoint = "https://api.minimax.io/v1"
+api_key = "your-minimax-api-key"
+```
+
+For users in mainland China, use the domestic endpoint:
+
+```toml title="~/.tabby/config.toml"
+[model.chat.http]
+kind = "minimax/chat"
+model_name = "MiniMax-M2.7"
+api_endpoint = "https://api.minimaxi.com/v1"
+api_key = "your-minimax-api-key"
+```
+
+## Completion model
+
+MiniMax does not currently offer a dedicated completion (FIM) API endpoint.
+
+## Embeddings model
+
+MiniMax does not currently offer embedding model APIs.
+
+## Available Models
+
+| Model | Context Length | Max Output |
+|---|---|---|
+| `MiniMax-M2.7` | 204K | 192K |
+| `MiniMax-M2.7-highspeed` | 204K | 192K |
+
+For the latest model list and pricing, visit [MiniMax Platform](https://platform.minimax.io/).


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as a first-class chat model provider with a dedicated `minimax/chat` kind that handles MiniMax-specific API constraints.

## Changes

- Add `minimax/chat` kind to the chat routing in `http-api-bindings`
- Add MiniMax-specific request processing in `ExtendedOpenAIConfig`:
  - Temperature clamping to valid range `(0.0, 1.0]` (defaults to 1.0)
- Add 6 unit tests for temperature clamping and model fallback
- Add documentation page with configuration examples (global and China endpoints)

## Supported Models

| Model | Context Length | Max Output |
|---|---|---|
| `MiniMax-M2.7` | 204K | 192K |
| `MiniMax-M2.7-highspeed` | 204K | 192K |

## Configuration Example

```toml
[model.chat.http]
kind = "minimax/chat"
model_name = "MiniMax-M2.7"
api_endpoint = "https://api.minimax.io/v1"
api_key = "your-minimax-api-key"
```

## API Documentation
- OpenAI Compatible: https://platform.minimax.io/docs/api-reference/text-openai-api
