### PR TITLE
fix: duplicated "the" in tabby main.rs comment

### DIFF
--- a/crates/tabby/src/main.rs
+++ b/crates/tabby/src/main.rs
@@ -100,7 +100,7 @@ fn to_local_config(model: &str, parallelism: u8, device: &Device) -> ModelConfig
     } else {
         0
     };
-    // This only works when the the model is included in cli arguments.
+    // This only works when the model is included in cli arguments.
     let enable_fast_attention = Some(std::env::var("LLAMA_CPP_FAST_ATTENTION").is_ok());
 
     ModelConfig::new_local(model, parallelism, num_gpu_layers, enable_fast_attention)


### PR DESCRIPTION
One-line typo fix in `crates/tabby/src/main.rs`: "// This only works when the the model is included in cli arguments." → "// This only works when the model is included in cli arguments.". No code/behavior change.