### PR TITLE
fix(tabby-agent): only send tabby/chat feature registration to VS Code LSP Clients

### DIFF
--- a/.changes/unreleased/Fixed and Improvements-20260428-092408.yaml
+++ b/.changes/unreleased/Fixed and Improvements-20260428-092408.yaml
@@ -1,0 +1,3 @@
+kind: Fixed and Improvements
+body: Do not send tabby/chat LSP Feature to clients that cannot support it
+time: 2026-04-28T09:24:08.662286918-04:00

--- a/clients/tabby-agent/src/chat/index.ts
+++ b/clients/tabby-agent/src/chat/index.ts
@@ -4,6 +4,7 @@ import type { ServerCapabilities } from "../protocol";
 import type { Feature } from "../feature";
 import type { TabbyApiClient } from "../http/tabbyApiClient";
 import { ChatFeatures } from "../protocol";
+import { getClientType } from "../utils/clientType";
 
 export class ChatFeature extends EventEmitter implements Feature {
   private isApiAvailable = false;
@@ -41,7 +42,7 @@ export class ChatFeature extends EventEmitter implements Feature {
   }
 
   private async syncFeatureRegistration(connection: Connection) {
-    if (this.isApiAvailable) {
+    if (this.isApiAvailable && getClientType(this.tabbyApiClient.getClientInfo()) === "vscode") {
       if (!this.featureRegistration) {
         try {
           this.featureRegistration = await connection.client.register(ChatFeatures.type);

--- a/clients/tabby-agent/src/http/tabbyApiClient.ts
+++ b/clients/tabby-agent/src/http/tabbyApiClient.ts
@@ -37,6 +37,7 @@ export class TabbyApiClient extends EventEmitter {
   private readonly logger = getLogger("TabbyApiClient");
 
   private userAgentString: string | undefined = undefined;
+  private clientInfo: ClientInfo | undefined = undefined;
   private api: ReturnType<typeof createClient<TabbyApi>> | undefined;
   private endpoint: string | undefined = undefined;
 
@@ -60,6 +61,7 @@ export class TabbyApiClient extends EventEmitter {
 
   async initialize(clientInfo: ClientInfo | undefined) {
     this.userAgentString = this.buildUserAgentString(clientInfo);
+    this.clientInfo = clientInfo;
     this.connect(); // no await
 
     this.configurations.on("updated", (config: ConfigData, oldConfig: ConfigData) => {
@@ -153,6 +155,10 @@ export class TabbyApiClient extends EventEmitter {
 
   getServerHealth(): TabbyApiComponents["schemas"]["HealthState"] | undefined {
     return this.serverHealth;
+  }
+
+  getClientInfo(): ClientInfo | undefined {
+    return this.clientInfo;
   }
 
   async connect(options: { skipReset?: boolean } = {}): Promise<void> {

--- a/clients/tabby-agent/src/telemetry.ts
+++ b/clients/tabby-agent/src/telemetry.ts
@@ -13,6 +13,7 @@ import { isBrowser } from "./env";
 import { ProxyConfig, createProxyForUrl } from "./http/proxy";
 import { getLogger } from "./logger";
 import { isBlank } from "./utils/string";
+import { getClientType } from "./utils/clientType";
 
 export class AnonymousUsageLogger {
   private readonly logger = getLogger("Telemetry");
@@ -121,7 +122,7 @@ export class AnonymousUsageLogger {
   }
 
   private updateUserProperties(clientInfo: ClientInfo | undefined, clientProvidedConfig: ClientProvidedConfig) {
-    const clientType = this.getClientType(clientInfo);
+    const clientType = getClientType(clientInfo);
     const properties = {
       [clientType]: {
         triggerMode: clientProvidedConfig?.inlineCompletion?.triggerMode,
@@ -149,19 +150,5 @@ export class AnonymousUsageLogger {
     if (!deepEqual(properties, this.clientInfoProperties)) {
       this.clientInfoProperties = properties;
     }
-  }
-
-  private getClientType(clientInfo: ClientInfo | undefined): string {
-    if (!clientInfo) {
-      return "unknown";
-    }
-    if (clientInfo.tabbyPlugin?.name.includes("vscode")) {
-      return "vscode";
-    } else if (clientInfo.tabbyPlugin?.name.includes("intellij")) {
-      return "intellij";
-    } else if (clientInfo.tabbyPlugin?.name.includes("vim")) {
-      return "vim";
-    }
-    return clientInfo.name;
   }
 }

--- a/clients/tabby-agent/src/utils/clientType.ts
+++ b/clients/tabby-agent/src/utils/clientType.ts
@@ -1,0 +1,17 @@
+import type { ClientInfo } from "../protocol";
+
+export type ClientType = "vscode" | "intellij" | "vim" | "unknown";
+
+export function getClientType(clientInfo: ClientInfo | undefined): ClientType {
+  const pluginName = clientInfo?.tabbyPlugin?.name ?? "";
+  if (pluginName.includes("vscode")) {
+    return "vscode";
+  }
+  if (pluginName.includes("intellij")) {
+    return "intellij";
+  }
+  if (pluginName.includes("vim")) {
+    return "vim";
+  }
+  return "unknown";
+}


### PR DESCRIPTION
## Summary

Fixes Neovim 0.12 crash where `tabby/chat` registration sent via `client/registerCapability` caused a LuaJIT panic (`table index is nil`) because it is a VS Code-specific method not recognized by Neovim's LSP client.

## Changes

- `src/utils/clientType.ts` - Extracted `getClientType(clientInfo)` from `telemetry.ts` into a shared utility with a `ClientType` union type (`"vscode" | "intellij" | "vim" | "unknown"`)

- `src/telemetry.ts` - Use the shared `getClientType` instead of the private method

- `src/http/tabbyApiClient.ts` - Store and expose `clientInfo` via `getClientInfo()` getter (previously only used it to build `userAgentString`)

- `src/chat/index.ts` - `syncFeatureRegistration()` gates `tabby/chat` registration behind `getClientType(...) === "vscode"`

## Verification

- Builds, all 84 tests pass, lint clean
- Tested locally with Neovim 0.12, completions working again through vim-tabby

## Related

Fixes #4486, vim-tabby[#40](https://github.com/TabbyML/vim-tabby/issues/40)