### PR TITLE
fix(vscode,intellij): handle missing status and fix StringIndexOutOfBoundsException in completion renderer

### DIFF
--- a/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/completion/InlineCompletionRenderer.kt
+++ b/clients/intellij/src/main/kotlin/com/tabbyml/intellijtabby/completion/InlineCompletionRenderer.kt
@@ -90,7 +90,7 @@ class InlineCompletionRenderer {
             }
           }
         }
-      } else if (suffixReplaceLength == 1) {
+      } else if (suffixReplaceLength == 1 && currentLineSuffix.isNotEmpty()) {
         // Replace range contains one char
         val replaceChar = currentLineSuffix[0]
         // Insert part is substring of first line that before the char

--- a/clients/vscode/src/StatusBarItem.ts
+++ b/clients/vscode/src/StatusBarItem.ts
@@ -100,6 +100,12 @@ export class StatusBarItem {
             this.setTooltip(statusInfo.tooltip);
             break;
           }
+          case "codeCompletionNotAvailable": {
+            this.setColorWarning();
+            this.setIcon(iconWarning);
+            this.setTooltip(statusInfo.tooltip);
+            break;
+          }
           case "completionResponseSlow":
           case "rateLimitExceeded": {
             this.setColorWarning();


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the client extensions:

### 1. VSCode: Constant spinner when no completion model is running (fixes #4418)

**Problem**: When the Tabby server is connected but no completion model is configured, the status bar shows a persistent spinning animation. This happens because `StatusBarItem.ts` does not handle the `codeCompletionNotAvailable` status emitted by `tabby-agent`, so the icon stays as the loading spinner from the previous `Starting` state.

**Solution**: Add a `codeCompletionNotAvailable` case to the switch statement in `StatusBarItem.ts` that displays the warning icon with the appropriate tooltip — consistent with other warning states like `rateLimitExceeded`.

### 2. IntelliJ: `StringIndexOutOfBoundsException` in `InlineCompletionRenderer` (fixes #4404)

**Problem**: `InlineCompletionRenderer.kt` throws `java.lang.StringIndexOutOfBoundsException: Index 0 out of bounds for length 0` at line 95 (`currentLineSuffix[0]`) when `suffixReplaceLength == 1` but `currentLineSuffix` is empty. This can happen when the completion item's `replaceRange.end` extends past the end of the actual document line (e.g., cursor at end of line or document state mismatch).

**Solution**: Guard the `suffixReplaceLength == 1` branch with `currentLineSuffix.isNotEmpty()`. When the suffix is empty, the code falls through to the existing `else` block which handles the case gracefully without accessing out-of-bounds indices.

## Test plan

- [ ] VSCode: Connect to a Tabby server with no completion model configured; verify the status bar shows a warning icon (⚠) instead of a spinning spinner
- [ ] IntelliJ: Verify no `StringIndexOutOfBoundsException` when inline completion is triggered at the end of a line