### PR TITLE
docs(models-http-api): update MiniMax model references to M3

### DIFF
--- a/website/docs/references/models-http-api/avian.md
+++ b/website/docs/references/models-http-api/avian.md
@@ -1,6 +1,6 @@
 # Avian
 
-[Avian](https://avian.io/) is an inference API provider offering access to frontier open-source models through an OpenAI-compatible endpoint. Available models include DeepSeek V3.2, Kimi K2.5, GLM-5, and MiniMax M2.5.
+[Avian](https://avian.io/) is an inference API provider offering access to frontier open-source models through an OpenAI-compatible endpoint. Available models include DeepSeek V3.2, Kimi K2.5, GLM-5, and MiniMax M3.
 
 ## Chat Model
 
@@ -24,7 +24,7 @@ supported_models = [
   "deepseek/deepseek-v3.2",
   "moonshotai/kimi-k2.5",
   "z-ai/glm-5",
-  "minimax/minimax-m2.5"
+  "minimax/minimax-m3"
 ]
 api_endpoint = "https://api.avian.io/v1"
 api_key = "your-api-key"
@@ -45,6 +45,6 @@ Avian does not currently offer embedding model APIs.
 | `deepseek/deepseek-v3.2` | 164K | 65K |
 | `moonshotai/kimi-k2.5` | 131K | 8K |
 | `z-ai/glm-5` | 131K | 16K |
-| `minimax/minimax-m2.5` | 1M | 1M |
+| `minimax/minimax-m3` | 200K | 200K |
 
 For the latest model list and pricing, visit [Avian](https://avian.io/).

--- a/website/docs/references/models-http-api/huggingface.md
+++ b/website/docs/references/models-http-api/huggingface.md
@@ -6,12 +6,12 @@ You'll need a [Hugging Face account](https://huggingface.co/join) and an [access
 
 ## Chat model
 
-Hugging Face Inference Providers provides an OpenAI-compatible chat API interface. Here we use the `MiniMaxAI/MiniMax-M2` model as an example.
+Hugging Face Inference Providers provides an OpenAI-compatible chat API interface. Here we use the `MiniMaxAI/MiniMax-M3` model as an example.
 
 ```toml title="~/.tabby/config.toml"
 [model.chat.http]
 kind = "openai/chat"
-model_name = "MiniMaxAI/MiniMax-M2" # specify the model you want to use
+model_name = "MiniMaxAI/MiniMax-M3" # specify the model you want to use
 api_endpoint = "https://router.huggingface.co/v1"
 api_key = "your-hf-token"
 ```


### PR DESCRIPTION
## Summary

Update example model identifiers in the Hugging Face Inference Providers and Avian provider docs to point to the latest MiniMax-M3 release. The current docs reference older revisions (M2 / M2.5) which are no longer the recommended versions.

## Changes

- `website/docs/references/models-http-api/huggingface.md`: bump the example chat config `model_name` from `MiniMaxAI/MiniMax-M2` to `MiniMaxAI/MiniMax-M3`.
- `website/docs/references/models-http-api/avian.md`:
  - update the intro sentence (`MiniMax M2.5` -> `MiniMax M3`);
  - replace `minimax/minimax-m2.5` with `minimax/minimax-m3` in the `supported_models` example;
  - replace the `minimax/minimax-m2.5 / 1M / 1M` entry in the Available Models table with `minimax/minimax-m3 / 200K / 200K` to reflect M3's published context window.

## Notes

- Docs-only change, no code or tests touched.
- Both files already follow the same provider-doc layout used by the rest of `models-http-api/`.