### PR TITLE
fix: propagate error instead of panicking on non-UTF-8 reference name in checkout

### DIFF
--- a/crates/tabby-index/src/code/repository.rs
+++ b/crates/tabby-index/src/code/repository.rs
@@ -109,7 +109,10 @@ pub fn checkout(repository: &CodeRepository, branch: &str) -> anyhow::Result<()>
     let mut checkout_builder = git2::build::CheckoutBuilder::new();
     checkout_builder.force();
 
-    repo.set_head(reference.name().unwrap())?;
+    let ref_name = reference
+        .name()
+        .ok_or_else(|| anyhow::anyhow!("Reference name is not valid UTF-8"))?;
+    repo.set_head(ref_name)?;
     repo.checkout_head(Some(&mut checkout_builder))?;
     Ok(())
 }


### PR DESCRIPTION
## Problem

In `crates/tabby-index/src/code/repository.rs`, the call to `reference.name().unwrap()` can panic at runtime. `reference.name()` returns `Option<&str>`, which is `None` when the reference name contains non-UTF-8 bytes. Since `git2` exposes raw bytes for ref names, this is a valid (if rare) code path that causes an unhandled panic.

## Fix

Replace `.unwrap()` with `.ok_or_else()` to convert the `Option` into a `Result` and propagate the error through `anyhow`, which the function already returns:

```rust
// Before
repo.set_head(reference.name().unwrap())?;

// After
let ref_name = reference
    .name()
    .ok_or_else(|| anyhow::anyhow!("Reference name is not valid UTF-8"))?;
repo.set_head(ref_name)?;
```

This avoids the panic and allows callers to handle the error gracefully.

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>