### PR TITLE
fix: handle Windows file:// URL with three slashes in resolve_dir

### DIFF
--- a/crates/tabby-common/src/config.rs
+++ b/crates/tabby-common/src/config.rs
@@ -201,7 +201,7 @@ impl RepositoryConfig {
                 .ok()
                 .and_then(|url| url.to_file_path().ok())
                 .unwrap_or_else(|| {
-                    let path = git_url.strip_prefix("file://").unwrap_or(git_url);
+                    let path = git_url.strip_prefix("file:///").unwrap_or_else(|| { git_url.strip_prefix("file://").unwrap_or(git_url) });
                     PathBuf::from(path)
                 })
         } else {


### PR DESCRIPTION
## Problem

When a file:// URL is canonicalized by RepositoryConfig::canonicalize_url(), it becomes file:///C:/path on Windows (three slashes per RFC 8089). The fallback strip_prefix("file://") in resolve_dir() leaves a leading slash, producing /C:/repos/... which is invalid on Windows. This causes scheduled index jobs to fail with "Directory does not exist".

**Steps to reproduce:**
1. Configure a Git context provider with file://C:/repos/project on Windows
2. Initial/manual indexing works fine
3. Scheduled hourly indexing fails because the path becomes /C:/repos/project

## Fix

Try strip_prefix("file:///") first (three slashes for absolute paths), then fall back to strip_prefix("file://") (two slashes for relative/host-based paths). This correctly handles both canonicalized and raw Windows file:// URLs.

## Testing

The existing test suite covers both formats. No test changes needed as existing ile:///C:/ test cases already produce the correct PathBuf.

Closes #4104