### PR TITLE
fix: pass original URL with credentials to sync_refs for private repos

### DIFF
--- a/crates/tabby-git/src/lib.rs
+++ b/crates/tabby-git/src/lib.rs
@@ -86,7 +86,20 @@ pub fn get_head_name(root: &Path) -> anyhow::Result<String> {
     Ok(name.to_string())
 }
 
+/// Returns the URL with credentials (username and password) removed, for safe logging.
+fn mask_url_credentials(url: &str) -> String {
+    url::Url::parse(url)
+        .map(|mut u| {
+            let _ = u.set_password(None);
+            let _ = u.set_username("");
+            u.to_string()
+        })
+        .unwrap_or_else(|_| url.to_string())
+}
+
 pub fn sync_refs(root: &Path, url: &str, refs: &Vec<String>) -> anyhow::Result<()> {
+    let display_url = mask_url_credentials(url);
+
     if !root.exists() {
         fs::create_dir_all(root)?;
         let status = Command::new("git")
@@ -100,12 +113,22 @@ pub fn sync_refs(root: &Path, url: &str, refs: &Vec<String>) -> anyhow::Result<(
             if code != 0 {
                 warn!(
                     "Failed to clone `{}`. Please check your repository configuration.",
-                    url
+                    display_url
                 );
                 fs::remove_dir_all(root).expect("Failed to remove directory");
 
-                bail!("Failed to clone `{}`", url);
+                bail!("Failed to clone `{}`", display_url);
             }
+        }
+    } else {
+        // Update the remote URL so that credential changes in config take effect
+        // without requiring a full re-clone.
+        let status = Command::new("git")
+            .current_dir(root)
+            .args(["remote", "set-url", "origin", url])
+            .status();
+        if let Err(e) = status {
+            warn!("Failed to update remote URL for `{}`: {}", display_url, e);
         }
     }
 

--- a/crates/tabby-index/src/code/repository.rs
+++ b/crates/tabby-index/src/code/repository.rs
@@ -19,7 +19,7 @@ impl RepositoryExt for CodeRepository {
     fn sync(&self) -> anyhow::Result<()> {
         if let Err(e) = sync_refs(
             self.dir().as_path(),
-            &self.canonical_git_url(),
+            &self.git_url,
             &self.git_refs,
         ) {
             logkit::error!("Failed to clone repository: {}", e);


### PR DESCRIPTION
## Problem

Private repositories configured with authentication credentials in the URL (e.g. Bitbucket, GitLab repositories in subgroups) fail to clone or pull with errors like:

```
fatal: could not read Username for 'https://bitbucket.org': No such device or address
```

The root cause is in `CodeRepository::sync()` — it calls `self.canonical_git_url()` which strips the username and password from the URL before passing it to `sync_refs()`. So the git clone/pull command runs without credentials.

Fixes #4434, closes #4431.

## Changes

**`crates/tabby-index/src/code/repository.rs`**
- Pass `self.git_url` (original URL with credentials) to `sync_refs` instead of `self.canonical_git_url()`.

**`crates/tabby-git/src/lib.rs`**
- Add `mask_url_credentials()` helper that strips credentials for safe log output.
- Update log/error messages in `sync_refs` to use the masked URL so credentials are never exposed in logs.
- For existing clones (`else` branch), call `git remote set-url origin <url>` so credential changes in the config take effect without a full re-clone.

## Testing

The directory name for cloned repos is derived from the canonical URL (no credentials), which is correct — this ensures the directory stays stable even when credentials change. The fix ensures only the git commands receive the full URL with credentials while logs always see the masked version.