### PR TITLE
fix(ui): collapse thinking blocks by default for reasoning models

### DIFF
--- a/ee/tabby-ui/components/message-markdown/index.tsx
+++ b/ee/tabby-ui/components/message-markdown/index.tsx
@@ -437,7 +437,6 @@ export function ErrorMessageBlock({
 function ThinkBlock({ children }: { children: ReactNode }): JSX.Element {
   return (
     <details
-      open
       className={`
         my-4 w-full rounded-md border border-gray-300 bg-white 
         p-3 text-sm text-gray-800


### PR DESCRIPTION
Fixes #3977

Removes the \open\ attribute from the \ThinkBlock\ \<details>\ element so that \<think>\ content from reasoning models (DeepSeek R1, etc.) is **collapsed by default**. Users can still expand to view the full thinking process by clicking the summary.

## Change

One-line change in \^[e/tabby-ui/components/message-markdown/index.tsx\:

\\\diff
- <details open className=...>
+ <details className=...>
\\\

The existing \<think>\ tag pipeline (CUSTOM_HTML_BLOCK_TAGS, formatCustomHTMLBlockTags, rehypeSanitize, ThinkBlock component) already handles parsing correctly. The only issue was the default visibility.
